### PR TITLE
Entity identifier implementation

### DIFF
--- a/konfigyr-api/build.gradle
+++ b/konfigyr-api/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'java-library'
 dependencies {
     /* Spring Boot starter */
     api 'org.springframework.boot:spring-boot-starter'
+    api 'org.springframework.boot:spring-boot-starter-json'
 
     /* Spring Cache and Caffeine implementation */
     api 'org.springframework.boot:spring-boot-starter-cache'
@@ -18,4 +19,7 @@ dependencies {
     /* Spring Common libraries */
     api 'org.springframework.retry:spring-retry'
     api 'org.springframework.data:spring-data-commons'
+
+    /* TSID */
+    implementation 'io.hypersistence:hypersistence-tsid:2.1.1'
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/entity/EntityId.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/entity/EntityId.java
@@ -1,0 +1,96 @@
+package com.konfigyr.entity;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.springframework.lang.NonNull;
+
+import java.io.Serializable;
+import java.util.Optional;
+
+/**
+ * An entity identifier, or {@link EntityId}, defines should a unique identifier for an entity be
+ * structured withing the Konfigyr application.
+ * <p>
+ * The identifier should come in two distinct forms, the first is the natural identifier represented
+ * as a {@link Long} type. The natural identifier is usually a database primary key value and should
+ * not be used outside the Konfigyr application scope or published through an API.
+ * <p>
+ * The second form is the external one and can be communicated and shared with other systems, usually
+ * through an API. Given the fact that this {@link EntityId} form is shared with others, it is important
+ * to be aware that any changes to this form need to be backwards compatible. Otherwise, the system having
+ * an older version of the identifier would no longer be able to access the entity.
+ * <p>
+ * Implementation how an {@link EntityId} is created is defined by the {@link EntityIdProvider} SPI.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see EntityIdProvider
+ **/
+public interface EntityId extends Comparable<EntityId>, Serializable {
+
+	/**
+	 * Generates a new unique {@link EntityId} for an entity. If the {@link EntityIdProvider} provides
+	 * this support the method would always return an {@link Optional} with the value, otherwise an
+	 * empty {@link Optional} would be returned.
+	 *
+	 * @return generated entity identifier or empty.
+	 */
+	@NonNull
+	static Optional<EntityId> generate() {
+		return EntityIdFactory.getInstance().create();
+	}
+
+	/**
+	 * Creates a new {@link EntityId} from its internal value.
+	 *
+	 * @param id internal value of the entity identifier
+	 * @return Entity identifier, never {@literal null}
+	 * @throws IllegalArgumentException if the external value is invalid
+	 */
+	@NonNull
+	static EntityId from(long id) {
+		return from((Long) id);
+	}
+
+	/**
+	 * Creates a new {@link EntityId} from its internal value.
+	 *
+	 * @param id internal value of the entity identifier
+	 * @return Entity identifier, never {@literal null}
+	 * @throws IllegalArgumentException if the external value is invalid
+	 */
+	@NonNull
+	static EntityId from(@NonNull Long id) {
+		return EntityIdFactory.getInstance().create(id);
+	}
+
+	/**
+	 * Creates a new {@link EntityId} from its external value.
+	 *
+	 * @param hash external value of the entity identifier
+	 * @return Entity identifier, never {@literal null}
+	 * @throws IllegalArgumentException if the external value is invalid
+	 */
+	@NonNull
+	@JsonCreator
+	static EntityId from(@NonNull String hash) {
+		return EntityIdFactory.getInstance().create(hash);
+	}
+
+	/**
+	 * Returns the internal value of the {@link EntityId}.
+	 *
+	 * @return the internal value
+	 */
+	long id();
+
+	/**
+	 * Returns the serialized external value of the {@link EntityId}.
+	 *
+	 * @return the serialized external value, never {@literal null}
+	 */
+	@NonNull
+	@JsonValue
+	String serialize();
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/entity/EntityIdFactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/entity/EntityIdFactory.java
@@ -1,0 +1,63 @@
+package com.konfigyr.entity;
+
+import org.springframework.core.OrderComparator;
+import org.springframework.lang.NonNull;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.function.SingletonSupplier;
+
+import java.util.Optional;
+import java.util.ServiceLoader;
+import java.util.function.Supplier;
+
+/**
+ * Singleton utility class that is used to load the configured {@link EntityIdProvider} SPI
+ * via {@link ServiceLoader} to generate and create instances of the {@link EntityId}.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ **/
+final class EntityIdFactory {
+
+	static final Supplier<EntityIdFactory> instance = SingletonSupplier.of(EntityIdFactory::new);
+
+	static EntityIdFactory getInstance() {
+		return instance.get();
+	}
+
+	private final EntityIdProvider provider;
+
+	EntityIdFactory() {
+		this(lookupEntityIdProvider());
+	}
+
+	EntityIdFactory(EntityIdProvider  provider) {
+		this.provider = provider;
+	}
+
+	@NonNull
+	Optional<EntityId> create() {
+		return Optional.ofNullable(provider.generate());
+	}
+
+	@NonNull
+	EntityId create(long id) {
+		return provider.create(id);
+	}
+
+	@NonNull
+	EntityId create(String hash) {
+		return provider.create(hash);
+	}
+
+	@NonNull
+	static EntityIdProvider lookupEntityIdProvider() {
+		final ServiceLoader<EntityIdProvider> loader = ServiceLoader.load(EntityIdProvider.class,
+				ClassUtils.getDefaultClassLoader());
+
+		return loader.stream()
+				.map(ServiceLoader.Provider::get)
+				.min(OrderComparator.INSTANCE)
+				.orElseGet(TimeSortedEntityIdProvider::getInstance);
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/entity/EntityIdProvider.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/entity/EntityIdProvider.java
@@ -1,0 +1,52 @@
+package com.konfigyr.entity;
+
+import org.springframework.core.Ordered;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.Nullable;
+
+/**
+ * Service provider interface that provides concrete implementations of the {@link EntityId}.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see EntityId
+ **/
+public interface EntityIdProvider extends Ordered {
+
+	/**
+	 * Method that generates a new unique {@link EntityId} value.
+	 * <p>
+	 * In case the concrete implementation of the {@link EntityId} can not be generated,
+	 * this method should return {@literal null}.
+	 *
+	 * @return generated entity identifier or {@literal null} if one can not be generated
+	 * by this service provider implementation.
+	 */
+	@Nullable
+	default EntityId generate() {
+		return null;
+	}
+
+	/**
+	 * Crates a {@link EntityId} from its natural long value that is used internally
+	 * within the Konfigyr application.
+	 *
+	 * @param id natural identifier
+	 * @return entity identifier, never {@literal null}
+	 * @throws IllegalArgumentException if the identifier value is invalid
+	 */
+	@NonNull
+	EntityId create(long id);
+
+	/**
+	 * Crates a {@link EntityId} from its serialized value that should be used externally
+	 * outside the Konfigyr application scope.
+	 *
+	 * @param hash serialized identifier value, can't be {@literal null}
+	 * @return entity identifier, never {@literal null}
+	 * @throws IllegalArgumentException if the serialized identifier value is blank or invalid
+	 */
+	@NonNull
+	EntityId create(@NonNull String hash);
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/entity/TimeSortedEntityId.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/entity/TimeSortedEntityId.java
@@ -1,0 +1,51 @@
+package com.konfigyr.entity;
+
+import io.hypersistence.tsid.TSID;
+import lombok.EqualsAndHashCode;
+import org.springframework.lang.NonNull;
+
+import java.io.Serial;
+
+/**
+ * Implementation of the {@link EntityId} that is based on the {@link TSID}.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see TSID
+ * @see TimeSortedEntityIdProvider
+ **/
+@EqualsAndHashCode(of = "id")
+final class TimeSortedEntityId implements EntityId {
+
+	@Serial
+	private static final long serialVersionUID = -6631425677891239174L;
+
+	private final long id;
+	private final String hash;
+
+	TimeSortedEntityId(@NonNull TSID value) {
+		this.id = value.toLong();
+		this.hash = value.toString();
+	}
+
+	@Override
+	public long id() {
+		return id;
+	}
+
+	@NonNull
+	@Override
+	public String serialize() {
+		return hash;
+	}
+
+	@Override
+	public int compareTo(@NonNull EntityId entityId) {
+		return Long.compare(id(), entityId.id());
+	}
+
+	@Override
+	public String toString() {
+		return "EntityId(" + id + ", " + hash + ")";
+	}
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/entity/TimeSortedEntityIdProvider.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/entity/TimeSortedEntityIdProvider.java
@@ -28,11 +28,10 @@ import java.util.function.Supplier;
  *         the millisecond changes.
  *     </li>
  *     <li>
- *         To generate the generate the time component f the {@link TSID}, a UTC system time {@link Clock}
- *         is used and is based on an epoch that starts from the following date: <code>2024-01-01</code>.
+ *         To generate the time component of the {@link TSID}, a UTC system time {@link Clock} is used
+ *         and is based on an epoch that starts from the following date: <code>2024-01-01</code>.
  *     </li>
  * </ul>
- * <p>
  * This class is considered as a default implementation of the {@link EntityIdProvider} SPI. If there is no
  * specific implementation of the provider that is configured to be loaded by the {@link java.util.ServiceLoader},
  * this one would be used.

--- a/konfigyr-api/src/main/java/com/konfigyr/entity/TimeSortedEntityIdProvider.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/entity/TimeSortedEntityIdProvider.java
@@ -1,0 +1,96 @@
+package com.konfigyr.entity;
+
+import io.hypersistence.tsid.TSID;
+import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
+import org.springframework.util.function.SingletonSupplier;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.function.Supplier;
+
+/**
+ * Implementation of the {@link EntityIdProvider} that creates instances of {@link EntityId} backed by
+ * a {@link TSID} implementation.
+ * <p>
+ * The {@link TSID} is configured using the following options:
+ * <ul>
+ *     <li>
+ *         Uses default configuration for the node part of the random component. You can change this
+ *         configuration via environment variables or system properties. Please consult the
+ *         <a href="https://github.com/vladmihalcea/hypersistence-tsid">TSID documentation</a> for
+ *         more information.
+ *     </li>
+ *     <li>
+ *         Second part of the random {@link TSID} component, apart from the above mentioned node part,
+ *         is the counter. This implementation uses the {@link SecureRandom} to reset the counter when
+ *         the millisecond changes.
+ *     </li>
+ *     <li>
+ *         To generate the generate the time component f the {@link TSID}, a UTC system time {@link Clock}
+ *         is used and is based on an epoch that starts from the following date: <code>2024-01-01</code>.
+ *     </li>
+ * </ul>
+ * <p>
+ * This class is considered as a default implementation of the {@link EntityIdProvider} SPI. If there is no
+ * specific implementation of the provider that is configured to be loaded by the {@link java.util.ServiceLoader},
+ * this one would be used.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see TSID
+ * @see <a href="https://github.com/vladmihalcea/hypersistence-tsid">TSID Docuentation</a>
+ **/
+final class TimeSortedEntityIdProvider implements EntityIdProvider {
+
+	static final Supplier<EntityIdProvider> instance = SingletonSupplier.of(TimeSortedEntityIdProvider::new);
+
+	static EntityIdProvider getInstance() {
+		return instance.get();
+	}
+
+	private final TSID.Factory factory;
+
+	TimeSortedEntityIdProvider() {
+		this(
+				new TSID.Factory.Builder()
+						.withRandom(new SecureRandom())
+						.withClock(Clock.systemUTC())
+						.withCustomEpoch(Instant.parse("2024-01-01T00:00:00.000Z"))
+						.build()
+		);
+	}
+
+	TimeSortedEntityIdProvider(TSID.Factory factory) {
+		this.factory = factory;
+	}
+
+	@Override
+	public int getOrder() {
+		return LOWEST_PRECEDENCE;
+	}
+
+	@NonNull
+	@Override
+	public synchronized EntityId generate() {
+		return new TimeSortedEntityId(factory.generate());
+	}
+
+	@NonNull
+	@Override
+	public EntityId create(long id) {
+		Assert.isTrue(id > 0, "Internal entity identifier must be a positive number: " + id);
+
+		return new TimeSortedEntityId(TSID.from(id));
+	}
+
+	@NonNull
+	@Override
+	public EntityId create(@NonNull String hash) {
+		Assert.isTrue(TSID.isValid(hash), "Invalid external entity identifier value: " + hash);
+
+		return new TimeSortedEntityId(TSID.from(hash));
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/entity/EntityIdTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/entity/EntityIdTest.java
@@ -1,0 +1,153 @@
+package com.konfigyr.entity;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.internal.StandardComparisonStrategy;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.boot.task.SimpleAsyncTaskExecutorBuilder;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
+
+class EntityIdTest {
+
+	@Test
+	@DisplayName("should parse entity identifier value")
+	void shouldParseLongEntityValue() {
+		assertThat(EntityId.from(31854375469809910L))
+				.isNotNull()
+				.returns(31854375469809910L, EntityId::id)
+				.returns("00W9BCAZ6Q07P", EntityId::serialize);
+	}
+
+	@Test
+	@DisplayName("should parse entity identifier serialized form")
+	void shouldParseSerializedEntityValue() {
+		assertThat(EntityId.from("00W9BCAZYQ01Q"))
+				.isNotNull()
+				.returns(31854375494975543L, EntityId::id)
+				.returns("00W9BCAZYQ01Q", EntityId::serialize);
+	}
+
+	@Test
+	@DisplayName("entity identifier should be sortable")
+	void shouldSortEntityIdentifiers() {
+		final var identifiers = Set.of(
+				EntityId.from("00W9BCAZYQ01Q"),
+				EntityId.from("00W9BCAZYQ01R"),
+				EntityId.from("00W9BCB02Q01W"),
+				EntityId.from("00W9BCAZ6Q07P")
+		);
+
+		assertThat(identifiers.stream().sorted())
+				.isSorted()
+				.containsExactly(
+						EntityId.from(31854375469809910L),
+						EntityId.from(31854375494975543L),
+						EntityId.from(31854375494975544L),
+						EntityId.from(31854375499169852L)
+				);
+	}
+
+	@Test
+	@DisplayName("should be serializable into JSON via Jackson")
+	void toJSON() throws Exception {
+		final var id = EntityId.from(31854375494975544L);
+		final var mapper = new ObjectMapper();
+
+		assertThat(mapper.writeValueAsString(id))
+				.as("Should write entity identifier using external form")
+				.isEqualTo("\"00W9BCAZYQ01R\"");
+
+		assertThat(mapper.readValue("\"00W9BCAZYQ01R\"", EntityId.class))
+				.as("Should generate entity identifier from external form")
+				.isEqualTo(id);
+
+		assertThatThrownBy(() -> mapper.readValue("31854375494975544", EntityId.class))
+				.as("Should not generate entity identifier from internal form")
+				.isInstanceOf(JsonMappingException.class);
+	}
+
+	@ValueSource(longs = { -124, 0 })
+	@ParameterizedTest(name = "should not create identifier from {0}")
+	@DisplayName("should not create entity identifier from invalid internal form")
+	void shouldValidateInternalIdentifierValues(long value) {
+		assertThatThrownBy(() -> EntityId.from(value))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Internal entity identifier must be a positive number: " + value);
+	}
+
+	@ValueSource(strings = { "", " ", "abc", "invalid hash", "00W9BCAZYQ01", "00W9BCAZYQ01Q1" })
+	@ParameterizedTest(name = "should not create identifier from \"{0}\"")
+	@DisplayName("should not create entity identifier from invalid external form")
+	void shouldValidateExternalIdentifierValues(String value) {
+		assertThatThrownBy(() -> EntityId.from(value))
+				.isInstanceOf(IllegalArgumentException.class)
+				.hasMessage("Invalid external entity identifier value: " + value);
+	}
+
+	@MethodSource("scenarios")
+	@DisplayName("should generate unique entity identifier")
+	@ParameterizedTest(name = "should generate ~{1} identifiers using {0} thread(s)")
+	void shouldGenerateEntityIdentifiers(int threads, int iterations) {
+		final var executor = new SimpleAsyncTaskExecutorBuilder()
+				.concurrencyLimit(threads)
+				.virtualThreads(true)
+				.build();
+
+		final List<EntityId> generated = new CopyOnWriteArrayList<>();
+		final List<CompletableFuture<Void>> tasks = new ArrayList<>();
+
+		final Runnable task = () -> EntityId.generate().ifPresent(generated::add);
+
+		for (int i = 0; i < iterations; i++) {
+			tasks.add(CompletableFuture.runAsync(task, executor));
+		}
+
+		final var future = CompletableFuture.allOf(tasks.toArray(CompletableFuture[]::new));
+
+		assertThatNoException()
+				.as("should generate identifiers within 300 milliseconds")
+				.isThrownBy(() -> future.get(300, TimeUnit.MILLISECONDS));
+
+		assertThat(generated)
+				.as("should generate %s identifiers", iterations)
+				.hasSizeGreaterThanOrEqualTo(iterations);
+
+		assertThat(StandardComparisonStrategy.instance().duplicatesFrom(generated))
+				.as("should not encounter any collisions")
+				.isEmpty();
+
+		executor.close();
+	}
+
+	static Stream<Arguments> scenarios() {
+		return Stream.of(
+				Arguments.of(1, 10),
+				Arguments.of(1, 100),
+				Arguments.of(5, 100),
+				Arguments.of(1, 100),
+				Arguments.of(10, 100),
+				Arguments.of(20, 100),
+				Arguments.of(2, 1000),
+				Arguments.of(15, 1000),
+				Arguments.of(20, 1000),
+				Arguments.of(5, 5000),
+				Arguments.of(15, 5000),
+				Arguments.of(20, 5000),
+				Arguments.of(10, 10000),
+				Arguments.of(20, 10000)
+		);
+	}
+
+}


### PR DESCRIPTION
Creates an `EntityId` type that defines the a unique identifier for an entity in the Konfigyr application.

Use the `EntityIdProvider` SPI to provide the actual implementation of the `EntityId` defaulting to `TimeSortedEntityIdProvider` using [`TSID`](https://github.com/vladmihalcea/hypersistence-tsid)