### PR TITLE
Account Principal and Remember Me services

### DIFF
--- a/konfigyr-data/src/main/resources/migrations/changelogs/changelog-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/changelogs/changelog-1.0.0.xml
@@ -116,7 +116,7 @@
                 <constraints nullable="false" />
             </column>
 
-            <column name="access_token_expiry_date" type="timestamptz">
+            <column name="access_token_expires_at" type="timestamptz">
                 <constraints nullable="false" />
             </column>
 
@@ -125,6 +125,10 @@
             </column>
 
             <column name="refresh_token_issued_at" type="timestamptz">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="refresh_token_expires_at" type="timestamptz">
                 <constraints nullable="true" />
             </column>
         </createTable>

--- a/konfigyr-security/build.gradle
+++ b/konfigyr-security/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     implementation project(':konfigyr-cryptography')
 
     api 'org.springframework.boot:spring-boot-starter-oauth2-client'
+    compileOnly 'org.springframework.boot:spring-boot-starter-web'
 
     testImplementation project(':konfigyr-test')
     testImplementation project(':konfigyr-namespace')

--- a/konfigyr-security/src/main/java/com/konfigyr/security/AccountPrincipal.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/AccountPrincipal.java
@@ -48,7 +48,10 @@ public class AccountPrincipal implements OAuth2User, UserDetails, Serializable {
 	private static final String EMPTY_PASSWORD = "";
 	private static final Map<String, Object> EMPTY_ATTRIBUTES = Collections.emptyMap();
 
-	Account account;
+	/**
+	 * The actual {@link Account} that identifies this {@link AccountPrincipal}.
+	 */
+	@NonNull Account account;
 
 	/**
 	 * Returns am {@link EntityId} of the {@link Account} that would be used as the
@@ -73,6 +76,11 @@ public class AccountPrincipal implements OAuth2User, UserDetails, Serializable {
 		return account.id().serialize();
 	}
 
+	/**
+	 * The email address of the logged-in user account.
+	 *
+	 * @return account email address, never {@literal null}
+	 */
 	@NonNull
 	public String getEmail() {
 		return account.email();

--- a/konfigyr-security/src/main/java/com/konfigyr/security/AccountPrincipal.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/AccountPrincipal.java
@@ -1,6 +1,7 @@
-package com.konfigyr.security.oauth;
+package com.konfigyr.security;
 
 import com.konfigyr.account.Account;
+import com.konfigyr.account.AccountStatus;
 import com.konfigyr.entity.EntityId;
 import lombok.RequiredArgsConstructor;
 import lombok.Value;
@@ -8,6 +9,7 @@ import org.springframework.lang.NonNull;
 import org.springframework.lang.Nullable;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.io.Serial;
@@ -17,19 +19,33 @@ import java.util.Collections;
 import java.util.Map;
 
 /**
- * {@link OAuth2User} implementation that bridges the gap between the original {@link OAuth2User} and
- * the {@link Account}.
+ * Class that represents the {@link org.springframework.security.core.AuthenticatedPrincipal}
+ * that retrieves all the security attributes from the {@link Account}.
+ * <p>
+ * It is recommended that every {@link org.springframework.security.core.Authentication} type
+ * that is created by Spring Security should contain this {@link AccountPrincipal} as it's subject.
+ * <p>
+ * {@link AccountPrincipal} implements both {@link OAuth2User} and {@link UserDetails} on order
+ * to be compatible with Spring OAuth authentication types and authentication types that are
+ * using the {@link org.springframework.security.core.userdetails.UserDetailsService} API.
+ * <p>
+ * Keep in mind that the <code>username</code> for this principal is the external representation
+ * of the {@link EntityId account entity identifier} and that the <code>password</code> is intentionally
+ * set to a <strong>blank string</strong> as {@link Account accounts} do not have one.
  *
  * @author Vladimir Spasic
  * @since 1.0.0
+ * @see OAuth2User
+ * @see UserDetails
  **/
 @Value
 @RequiredArgsConstructor
-public class OAuth2UserAccount implements OAuth2User, Serializable {
+public class AccountPrincipal implements OAuth2User, UserDetails, Serializable {
 
 	@Serial
 	private static final long serialVersionUID = -4208974779066630762L;
 
+	private static final String EMPTY_PASSWORD = "";
 	private static final Map<String, Object> EMPTY_ATTRIBUTES = Collections.emptyMap();
 
 	Account account;
@@ -62,6 +78,11 @@ public class OAuth2UserAccount implements OAuth2User, Serializable {
 		return account.email();
 	}
 
+	@Override
+	public String getUsername() {
+		return getName();
+	}
+
 	/**
 	 * The display name for the logged-in user account, if present, or the email account.
 	 *
@@ -80,6 +101,31 @@ public class OAuth2UserAccount implements OAuth2User, Serializable {
 	@Nullable
 	public String getAvatar() {
 		return account.avatar();
+	}
+
+	@Override
+	public boolean isAccountNonExpired() {
+		return AccountStatus.DEACTIVATED != account.status();
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return AccountStatus.SUSPENDED != account.status();
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return AccountStatus.ACTIVE == account.status();
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return AccountStatus.ACTIVE == account.status();
+	}
+
+	@Override
+	public String getPassword() {
+		return EMPTY_PASSWORD;
 	}
 
 	@Override

--- a/konfigyr-security/src/main/java/com/konfigyr/security/AccountPrincipalService.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/AccountPrincipalService.java
@@ -1,0 +1,112 @@
+package com.konfigyr.security;
+
+import com.konfigyr.account.Account;
+import com.konfigyr.account.AccountManager;
+import com.konfigyr.account.AccountRegistration;
+import com.konfigyr.entity.EntityId;
+import jakarta.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.userdetails.UserCache;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.cache.NullUserCache;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.util.Assert;
+
+import java.util.function.Supplier;
+
+/**
+ * Implementation of the {@link PrincipalService} that is able to load the {@link AccountPrincipal}
+ * using the {@link com.konfigyr.account.AccountManager}.
+ *
+ * @author Vladimir Spasic
+ **/
+@Slf4j
+@RequiredArgsConstructor
+public class AccountPrincipalService implements PrincipalService {
+
+	private final AccountManager manager;
+	private final UserCache cache;
+
+	public AccountPrincipalService(AccountManager manager) {
+		this(manager, new NullUserCache());
+	}
+
+	@NonNull
+	@Override
+	public AccountPrincipal lookup(@NonNull OAuth2User user, @NonNull Supplier<AccountRegistration> supplier) {
+		final Account account = manager.findByEmail(user.getName())
+				.orElseGet(() -> manager.create(supplier.get()));
+
+		Assert.notNull(account.id(), "User account identifier can not be null");
+		Assert.hasText(account.email(), "User account needs to have an email address set");
+
+		return new AccountPrincipal(account);
+	}
+
+	@NonNull
+	@Override
+	public AccountPrincipal lookup(@NonNull String username) throws UsernameNotFoundException {
+		final EntityId id;
+
+		try {
+			id = EntityId.from(username);
+		} catch (IllegalArgumentException ex) {
+			log.debug("Attempted to load an account principal for invalid username: {}", username);
+
+			throw new UsernameNotFoundException("Failed to lookup user account for invalid username: " + username, ex);
+		}
+
+		return lookup(id);
+	}
+
+	@NonNull
+	@Override
+	public AccountPrincipal lookup(@NonNull EntityId id) throws UsernameNotFoundException {
+		AccountPrincipal user = lookupFromCache(id.serialize());
+
+		if (user == null) {
+			user = lookupFromManager(id);
+		}
+
+		if (user == null) {
+			throw new UsernameNotFoundException("Failed to lookup user account for identifier: " + id);
+		}
+
+		cache.putUserInCache(user);
+
+		return user;
+	}
+
+	@Nullable
+	private AccountPrincipal lookupFromCache(@NonNull String username) {
+		final UserDetails user = cache.getUserFromCache(username);
+
+		if (user == null) {
+			return null;
+		}
+
+		if (user instanceof AccountPrincipal principal) {
+			return principal;
+		}
+
+		if (log.isDebugEnabled()) {
+			log.debug("Found an invalid type of user in the user cache, removing cache entry: {}", user);
+		}
+
+		// remove from cache as it contains an invalid user
+		cache.removeUserFromCache(username);
+
+		return null;
+	}
+
+	@Nullable
+	private AccountPrincipal lookupFromManager(@NonNull EntityId id) {
+		return manager.findById(id)
+				.map(AccountPrincipal::new)
+				.orElse(null);
+	}
+
+}

--- a/konfigyr-security/src/main/java/com/konfigyr/security/AccountPrincipalService.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/AccountPrincipalService.java
@@ -30,6 +30,13 @@ public class AccountPrincipalService implements PrincipalService {
 	private final AccountManager manager;
 	private final UserCache cache;
 
+	/**
+	 * Creates a new instance of the {@link AccountPrincipalService} with {@link NullUserCache} as
+	 * the {@link UserCache} implementation. This would not cache {@link AccountPrincipal principals}
+	 * that were retrieved by the {@link AccountManager}.
+	 *
+	 * @param manager account manager used to lookup accounts, can't be {@literal null}
+	 */
 	public AccountPrincipalService(AccountManager manager) {
 		this(manager, new NullUserCache());
 	}

--- a/konfigyr-security/src/main/java/com/konfigyr/security/PrincipalService.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/PrincipalService.java
@@ -1,0 +1,60 @@
+package com.konfigyr.security;
+
+import com.konfigyr.account.AccountRegistration;
+import com.konfigyr.entity.EntityId;
+import org.springframework.lang.NonNull;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.function.Supplier;
+
+/**
+ * Service used to retrieve {@link AccountPrincipal account principals} that would be used
+ * to create a Spring {@link org.springframework.security.core.Authentication}.
+ * <p>
+ * Keep in mind that we intentionally do not wish to extend this interface with Spring Security
+ * {@link org.springframework.security.core.userdetails.UserDetailsService} in order to exclude
+ * its registration via the {@code InitializeUserDetailsBeanManagerConfigurer} global configurer.
+ *
+ * @author Vladimir Spasic
+ **/
+public interface PrincipalService {
+
+	/**
+	 * Looks up a {@link AccountPrincipal} using the {@link EntityId account identifier}.
+	 *
+	 * @param id account identifier, never {@literal null}
+	 * @return located account principal, never {@literal null}
+	 * @throws UsernameNotFoundException  if the account could not be found
+	 */
+	@NonNull AccountPrincipal lookup(@NonNull EntityId id) throws UsernameNotFoundException;
+
+	/**
+	 * Looks up a {@link AccountPrincipal} using the username attribute. The username attribute
+	 * should be a serialized external value of the {@link EntityId}.
+	 * <p>
+	 * If the username is not a valid {@link EntityId}, this method would throw a {@link UsernameNotFoundException}.
+	 *
+	 * @param username account username, never {@literal null}
+	 * @return located account principal, never {@literal null}
+	 * @throws UsernameNotFoundException  if the account could not be found or username is invalid
+	 */
+	@NonNull AccountPrincipal lookup(@NonNull String username) throws UsernameNotFoundException;
+
+	/**
+	 * Looks up a {@link AccountPrincipal} using the resolved {@link OAuth2User} that was retrieved from
+	 * an external OAuth Authorization server.
+	 * <p>
+	 * The principal lookup is performed by matching the email address of the {@link com.konfigyr.account.Account},
+	 * therefore it is important the {@link OAuth2User#getName()} value is configured to use the email attribute.
+	 * <p>
+	 * In case the {@link AccountPrincipal} does not exist for the given {@link OAuth2User} user, the
+	 * {@link AccountRegistration} supplier function is needed. This registration data would be used to create
+	 * new {@link com.konfigyr.account.Account} and set up the {@link AccountPrincipal}.
+	 *
+	 * @param user retrieved OAuth user, never {@literal null}
+	 * @param supplier account registration supplier, never {@literal null}
+	 * @return existing or new account principal, never {@literal null}
+	 */
+	@NonNull AccountPrincipal lookup(@NonNull OAuth2User user, @NonNull Supplier<AccountRegistration> supplier);
+}

--- a/konfigyr-security/src/main/java/com/konfigyr/security/SecurityAutoConfiguration.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/SecurityAutoConfiguration.java
@@ -3,12 +3,19 @@ package com.konfigyr.security;
 import com.konfigyr.account.AccountManager;
 import com.konfigyr.crypto.KeysetOperationsFactory;
 import com.konfigyr.security.oauth.AuthorizedClientService;
-import com.konfigyr.security.oauth.DatabaseOAuth2UserService;
+import com.konfigyr.security.oauth.PrincipalAccountOAuth2UserService;
 import com.konfigyr.security.oauth.OAuthKeysets;
 import org.jooq.DSLContext;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.support.NoOpCache;
 import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.userdetails.UserCache;
+import org.springframework.security.core.userdetails.cache.SpringCacheBasedUserCache;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
@@ -26,14 +33,38 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 public class SecurityAutoConfiguration {
 
 	@Bean
-	OAuth2UserService<OAuth2UserRequest, OAuth2User> databaseOAuth2UserService(
-			AccountManager accountManager,
-			RestTemplateBuilder restTemplateBuilder) {
-		return new DatabaseOAuth2UserService(accountManager, restTemplateBuilder);
+	@ConditionalOnBean(CacheManager.class)
+	@ConditionalOnMissingBean(UserCache.class)
+	UserCache userCache(CacheManager manager) {
+		Cache cache = manager.getCache("user-cache");
+		if (cache == null) {
+			cache = new NoOpCache("user-cache");
+		}
+
+		return new SpringCacheBasedUserCache(cache);
 	}
 
 	@Bean
-	OAuth2AuthorizedClientService authorizedClientService(
+	@ConditionalOnBean(UserCache.class)
+	PrincipalService cachingAccountPrincipalService(AccountManager accountManager, UserCache userCache) {
+		return new AccountPrincipalService(accountManager, userCache);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(PrincipalService.class)
+	PrincipalService accountPrincipalService(AccountManager accountManager) {
+		return new AccountPrincipalService(accountManager);
+	}
+
+	@Bean
+	OAuth2UserService<OAuth2UserRequest, OAuth2User> principalAccountOAuth2UserService(
+			PrincipalService principalService,
+			RestTemplateBuilder restTemplateBuilder) {
+		return new PrincipalAccountOAuth2UserService(principalService, restTemplateBuilder);
+	}
+
+	@Bean
+	OAuth2AuthorizedClientService persistentAuthorizedClientService(
 			DSLContext context,
 			KeysetOperationsFactory keysetOperationsFactory,
 			ClientRegistrationRepository clientRegistrationRepository) {

--- a/konfigyr-security/src/main/java/com/konfigyr/security/SecurityAutoConfiguration.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/SecurityAutoConfiguration.java
@@ -6,6 +6,7 @@ import com.konfigyr.security.oauth.AuthorizedClientService;
 import com.konfigyr.security.oauth.PrincipalAccountOAuth2UserService;
 import com.konfigyr.security.oauth.OAuthKeysets;
 import org.jooq.DSLContext;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -15,6 +16,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.support.NoOpCache;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.core.userdetails.UserCache;
+import org.springframework.security.core.userdetails.cache.NullUserCache;
 import org.springframework.security.core.userdetails.cache.SpringCacheBasedUserCache;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
@@ -40,20 +42,13 @@ public class SecurityAutoConfiguration {
 		if (cache == null) {
 			cache = new NoOpCache("user-cache");
 		}
-
 		return new SpringCacheBasedUserCache(cache);
 	}
 
 	@Bean
-	@ConditionalOnBean(UserCache.class)
-	PrincipalService cachingAccountPrincipalService(AccountManager accountManager, UserCache userCache) {
+	PrincipalService accountPrincipalService(AccountManager accountManager, ObjectProvider<UserCache> cacheProvider) {
+		final UserCache userCache = cacheProvider.getIfAvailable(NullUserCache::new);
 		return new AccountPrincipalService(accountManager, userCache);
-	}
-
-	@Bean
-	@ConditionalOnMissingBean(PrincipalService.class)
-	PrincipalService accountPrincipalService(AccountManager accountManager) {
-		return new AccountPrincipalService(accountManager);
 	}
 
 	@Bean

--- a/konfigyr-security/src/main/java/com/konfigyr/security/oauth/PrincipalAccountOAuth2UserService.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/oauth/PrincipalAccountOAuth2UserService.java
@@ -35,6 +35,16 @@ public class PrincipalAccountOAuth2UserService implements OAuth2UserService<OAut
 	private final PrincipalService principalService;
 	private final OAuth2UserService<OAuth2UserRequest, ? extends OAuth2User> delegate;
 
+	/**
+	 * Creates the {@link PrincipalAccountOAuth2UserService} instance using the {@link PrincipalService}
+	 * to retrieve or register new {@link com.konfigyr.account.Account accounts} for resolved {@link OAuth2User}.
+	 * <p>
+	 * The {@link RestTemplateBuilder} would be used to configure the delegating {@link OAuth2UserService} that
+	 * would attempt to fetch and resolved the {@link OAuth2User} attributes.
+	 *
+	 * @param principalService principal service to resolve accounts, can't be {@literal null}
+	 * @param restTemplateBuilder rest template builder to create {@link OAuth2UserService} delegate, can't be {@literal null}
+	 */
 	public PrincipalAccountOAuth2UserService(PrincipalService principalService, RestTemplateBuilder restTemplateBuilder) {
 		this(principalService, createDefaultDelegate(restTemplateBuilder));
 	}

--- a/konfigyr-security/src/main/java/com/konfigyr/security/oauth/PrincipalAccountOAuth2UserService.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/oauth/PrincipalAccountOAuth2UserService.java
@@ -1,8 +1,7 @@
 package com.konfigyr.security.oauth;
 
-import com.konfigyr.account.Account;
-import com.konfigyr.account.AccountManager;
 import com.konfigyr.account.AccountRegistration;
+import com.konfigyr.security.PrincipalService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
@@ -19,21 +18,25 @@ import org.springframework.util.Assert;
  * {@link OAuth2User} using the {@link DefaultOAuth2UserService} that would fetch all user
  * attributes from OAuth Authorization server.
  * <p>
- * Once the attributes are resolved, it would try to load the user account from the
- * database or create a new one if needed. The returned {@link OAuth2User} implementation
- * would be decorated with attributes from the loaded or created {@link Account}.
+ * Once the {@link OAuth2User user attributes} are resolved, it would try to load the
+ * {@link com.konfigyr.security.AccountPrincipal}, if one already exists, or it would attempt
+ * to register a new one.
+ * <p>
+ * When registering a new {@link com.konfigyr.security.AccountPrincipal} this service would
+ * attempt to create an {@link AccountRegistration} using the resolved {@link OAuth2User} from
+ * the OAuth Authorization server.
  *
  * @author Vladimir Spasic
  * @since 1.0.0
  **/
 @RequiredArgsConstructor
-public class DatabaseOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+public class PrincipalAccountOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
 
-	private final AccountManager accountManager;
+	private final PrincipalService principalService;
 	private final OAuth2UserService<OAuth2UserRequest, ? extends OAuth2User> delegate;
 
-	public DatabaseOAuth2UserService(AccountManager accountManager, RestTemplateBuilder restTemplateBuilder) {
-		this(accountManager, createDefaultDelegate(restTemplateBuilder));
+	public PrincipalAccountOAuth2UserService(PrincipalService principalService, RestTemplateBuilder restTemplateBuilder) {
+		this(principalService, createDefaultDelegate(restTemplateBuilder));
 	}
 
 	@Override
@@ -44,23 +47,19 @@ public class DatabaseOAuth2UserService implements OAuth2UserService<OAuth2UserRe
 			return null;
 		}
 
-		final Account account = accountManager.findByEmail(user.getName())
-			.orElseGet(() -> createUserAccount(request.getClientRegistration(), user));
-
-		Assert.notNull(account.id(), "User account identifier can not be null");
-		Assert.hasText(account.email(), "User account needs to have an email address set");
-
-		return new OAuth2UserAccount(account);
+		return principalService.lookup(user, () -> createAccountRegistration(request, user));
 	}
 
-	private Account createUserAccount(ClientRegistration clientRegistration, OAuth2User user) {
+	private AccountRegistration createAccountRegistration(OAuth2UserRequest request, OAuth2User user) {
+		final ClientRegistration clientRegistration = request.getClientRegistration();
+
 		final AccountRegistration accountRegistration = OAuth2UserConverters.get(clientRegistration)
 				.convert(user);
 
 		Assert.notNull(accountRegistration, "Failed to create account registration for " +
 				"OAuth client registration with id: " + clientRegistration.getRegistrationId());
 
-		return accountManager.create(accountRegistration);
+		return accountRegistration;
 	}
 
 	private static OAuth2UserService<OAuth2UserRequest, ? extends OAuth2User> createDefaultDelegate(

--- a/konfigyr-security/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
@@ -46,6 +46,16 @@ public class AccountRememberMeServices extends AbstractRememberMeServices {
 	static final String DIGEST_ALGORITHM = "SHA-256";
 	static final int TOKEN_VALIDITY = (int) Duration.ofDays(14).toSeconds();
 
+	/**
+	 * Creates a new instance of the {@link AccountRememberMeServices} that uses the {@link PrincipalService}
+	 * as the actual {@link org.springframework.security.core.userdetails.UserDetailsService} implementation.
+	 * <p>
+	 * The {@link org.springframework.security.web.authentication.RememberMeServices} would create instances
+	 * of the {@link org.springframework.security.authentication.RememberMeAuthenticationToken} with the
+	 * {@link com.konfigyr.security.AccountPrincipal} as the principal.
+	 *
+	 * @param service account principal service used to load users, can't be {@literal null}
+	 */
 	public AccountRememberMeServices(PrincipalService service) {
 		super(KEY, service::lookup);
 

--- a/konfigyr-security/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
@@ -8,9 +8,12 @@ import org.springframework.core.log.LogMessage;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.codec.Hex;
 import org.springframework.security.crypto.codec.Utf8;
+import org.springframework.security.web.authentication.RememberMeServices;
+import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
 import org.springframework.security.web.authentication.rememberme.InvalidCookieException;
 import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationException;
@@ -19,7 +22,6 @@ import org.springframework.util.StringUtils;
 
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.time.Duration;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Objects;
@@ -35,16 +37,22 @@ import java.util.Objects;
  * <pre>
  * username + ":" + expiryTime + HEX(SHA-256(username + ":" + expiryTime + ":" + key))
  * </pre>
+ * <p>
+ * Keep in mind that this implementation of the {@link RememberMeServices} would <strong>always</strong>
+ * add the cookie when there was a successful authentication. The cookie that is set would expire after
+ * <strong>14 days</strong>
  *
  * @author Vladimir Spasic
  * @see org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices
  **/
-public class AccountRememberMeServices extends AbstractRememberMeServices {
+public class AccountRememberMeServices implements RememberMeServices, LogoutHandler {
 
 	static final String KEY = EntityId.from(123456789).serialize();
 	static final String COOKIE_NAME = "konfigyr.account";
 	static final String DIGEST_ALGORITHM = "SHA-256";
-	static final int TOKEN_VALIDITY = (int) Duration.ofDays(14).toSeconds();
+	static final int TOKEN_VALIDITY = 14 * 24 * 60 * 60; // 14 days in seconds (days * hours * minutes * seconds = 1209600)
+
+	private final AbstractRememberMeServices delegate;
 
 	/**
 	 * Creates a new instance of the {@link AccountRememberMeServices} that uses the {@link PrincipalService}
@@ -57,133 +65,32 @@ public class AccountRememberMeServices extends AbstractRememberMeServices {
 	 * @param service account principal service used to load users, can't be {@literal null}
 	 */
 	public AccountRememberMeServices(PrincipalService service) {
-		super(KEY, service::lookup);
-
-		super.setTokenValiditySeconds(TOKEN_VALIDITY);
-		super.setCookieName(COOKIE_NAME);
-		super.setUseSecureCookie(true);
-		super.setAlwaysRemember(true);
+		this.delegate = new InternalRememberMeServices(KEY, service::lookup);
+		delegate.setTokenValiditySeconds(TOKEN_VALIDITY);
+		delegate.setCookieName(COOKIE_NAME);
+		delegate.setUseSecureCookie(true);
+		delegate.setAlwaysRemember(true);
+		delegate.afterPropertiesSet();
 	}
 
 	@Override
-	protected void onLoginSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
-		final String username = retrieveUserName(authentication);
-
-		// If we are unable to find a username do not generate any remember-me cookie
-		if (!StringUtils.hasLength(username)) {
-			logger.debug(LogMessage.format(
-					"Can not add remember-me cookie due to a missing username in: %s",
-					authentication
-			));
-			return;
-		}
-
-		final long expiryTime = System.currentTimeMillis() + getTokenValiditySeconds();
-		final String signature = generateSignature(username, expiryTime);
-
-		setCookie(new String[] { username, Long.toString(expiryTime), signature }, getTokenValiditySeconds(), request, response);
-
-		if (this.logger.isDebugEnabled()) {
-			this.logger.debug(LogMessage.format(
-					"Added remember-me cookie for principal '%s' that expires at: '%s'",
-					username,
-					new Date(expiryTime)
-			));
-		}
+	public Authentication autoLogin(HttpServletRequest request, HttpServletResponse response) {
+		return delegate.autoLogin(request, response);
 	}
 
 	@Override
-	protected UserDetails processAutoLoginCookie(
-			String[] cookieTokens,
-			HttpServletRequest request,
-			HttpServletResponse response
-	) throws RememberMeAuthenticationException, UsernameNotFoundException {
-		assertTokenLength(cookieTokens);
-		long tokenExpiryTime = extractTokenExpiryTime(cookieTokens);
-
-		final UserDetails userDetails = retrieveUserDetails(cookieTokens[0]);
-
-		// Generate the signature to check if it matches the signature of token
-		final String signature = generateSignature(userDetails.getUsername(), tokenExpiryTime);
-
-		if (signaturesMatch(signature, cookieTokens[2])) {
-			return userDetails;
-		}
-
-		throw new InvalidCookieException("Cookie contained signature '" + cookieTokens[2] + "' but expected '"
-				+ signature + "'");
-	}
-
-	private long extractTokenExpiryTime(String[] cookieTokens) {
-		final long expiryTime;
-
-		try {
-			expiryTime = Long.parseLong(cookieTokens[1]);
-		} catch (NumberFormatException nfe) {
-			throw new InvalidCookieException("Cookie did not contain a valid number (contained '" + cookieTokens[1] + "')");
-		}
-
-		if (expiryTime < System.currentTimeMillis()) {
-			throw new InvalidCookieException("Cookie has expired (expired on '" + new Date(expiryTime) + "')");
-		}
-
-		return expiryTime;
+	public void loginFail(HttpServletRequest request, HttpServletResponse response) {
+		delegate.loginFail(request, response);
 	}
 
 	@Override
-	public void setAlwaysRemember(boolean alwaysRemember) {
-		unsupportedOperation("alwaysRemember");
+	public void loginSuccess(HttpServletRequest request, HttpServletResponse response, Authentication successfulAuthentication) {
+		delegate.loginSuccess(request, response, successfulAuthentication);
 	}
 
 	@Override
-	public void setCookieName(String cookieName) {
-		unsupportedOperation("cookieName");
-	}
-
-	@Override
-	public void setUseSecureCookie(boolean useSecureCookie) {
-		unsupportedOperation("useSecureCookie");
-	}
-
-	@Override
-	public void setParameter(String parameter) {
-		unsupportedOperation("parameter");
-	}
-
-	@Override
-	public void setTokenValiditySeconds(int tokenValiditySeconds) {
-		unsupportedOperation("tokenValiditySeconds");
-	}
-
-	private UserDetails retrieveUserDetails(String username) {
-		final UserDetails userDetails = getUserDetailsService().loadUserByUsername(username);
-
-		if (userDetails == null) {
-			throw new InternalAuthenticationServiceException("User details service returned null for username '"
-					+ username + "'. This is considered as an interface contract violation.");
-		}
-
-		return userDetails;
-	}
-
-	private String retrieveUserName(Authentication authentication) {
-		Assert.notNull(authentication, "Authentication can not be null");
-
-		if (authentication.getPrincipal() instanceof UserDetails user) {
-			return user.getUsername();
-		}
-
-		return Objects.toString(authentication.getPrincipal(), null);
-	}
-
-	private String generateSignature(String username, long tokenExpiryTime) {
-		return generateSignature(username, tokenExpiryTime, getKey(), DIGEST_ALGORITHM);
-	}
-
-	private static void assertTokenLength(String[] tokens) {
-		if (tokens.length != 3) {
-			throw new InvalidCookieException("Cookie needs to contain 3 tokens: '" + Arrays.asList(tokens) + "'");
-		}
+	public void logout(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+		delegate.logout(request, response, authentication);
 	}
 
 	static String generateSignature(String username, long tokenExpiryTime, String key, String algorithm) {
@@ -197,12 +104,108 @@ public class AccountRememberMeServices extends AbstractRememberMeServices {
 		}
 	}
 
-	private static boolean signaturesMatch(String expected, String actual) {
+	static boolean signaturesMatch(String expected, String actual) {
 		return MessageDigest.isEqual(Utf8.encode(expected), Utf8.encode(actual));
 	}
 
-	private static void unsupportedOperation(String field) {
-		throw new UnsupportedOperationException("It is not possible to set '" + field + "' field for " +
-				"this implementation of the remember me services.");
+	/**
+	 * This class is intentionally made internal as we do not wish to expose the API of the
+	 * {@link AbstractRememberMeServices} via {@link AccountRememberMeServices}. We should prevent
+	 * any customization, i.e. different cookie names or max age..., of the {@link RememberMeServices}
+	 * that would be registered in Spring HTTP security filter chain.
+	 */
+	private static final class InternalRememberMeServices extends AbstractRememberMeServices {
+
+		private InternalRememberMeServices(String key, UserDetailsService userDetailsService) {
+			super(key, userDetailsService);
+		}
+
+		@Override
+		protected void onLoginSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+			final String username = retrieveUserName(authentication);
+
+			// If we are unable to find a username do not generate any remember-me cookie
+			if (!StringUtils.hasLength(username)) {
+				logger.debug(LogMessage.format(
+						"Can not add remember-me cookie due to a missing username in: %s",
+						authentication
+				));
+				return;
+			}
+
+			final long expiryTime = System.currentTimeMillis() + getTokenValiditySeconds();
+			final String signature = generateSignature(username, expiryTime, getKey(), DIGEST_ALGORITHM);
+
+			setCookie(new String[] { username, Long.toString(expiryTime), signature }, getTokenValiditySeconds(), request, response);
+
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug(LogMessage.format(
+						"Added remember-me cookie for principal '%s' that expires at: '%s'",
+						username,
+						new Date(expiryTime)
+				));
+			}
+		}
+
+		@Override
+		protected UserDetails processAutoLoginCookie(
+				String[] tokens,
+				HttpServletRequest request,
+				HttpServletResponse response
+		) throws RememberMeAuthenticationException, UsernameNotFoundException {
+			if (tokens.length != 3) {
+				throw new InvalidCookieException("Cookie needs to contain 3 tokens: '" + Arrays.asList(tokens) + "'");
+			}
+
+			final long tokenExpiryTime = extractTokenExpiryTime(tokens);
+			final UserDetails user = retrieveUserDetails(tokens[0]);
+
+			// Generate the signature to check if it matches the signature of token
+			final String signature = generateSignature(user.getUsername(), tokenExpiryTime, getKey(), DIGEST_ALGORITHM);
+
+			if (signaturesMatch(signature, tokens[2])) {
+				return user;
+			}
+
+			throw new InvalidCookieException("Cookie contained signature '" + tokens[2] + "' but expected '" + signature + "'");
+		}
+
+		private long extractTokenExpiryTime(String[] tokens) {
+			final long expiryTime;
+
+			try {
+				expiryTime = Long.parseLong(tokens[1]);
+			} catch (NumberFormatException nfe) {
+				throw new InvalidCookieException("Cookie did not contain a valid number (contained '" + tokens[1] + "')");
+			}
+
+			if (expiryTime < System.currentTimeMillis()) {
+				throw new InvalidCookieException("Cookie has expired (expired on '" + new Date(expiryTime) + "')");
+			}
+
+			return expiryTime;
+		}
+
+		private UserDetails retrieveUserDetails(String username) {
+			final UserDetails userDetails = getUserDetailsService().loadUserByUsername(username);
+
+			if (userDetails == null) {
+				throw new InternalAuthenticationServiceException("User details service returned null for username '"
+						+ username + "'. This is considered as an interface contract violation.");
+			}
+
+			return userDetails;
+		}
+
+		private String retrieveUserName(Authentication authentication) {
+			Assert.notNull(authentication, "Authentication can not be null");
+
+			if (authentication.getPrincipal() instanceof UserDetails user) {
+				return user.getUsername();
+			}
+
+			return Objects.toString(authentication.getPrincipal(), null);
+		}
+
 	}
 }

--- a/konfigyr-security/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
@@ -39,8 +39,8 @@ import java.util.Objects;
  * </pre>
  * <p>
  * Keep in mind that this implementation of the {@link RememberMeServices} would <strong>always</strong>
- * add the cookie when there was a successful authentication. The cookie that is set would expire after
- * <strong>14 days</strong>
+ * add, or extend the existing, cookie when there was a successful authentication. The cookie that is
+ * set would have a name of <code>konfigyr.account</code> and would expire after <strong>14 days</strong>.
  *
  * @author Vladimir Spasic
  * @see org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices

--- a/konfigyr-security/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
+++ b/konfigyr-security/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
@@ -1,0 +1,199 @@
+package com.konfigyr.security.rememberme;
+
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.security.PrincipalService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.log.LogMessage;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.codec.Hex;
+import org.springframework.security.crypto.codec.Utf8;
+import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
+import org.springframework.security.web.authentication.rememberme.InvalidCookieException;
+import org.springframework.security.web.authentication.rememberme.RememberMeAuthenticationException;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Objects;
+
+/**
+ * Implementation of the {@link org.springframework.security.web.authentication.RememberMeServices} that
+ * is based on the {@link org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices}.
+ * <p>
+ * The difference here is that we are not using the password of the {@link UserDetails user} to generate
+ * the cookie token value. User accounts within this application do not use passwords.
+ * <p>
+ * The cookie encoded by this implementation adopts the following form:
+ * <pre>
+ * username + ":" + expiryTime + HEX(SHA-256(username + ":" + expiryTime + ":" + key))
+ * </pre>
+ *
+ * @author Vladimir Spasic
+ * @see org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices
+ **/
+public class AccountRememberMeServices extends AbstractRememberMeServices {
+
+	static final String KEY = EntityId.from(123456789).serialize();
+	static final String COOKIE_NAME = "konfigyr.account";
+	static final String DIGEST_ALGORITHM = "SHA-256";
+	static final int TOKEN_VALIDITY = (int) Duration.ofDays(14).toSeconds();
+
+	public AccountRememberMeServices(PrincipalService service) {
+		this(service::lookup);
+	}
+
+	AccountRememberMeServices(UserDetailsService service) {
+		super(KEY, service);
+
+		super.setTokenValiditySeconds(TOKEN_VALIDITY);
+		super.setCookieName(COOKIE_NAME);
+		super.setUseSecureCookie(true);
+		super.setAlwaysRemember(true);
+	}
+
+	@Override
+	protected void onLoginSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+		final String username = retrieveUserName(authentication);
+
+		// If we are unable to find a username do not generate any remember-me cookie
+		if (!StringUtils.hasLength(username)) {
+			logger.debug(LogMessage.format(
+					"Can not add remember-me cookie due to a missing username in: %s",
+					authentication
+			));
+			return;
+		}
+
+		final long expiryTime = System.currentTimeMillis() + getTokenValiditySeconds();
+		final String signature = generateSignature(username, expiryTime, getKey());
+
+		setCookie(new String[] { username, Long.toString(expiryTime), signature }, getTokenValiditySeconds(), request, response);
+
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug(LogMessage.format(
+					"Added remember-me cookie for principal '%s' that expires at: '%s'",
+					username,
+					new Date(expiryTime)
+			));
+		}
+	}
+
+	@Override
+	protected UserDetails processAutoLoginCookie(
+			String[] cookieTokens,
+			HttpServletRequest request,
+			HttpServletResponse response
+	) throws RememberMeAuthenticationException, UsernameNotFoundException {
+		assertTokenLength(cookieTokens);
+		long tokenExpiryTime = extractTokenExpiryTime(cookieTokens);
+
+		final UserDetails userDetails = retrieveUserDetails(cookieTokens[0]);
+
+		// Generate the signature to check if it matches the signature of token
+		final String signature = generateSignature(userDetails.getUsername(), tokenExpiryTime, getKey());
+
+		if (signaturesMatch(signature, cookieTokens[2])) {
+			return userDetails;
+		}
+
+		throw new InvalidCookieException("Cookie contained signature '" + cookieTokens[2] + "' but expected '"
+				+ signature + "'");
+	}
+
+	private long extractTokenExpiryTime(String[] cookieTokens) {
+		final long expiryTime;
+
+		try {
+			expiryTime = Long.parseLong(cookieTokens[1]);
+		} catch (NumberFormatException nfe) {
+			throw new InvalidCookieException("Cookie did not contain a valid number (contained '" + cookieTokens[1] + "')");
+		}
+
+		if (expiryTime < System.currentTimeMillis()) {
+			throw new InvalidCookieException("Cookie has expired (expired on '" + new Date(expiryTime) + "')");
+		}
+
+		return expiryTime;
+	}
+
+	@Override
+	public void setAlwaysRemember(boolean alwaysRemember) {
+		unsupportedOperation("alwaysRemember");
+	}
+
+	@Override
+	public void setCookieName(String cookieName) {
+		unsupportedOperation("cookieName");
+	}
+
+	@Override
+	public void setUseSecureCookie(boolean useSecureCookie) {
+		unsupportedOperation("useSecureCookie");
+	}
+
+	@Override
+	public void setParameter(String parameter) {
+		unsupportedOperation("parameter");
+	}
+
+	@Override
+	public void setTokenValiditySeconds(int tokenValiditySeconds) {
+		unsupportedOperation("tokenValiditySeconds");
+	}
+
+	private UserDetails retrieveUserDetails(String username) {
+		final UserDetails userDetails = getUserDetailsService().loadUserByUsername(username);
+
+		if (userDetails == null) {
+			throw new InternalAuthenticationServiceException("User details service returned null for username '"
+					+ username + "'. This is considered as an interface contract violation.");
+		}
+
+		return userDetails;
+	}
+
+	private String retrieveUserName(Authentication authentication) {
+		Assert.notNull(authentication, "Authentication can not be null");
+
+		if (authentication.getPrincipal() instanceof UserDetails user) {
+			return user.getUsername();
+		}
+
+		return Objects.toString(authentication.getPrincipal(), null);
+	}
+
+	private static void assertTokenLength(String[] tokens) {
+		if (tokens.length != 3) {
+			throw new InvalidCookieException("Cookie needs to contain 3 tokens: '" + Arrays.asList(tokens) + "'");
+		}
+	}
+
+	private static String generateSignature(String username, long tokenExpiryTime, String key) {
+		final String data = username + ":" + tokenExpiryTime + ":" + key;
+
+		try {
+			final MessageDigest digest = MessageDigest.getInstance(DIGEST_ALGORITHM);
+			return new String(Hex.encode(digest.digest(data.getBytes())));
+		} catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("No SHA-256 digest algorithm is available!");
+		}
+	}
+
+	private static boolean signaturesMatch(String expected, String actual) {
+		return MessageDigest.isEqual(Utf8.encode(expected), Utf8.encode(actual));
+	}
+
+	private static void unsupportedOperation(String field) {
+		throw new UnsupportedOperationException("It is not possible to set '" + field + "' field for " +
+				"this implementation of the remember me services.");
+	}
+}

--- a/konfigyr-security/src/test/java/com/konfigyr/security/AccountPrincipalServiceTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/AccountPrincipalServiceTest.java
@@ -1,0 +1,171 @@
+package com.konfigyr.security;
+
+import com.konfigyr.account.AccountManager;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.test.TestAccounts;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.core.userdetails.cache.SpringCacheBasedUserCache;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccountPrincipalServiceTest {
+
+	@Mock
+	AccountManager manager;
+
+	PrincipalService service;
+
+	@BeforeEach
+	void setup() {
+		service = new AccountPrincipalService(manager);
+	}
+
+	@Test
+	@DisplayName("should load account by identifier")
+	void loadByIdentifier() {
+		final var account = TestAccounts.jane().build();
+
+		doReturn(Optional.of(account)).when(manager).findById(account.id());
+
+		assertThat(service.lookup(account.id().serialize()))
+				.isNotNull()
+				.isInstanceOf(AccountPrincipal.class)
+				.returns(account.id().serialize(), UserDetails::getUsername)
+				.returns("", UserDetails::getPassword)
+				.returns(AuthorityUtils.createAuthorityList("admin"), UserDetails::getAuthorities)
+				.returns(false, UserDetails::isEnabled)
+				.returns(true, UserDetails::isAccountNonLocked)
+				.returns(true, UserDetails::isAccountNonExpired)
+				.returns(false, UserDetails::isCredentialsNonExpired);
+	}
+
+	@Test
+	@DisplayName("should load account by serialized identifier")
+	void loadBySerializedIdentifier() {
+		final var account = TestAccounts.john().build();
+
+		doReturn(Optional.of(account)).when(manager).findById(account.id());
+
+		assertThat(service.lookup(account.id().serialize()))
+				.isNotNull()
+				.isInstanceOf(AccountPrincipal.class)
+				.returns(account.id().serialize(), UserDetails::getUsername)
+				.returns("", UserDetails::getPassword)
+				.returns(AuthorityUtils.createAuthorityList("admin"), UserDetails::getAuthorities)
+				.returns(true, UserDetails::isEnabled)
+				.returns(true, UserDetails::isAccountNonLocked)
+				.returns(true, UserDetails::isAccountNonExpired)
+				.returns(true, UserDetails::isCredentialsNonExpired);
+	}
+
+	@Test
+	@DisplayName("should load user from cache")
+	void loadUserFromCache() {
+		final var cache = new ConcurrentMapCache("user-cache");
+		service = new AccountPrincipalService(manager, new SpringCacheBasedUserCache(cache));
+
+		final var account = TestAccounts.john().build();
+
+		doReturn(Optional.of(account)).when(manager).findById(account.id());
+
+		final var principal = service.lookup(account.id().serialize());
+
+		assertThat(principal)
+				.isNotNull()
+				.isSameAs(service.lookup(account.id().serialize()));
+
+		assertThat(cache.getNativeCache())
+				.isNotEmpty()
+				.containsEntry(principal.getUsername(), principal);
+
+		verify(manager, times(1)).findById(account.id());
+	}
+
+	@Test
+	@DisplayName("should evict user from cache when invalid")
+	void loadEvictInvalidPrincipalFromCache() {
+		final var account = TestAccounts.john().build();
+		final var invalid = User.withUsername("test")
+				.password("pass")
+				.authorities("testing")
+				.build();
+
+		final var cache = new ConcurrentMapCache("user-cache");
+		cache.put(account.id().serialize(), invalid);
+
+		service = new AccountPrincipalService(manager, new SpringCacheBasedUserCache(cache));
+
+		assertThatThrownBy(() -> service.lookup(account.id()))
+				.isInstanceOf(UsernameNotFoundException.class);
+
+		assertThat(cache.getNativeCache())
+				.isEmpty();
+
+		verify(manager, times(1)).findById(account.id());
+	}
+
+	@Test
+	@DisplayName("should fail to load account by identifier")
+	void failToLoadByIdentifier() {
+		final var id = EntityId.from(1);
+
+		assertThatThrownBy(() -> service.lookup(id))
+				.isInstanceOf(UsernameNotFoundException.class)
+				.hasMessageContaining("Failed to lookup user account for identifier:")
+				.hasMessageContaining(id.toString())
+				.hasNoCause();
+
+		verify(manager).findById(id);
+	}
+
+	@Test
+	@DisplayName("should fail to load account by serialized identifier")
+	void failToLoadBySerializedIdentifier() {
+		final var id = EntityId.from(1);
+
+		assertThatThrownBy(() -> service.lookup(id.serialize()))
+				.isInstanceOf(UsernameNotFoundException.class)
+				.hasMessageContaining("Failed to lookup user account for identifier:")
+				.hasMessageContaining(id.toString())
+				.hasNoCause();
+
+		verify(manager).findById(id);
+	}
+
+	@Test
+	@DisplayName("should fail load account when identifier is empty, blank or invalid")
+	void failToLoadWhenBlankOrInvalid() {
+		assertThatThrownBy(() -> service.lookup(""))
+				.isInstanceOf(UsernameNotFoundException.class)
+				.hasMessageContaining("Failed to lookup user account for invalid username")
+				.hasRootCauseInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> service.lookup("   "))
+				.isInstanceOf(UsernameNotFoundException.class)
+				.hasMessageContaining("Failed to lookup user account for invalid username")
+				.hasRootCauseInstanceOf(IllegalArgumentException.class);
+
+		assertThatThrownBy(() -> service.lookup("account@acme.com"))
+				.isInstanceOf(UsernameNotFoundException.class)
+				.hasMessageContaining("Failed to lookup user account for invalid username")
+				.hasRootCauseInstanceOf(IllegalArgumentException.class);
+
+		verifyNoInteractions(manager);
+	}
+
+}

--- a/konfigyr-security/src/test/java/com/konfigyr/security/AccountPrincipalTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/AccountPrincipalTest.java
@@ -1,0 +1,36 @@
+package com.konfigyr.security;
+
+import com.konfigyr.test.TestAccounts;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AccountPrincipalTest {
+
+	@Test
+	@DisplayName("should create account user")
+	void shouldCreateUserFromAccount() {
+		final var account = TestAccounts.john().build();
+
+		assertThat(new AccountPrincipal(account))
+				.returns(account.id(), AccountPrincipal::getId)
+				.returns(account.email(), AccountPrincipal::getEmail)
+				.returns(account.id().serialize(), UserDetails::getUsername)
+				.returns(account.avatar(), AccountPrincipal::getAvatar)
+				.returns(Map.of(), AccountPrincipal::getAttributes)
+				.returns("", UserDetails::getPassword)
+				.returns(AuthorityUtils.createAuthorityList("admin"), UserDetails::getAuthorities)
+				.returns(true, UserDetails::isEnabled)
+				.returns(true, UserDetails::isAccountNonLocked)
+				.returns(true, UserDetails::isAccountNonExpired)
+				.returns(true, UserDetails::isCredentialsNonExpired)
+				.hasSameHashCodeAs(new AccountPrincipal(account))
+				.isEqualTo(new AccountPrincipal(account));
+	}
+
+}

--- a/konfigyr-security/src/test/java/com/konfigyr/security/AccountPrincipalTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/AccountPrincipalTest.java
@@ -1,5 +1,6 @@
 package com.konfigyr.security;
 
+import com.konfigyr.account.AccountStatus;
 import com.konfigyr.test.TestAccounts;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -13,8 +14,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 class AccountPrincipalTest {
 
 	@Test
-	@DisplayName("should create account user")
-	void shouldCreateUserFromAccount() {
+	@DisplayName("should create active account principal")
+	void shouldCreatePrincipalFromActiveAccount() {
 		final var account = TestAccounts.john().build();
 
 		assertThat(new AccountPrincipal(account))
@@ -29,6 +30,73 @@ class AccountPrincipalTest {
 				.returns(true, UserDetails::isAccountNonLocked)
 				.returns(true, UserDetails::isAccountNonExpired)
 				.returns(true, UserDetails::isCredentialsNonExpired)
+				.hasSameHashCodeAs(new AccountPrincipal(account))
+				.isEqualTo(new AccountPrincipal(account));
+	}
+
+	@Test
+	@DisplayName("should create inactive account principal")
+	void shouldCreatePrincipalFromInactiveAccount() {
+		final var account = TestAccounts.jane().build();
+
+		assertThat(new AccountPrincipal(account))
+				.returns(account.id(), AccountPrincipal::getId)
+				.returns(account.email(), AccountPrincipal::getEmail)
+				.returns(account.id().serialize(), UserDetails::getUsername)
+				.returns(account.avatar(), AccountPrincipal::getAvatar)
+				.returns(Map.of(), AccountPrincipal::getAttributes)
+				.returns("", UserDetails::getPassword)
+				.returns(AuthorityUtils.createAuthorityList("admin"), UserDetails::getAuthorities)
+				.returns(false, UserDetails::isEnabled)
+				.returns(true, UserDetails::isAccountNonLocked)
+				.returns(true, UserDetails::isAccountNonExpired)
+				.returns(false, UserDetails::isCredentialsNonExpired)
+				.hasSameHashCodeAs(new AccountPrincipal(account))
+				.isEqualTo(new AccountPrincipal(account));
+	}
+
+	@Test
+	@DisplayName("should create deactivated account principal")
+	void shouldCreatePrincipalFromDeactivatedAccount() {
+		final var account = TestAccounts.john()
+				.status(AccountStatus.DEACTIVATED)
+				.build();
+
+		assertThat(new AccountPrincipal(account))
+				.returns(account.id(), AccountPrincipal::getId)
+				.returns(account.email(), AccountPrincipal::getEmail)
+				.returns(account.id().serialize(), UserDetails::getUsername)
+				.returns(account.avatar(), AccountPrincipal::getAvatar)
+				.returns(Map.of(), AccountPrincipal::getAttributes)
+				.returns("", UserDetails::getPassword)
+				.returns(AuthorityUtils.createAuthorityList("admin"), UserDetails::getAuthorities)
+				.returns(false, UserDetails::isEnabled)
+				.returns(true, UserDetails::isAccountNonLocked)
+				.returns(false, UserDetails::isAccountNonExpired)
+				.returns(false, UserDetails::isCredentialsNonExpired)
+				.hasSameHashCodeAs(new AccountPrincipal(account))
+				.isEqualTo(new AccountPrincipal(account));
+	}
+
+	@Test
+	@DisplayName("should create suspended account principal")
+	void shouldCreatePrincipalFromSuspendedAccount() {
+		final var account = TestAccounts.john()
+				.status(AccountStatus.SUSPENDED)
+				.build();
+
+		assertThat(new AccountPrincipal(account))
+				.returns(account.id(), AccountPrincipal::getId)
+				.returns(account.email(), AccountPrincipal::getEmail)
+				.returns(account.id().serialize(), UserDetails::getUsername)
+				.returns(account.avatar(), AccountPrincipal::getAvatar)
+				.returns(Map.of(), AccountPrincipal::getAttributes)
+				.returns("", UserDetails::getPassword)
+				.returns(AuthorityUtils.createAuthorityList("admin"), UserDetails::getAuthorities)
+				.returns(false, UserDetails::isEnabled)
+				.returns(false, UserDetails::isAccountNonLocked)
+				.returns(true, UserDetails::isAccountNonExpired)
+				.returns(false, UserDetails::isCredentialsNonExpired)
 				.hasSameHashCodeAs(new AccountPrincipal(account))
 				.isEqualTo(new AccountPrincipal(account));
 	}

--- a/konfigyr-security/src/test/java/com/konfigyr/security/SecurityAutoConfigurationTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/SecurityAutoConfigurationTest.java
@@ -1,0 +1,114 @@
+package com.konfigyr.security;
+
+import com.konfigyr.account.AccountManager;
+import com.konfigyr.crypto.*;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
+import org.springframework.boot.context.annotation.Configurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.cache.support.NoOpCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.security.core.userdetails.UserCache;
+import org.springframework.security.core.userdetails.cache.SpringCacheBasedUserCache;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ExtendWith(MockitoExtension.class)
+class SecurityAutoConfigurationTest {
+
+	final Configurations configurations = AutoConfigurations.of(
+			SecurityAutoConfiguration.class,
+			RestTemplateAutoConfiguration.class
+	);
+
+	@Mock
+	DSLContext context;
+
+	@Mock
+	AccountManager manager;
+
+	@Mock
+	KeysetOperationsFactory operationsFactory;
+
+	@Mock
+	ClientRegistrationRepository registrationRepository;
+
+	ApplicationContextRunner runner;
+
+	@BeforeEach
+	void setup() {
+		runner = new ApplicationContextRunner().withConfiguration(configurations)
+				.withBean(DSLContext.class, () -> context)
+				.withBean(AccountManager.class, () -> manager)
+				.withBean(KeysetOperationsFactory.class, () -> operationsFactory)
+				.withBean(ClientRegistrationRepository.class, () -> registrationRepository);
+	}
+
+	@Test
+	void shouldCreateDefaultBeans() {
+		runner.withConfiguration(configurations).run(ctx -> assertThat(ctx)
+				.hasNotFailed()
+				.hasBean("accountPrincipalService")
+				.hasBean("principalAccountOAuth2UserService")
+				.hasBean("persistentAuthorizedClientService")
+				.doesNotHaveBean("userCache")
+				.doesNotHaveBean("cachingAccountPrincipalService")
+		);
+	}
+
+	@Test
+	void shouldCreateNoopCachedAccountService() {
+		runner.withConfiguration(configurations)
+				.withBean(CacheManager.class, SimpleCacheManager::new)
+				.run(ctx -> {
+					assertThat(ctx)
+							.hasNotFailed()
+							.hasBean("userCache")
+							.hasBean("cachingAccountPrincipalService")
+							.hasBean("principalAccountOAuth2UserService")
+							.hasBean("persistentAuthorizedClientService")
+							.doesNotHaveBean("accountPrincipalService");
+
+					assertThat(ctx.getBean(UserCache.class))
+							.isInstanceOf(SpringCacheBasedUserCache.class)
+							.extracting("cache")
+							.isInstanceOf(NoOpCache.class);
+				});
+	}
+
+	@Test
+	void shouldCreateCachedAccountService() {
+		final var cache = new ConcurrentMapCache("user-cache");
+		final var manager = new SimpleCacheManager();
+		manager.setCaches(List.of(cache));
+
+		runner.withConfiguration(configurations)
+				.withBean(CacheManager.class, () -> manager)
+				.run(ctx -> {
+					assertThat(ctx)
+							.hasNotFailed()
+							.hasBean("userCache")
+							.hasBean("cachingAccountPrincipalService")
+							.hasBean("principalAccountOAuth2UserService")
+							.hasBean("persistentAuthorizedClientService")
+							.doesNotHaveBean("accountPrincipalService");
+
+					assertThat(ctx.getBean(UserCache.class))
+							.isInstanceOf(SpringCacheBasedUserCache.class)
+							.extracting("cache")
+							.isEqualTo(cache);
+				});
+	}
+
+}

--- a/konfigyr-security/src/test/java/com/konfigyr/security/SecurityAutoConfigurationTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/SecurityAutoConfigurationTest.java
@@ -16,7 +16,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 import org.springframework.cache.support.NoOpCache;
 import org.springframework.cache.support.SimpleCacheManager;
-import org.springframework.security.core.userdetails.UserCache;
+import org.springframework.security.core.userdetails.cache.NullUserCache;
 import org.springframework.security.core.userdetails.cache.SpringCacheBasedUserCache;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
@@ -57,14 +57,19 @@ class SecurityAutoConfigurationTest {
 
 	@Test
 	void shouldCreateDefaultBeans() {
-		runner.withConfiguration(configurations).run(ctx -> assertThat(ctx)
-				.hasNotFailed()
-				.hasBean("accountPrincipalService")
-				.hasBean("principalAccountOAuth2UserService")
-				.hasBean("persistentAuthorizedClientService")
-				.doesNotHaveBean("userCache")
-				.doesNotHaveBean("cachingAccountPrincipalService")
-		);
+		runner.withConfiguration(configurations).run(ctx -> {
+			assertThat(ctx)
+					.hasNotFailed()
+					.hasBean("accountPrincipalService")
+					.hasBean("principalAccountOAuth2UserService")
+					.hasBean("persistentAuthorizedClientService")
+					.doesNotHaveBean("userCache");
+
+			assertThat(ctx.getBean(PrincipalService.class))
+					.isInstanceOf(AccountPrincipalService.class)
+					.extracting("cache")
+					.isInstanceOf(NullUserCache.class);
+		});
 	}
 
 	@Test
@@ -75,12 +80,13 @@ class SecurityAutoConfigurationTest {
 					assertThat(ctx)
 							.hasNotFailed()
 							.hasBean("userCache")
-							.hasBean("cachingAccountPrincipalService")
+							.hasBean("accountPrincipalService")
 							.hasBean("principalAccountOAuth2UserService")
-							.hasBean("persistentAuthorizedClientService")
-							.doesNotHaveBean("accountPrincipalService");
+							.hasBean("persistentAuthorizedClientService");
 
-					assertThat(ctx.getBean(UserCache.class))
+					assertThat(ctx.getBean(PrincipalService.class))
+							.isInstanceOf(AccountPrincipalService.class)
+							.extracting("cache")
 							.isInstanceOf(SpringCacheBasedUserCache.class)
 							.extracting("cache")
 							.isInstanceOf(NoOpCache.class);
@@ -99,12 +105,13 @@ class SecurityAutoConfigurationTest {
 					assertThat(ctx)
 							.hasNotFailed()
 							.hasBean("userCache")
-							.hasBean("cachingAccountPrincipalService")
+							.hasBean("accountPrincipalService")
 							.hasBean("principalAccountOAuth2UserService")
-							.hasBean("persistentAuthorizedClientService")
-							.doesNotHaveBean("accountPrincipalService");
+							.hasBean("persistentAuthorizedClientService");
 
-					assertThat(ctx.getBean(UserCache.class))
+					assertThat(ctx.getBean(PrincipalService.class))
+							.isInstanceOf(AccountPrincipalService.class)
+							.extracting("cache")
 							.isInstanceOf(SpringCacheBasedUserCache.class)
 							.extracting("cache")
 							.isEqualTo(cache);

--- a/konfigyr-security/src/test/java/com/konfigyr/security/oauth/OAuth2AccessTokens.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/oauth/OAuth2AccessTokens.java
@@ -2,6 +2,7 @@ package com.konfigyr.security.oauth;
 
 import org.springframework.lang.NonNull;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
+import org.springframework.security.oauth2.core.OAuth2RefreshToken;
 
 import java.time.Duration;
 import java.time.Instant;
@@ -16,6 +17,16 @@ public interface OAuth2AccessTokens {
 		final Instant timestamp = Instant.now();
 
 		return new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, value, timestamp, timestamp.plus(expiry));
+	}
+
+	static OAuth2RefreshToken createRefreshToken(@NonNull String value) {
+		return createRefreshToken(value, Duration.ofSeconds(60));
+	}
+
+	static OAuth2RefreshToken createRefreshToken(@NonNull String value, @NonNull Duration expiry) {
+		final Instant timestamp = Instant.now();
+
+		return new OAuth2RefreshToken(value, timestamp, timestamp.plus(expiry));
 	}
 
 }

--- a/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
@@ -1,0 +1,308 @@
+package com.konfigyr.security.rememberme;
+
+import jakarta.servlet.http.Cookie;
+import org.assertj.core.data.Index;
+import org.assertj.core.data.Offset;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.codec.Hex;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class AccountRememberMeServicesTest {
+
+	@Mock
+	UserDetailsService userDetailsService;
+
+	UserDetails user = User.withUsername("user-name")
+			.password("pass")
+			.accountExpired(false)
+			.accountLocked(false)
+			.credentialsExpired(false)
+			.disabled(false)
+			.authorities("test-authority")
+			.build();
+
+	MockHttpServletRequest request;
+	MockHttpServletResponse response;
+	AccountRememberMeServices services;
+
+	@BeforeEach
+	public void createTokenBasedRememberMeServices() {
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+		services = new AccountRememberMeServices(userDetailsService);
+	}
+
+	@Test
+	@DisplayName("should return null when cookies are present in the request")
+	public void autoLoginReturnsNullIfNoCookiePresented() {
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNull();
+	}
+
+	@Test
+	@DisplayName("should return null when remember-me cookie is not present")
+	public void autoLoginIgnoresUnrelatedCookie() {
+		request.setCookies(new Cookie("some", "cookie"));
+
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNull();
+	}
+
+	@Test
+	@DisplayName("should return null when remember-me cookie is invalid and clear it")
+	public void autoLoginReturnsNullAndClearsCookieIfMissingThreeTokensInCookieValue() {
+		request.setCookies(createCookie(encode("x")));
+
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should return null when remember-me cookie is not Base64 encoded and clear it")
+	public void autoLoginClearsNonBase64EncodedCookie() {
+		request.setCookies(createCookie("non-encoded-value"));
+
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should return null when remember-me cookie is expired and clear it")
+	public void autoLoginReturnsNullForExpiredCookieAndClearsCookie() {
+		request.setCookies(createCookie(System.currentTimeMillis() - 1000000, user.getUsername()));
+
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should return null when remember-me cookie signature does not match and clear it")
+	public void autoLoginClearsCookieIfSignatureBlocksDoesNotMatchExpectedValue() {
+		doReturn(user).when(userDetailsService).loadUserByUsername(anyString());
+
+		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, user.getUsername(), "WRONG_KEY"));
+
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should return null when remember-me cookie expiry time is invalid and clear it")
+	public void autoLoginClearsCookieIfTokenDoesNotContainANumberInCookieValue() {
+		request.setCookies(createCookie(encode("username:NOT_A_NUMBER:signature")));
+
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should return null when user account is not found and clear it")
+	public void autoLoginClearsCookieIfUserNotFound() {
+		doThrow(UsernameNotFoundException.class).when(userDetailsService).loadUserByUsername(anyString());
+
+		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, "not-found"));
+
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should throw internal service error when user service returns null")
+	public void autoLoginClearsCookieIfUserServiceMisconfigured() {
+		doReturn(null).when(userDetailsService).loadUserByUsername(anyString());
+
+		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, user.getUsername()));
+
+		assertThatException().isThrownBy(() -> this.services.autoLogin(request, response))
+				.isInstanceOf(InternalAuthenticationServiceException.class);
+	}
+
+	@Test
+	@DisplayName("should create authentication for valid cookie")
+	public void autoLoginWithValidTokenAndUserSucceeds() {
+		doReturn(user).when(userDetailsService).loadUserByUsername(anyString());
+
+		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, user.getUsername()));
+
+		assertThat(services.autoLogin(request, response))
+				.isNotNull()
+				.returns(user, Authentication::getPrincipal)
+				.returns(user.getUsername(), Authentication::getName)
+				.returns(AuthorityUtils.createAuthorityList("test-authority"), Authentication::getAuthorities);
+	}
+
+	@Test
+	@DisplayName("should clear cookie when authentication fails")
+	public void loginFailClearsCookie() {
+		assertThatNoException().isThrownBy(() -> services.loginFail(request, response));
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should create cookie even without remember-me parameter set")
+	public void loginSuccessWhenParameterNotSetOrFalse() {
+		request.addParameter(AccountRememberMeServices.DEFAULT_PARAMETER, "false");
+
+		services.loginSuccess(request, response, createAuthentication(user));
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(AccountRememberMeServices.TOKEN_VALIDITY, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should create cookie with remember-me parameter set")
+	public void loginSuccessSetsCookie() {
+		request.addParameter(AccountRememberMeServices.DEFAULT_PARAMETER, "on");
+
+		services.loginSuccess(request, response, createAuthentication(user));
+
+		final var cookie = response.getCookie(AccountRememberMeServices.COOKIE_NAME);
+
+		assertThat(cookie)
+				.isNotNull()
+				.returns(AccountRememberMeServices.TOKEN_VALIDITY, Cookie::getMaxAge)
+				.returns(true, Cookie::getSecure)
+				.returns("/", Cookie::getPath)
+				.returns(null, Cookie::getDomain);
+
+		assertThat(cookie.getValue())
+				.isNotBlank()
+				.isBase64();
+
+		assertThat(decode(cookie.getValue()).split(":"))
+				.hasSize(3)
+				.contains(user.getUsername(), Index.atIndex(0))
+				.satisfies(tokens -> assertThat(Long.parseLong(tokens[1]))
+						.isCloseTo(
+								System.currentTimeMillis() + AccountRememberMeServices.TOKEN_VALIDITY,
+								Offset.offset(300L) // should not take more than 300ms to generate cookie
+						)
+				)
+				.satisfies(tokens -> assertThat(tokens[2])
+						.isNotBlank()
+						.isHexadecimal()
+				);
+	}
+
+	@Test
+	@DisplayName("should not create cookie without a valid principal in authentication")
+	public void loginSuccessWithoutAuthenticationName() {
+		final var authentication = new TestingAuthenticationToken(null, "", "authority");
+		services.loginSuccess(request, response, authentication);
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNull();
+	}
+
+	@Test
+	@DisplayName("should disable setters")
+	public void testDisabledSetters() {
+		assertThatException().isThrownBy(() -> services.setAlwaysRemember(false))
+				.isInstanceOf(UnsupportedOperationException.class);
+
+		assertThatException().isThrownBy(() -> services.setCookieName("cookie name"))
+				.isInstanceOf(UnsupportedOperationException.class);
+
+		assertThatException().isThrownBy(() -> services.setUseSecureCookie(true))
+				.isInstanceOf(UnsupportedOperationException.class);
+
+		assertThatException().isThrownBy(() -> services.setParameter("parameter name"))
+				.isInstanceOf(UnsupportedOperationException.class);
+
+		assertThatException().isThrownBy(() -> services.setTokenValiditySeconds(1238564))
+				.isInstanceOf(UnsupportedOperationException.class);
+
+		assertThat(services.getKey())
+				.isEqualTo(AccountRememberMeServices.KEY);
+
+		assertThat(services.getParameter())
+				.isEqualTo(AccountRememberMeServices.DEFAULT_PARAMETER);
+	}
+
+	private static Authentication createAuthentication(UserDetails user) {
+		return new TestingAuthenticationToken(user, user.getPassword(), user.getAuthorities());
+	}
+
+	private static Cookie createCookie(long expiryTime, String username) {
+		return createCookie(expiryTime, username, AccountRememberMeServices.KEY);
+	}
+
+	private static Cookie createCookie(long expiryTime, String username, String key) {
+		try {
+			final MessageDigest digest = MessageDigest.getInstance(AccountRememberMeServices.DIGEST_ALGORITHM);
+			final char[] signature = Hex.encode(digest.digest((username + ":" + expiryTime + ":" + key).getBytes()));
+			return createCookie(encode(username + ":" + expiryTime + ":" + new String(signature)));
+		} catch (NoSuchAlgorithmException ex) {
+			throw new IllegalStateException("No SHA-256 digest algorithm is available!");
+		}
+	}
+
+	private static Cookie createCookie(String value) {
+		return new Cookie(AccountRememberMeServices.COOKIE_NAME, value);
+	}
+
+	private static String encode(String value) {
+		return Base64.getEncoder().encodeToString(value.getBytes());
+	}
+
+	private static String decode(String value) {
+		return new String(Base64.getDecoder().decode(value));
+	}
+
+}

--- a/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
@@ -1,5 +1,9 @@
 package com.konfigyr.security.rememberme;
 
+import com.konfigyr.account.Account;
+import com.konfigyr.security.AccountPrincipal;
+import com.konfigyr.security.PrincipalService;
+import com.konfigyr.test.TestAccounts;
 import jakarta.servlet.http.Cookie;
 import org.assertj.core.data.Index;
 import org.assertj.core.data.Offset;
@@ -14,14 +18,9 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.codec.Hex;
 
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
@@ -31,17 +30,11 @@ import static org.assertj.core.api.Assertions.*;
 @ExtendWith(MockitoExtension.class)
 class AccountRememberMeServicesTest {
 
-	@Mock
-	UserDetailsService userDetailsService;
+	final Account account = TestAccounts.john().build();
+	final AccountPrincipal principal = new AccountPrincipal(account);
 
-	UserDetails user = User.withUsername("user-name")
-			.password("pass")
-			.accountExpired(false)
-			.accountLocked(false)
-			.credentialsExpired(false)
-			.disabled(false)
-			.authorities("test-authority")
-			.build();
+	@Mock
+	PrincipalService service;
 
 	MockHttpServletRequest request;
 	MockHttpServletResponse response;
@@ -51,7 +44,7 @@ class AccountRememberMeServicesTest {
 	public void createTokenBasedRememberMeServices() {
 		request = new MockHttpServletRequest();
 		response = new MockHttpServletResponse();
-		services = new AccountRememberMeServices(userDetailsService);
+		services = new AccountRememberMeServices(service);
 	}
 
 	@Test
@@ -105,7 +98,7 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should return null when remember-me cookie is expired and clear it")
 	public void autoLoginReturnsNullForExpiredCookieAndClearsCookie() {
-		request.setCookies(createCookie(System.currentTimeMillis() - 1000000, user.getUsername()));
+		request.setCookies(createCookie(System.currentTimeMillis() - 1000000, principal.getUsername()));
 
 		assertThat(services.autoLogin(request, response))
 				.isNull();
@@ -118,9 +111,26 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should return null when remember-me cookie signature does not match and clear it")
 	public void autoLoginClearsCookieIfSignatureBlocksDoesNotMatchExpectedValue() {
-		doReturn(user).when(userDetailsService).loadUserByUsername(anyString());
+		doReturn(principal).when(service).lookup(anyString());
 
-		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, user.getUsername(), "WRONG_KEY"));
+		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername(), "WRONG_KEY"));
+
+		assertThat(services.autoLogin(request, response))
+				.isNull();
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should return null when remember-me signing algorithm is different")
+	public void autoLoginClearsCookieIfSignatureAlgorithmDoesNotMatch() {
+		doReturn(principal).when(service).lookup(anyString());
+
+		request.setCookies(createCookie(
+				System.currentTimeMillis() + 1000000, principal.getUsername(), AccountRememberMeServices.KEY, "MD5"
+		));
 
 		assertThat(services.autoLogin(request, response))
 				.isNull();
@@ -146,7 +156,7 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should return null when user account is not found and clear it")
 	public void autoLoginClearsCookieIfUserNotFound() {
-		doThrow(UsernameNotFoundException.class).when(userDetailsService).loadUserByUsername(anyString());
+		doThrow(UsernameNotFoundException.class).when(service).lookup(anyString());
 
 		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, "not-found"));
 
@@ -161,26 +171,26 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should throw internal service error when user service returns null")
 	public void autoLoginClearsCookieIfUserServiceMisconfigured() {
-		doReturn(null).when(userDetailsService).loadUserByUsername(anyString());
+		doReturn(null).when(service).lookup(anyString());
 
-		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, user.getUsername()));
+		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername()));
 
-		assertThatException().isThrownBy(() -> this.services.autoLogin(request, response))
+		assertThatThrownBy(() -> this.services.autoLogin(request, response))
 				.isInstanceOf(InternalAuthenticationServiceException.class);
 	}
 
 	@Test
 	@DisplayName("should create authentication for valid cookie")
 	public void autoLoginWithValidTokenAndUserSucceeds() {
-		doReturn(user).when(userDetailsService).loadUserByUsername(anyString());
+		doReturn(principal).when(service).lookup(anyString());
 
-		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, user.getUsername()));
+		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername()));
 
 		assertThat(services.autoLogin(request, response))
 				.isNotNull()
-				.returns(user, Authentication::getPrincipal)
-				.returns(user.getUsername(), Authentication::getName)
-				.returns(AuthorityUtils.createAuthorityList("test-authority"), Authentication::getAuthorities);
+				.returns(principal, Authentication::getPrincipal)
+				.returns(principal.getUsername(), Authentication::getName)
+				.returns(principal.getAuthorities(), Authentication::getAuthorities);
 	}
 
 	@Test
@@ -198,7 +208,7 @@ class AccountRememberMeServicesTest {
 	public void loginSuccessWhenParameterNotSetOrFalse() {
 		request.addParameter(AccountRememberMeServices.DEFAULT_PARAMETER, "false");
 
-		services.loginSuccess(request, response, createAuthentication(user));
+		services.loginSuccess(request, response, createAuthentication(principal));
 
 		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
 				.isNotNull()
@@ -210,7 +220,7 @@ class AccountRememberMeServicesTest {
 	public void loginSuccessSetsCookie() {
 		request.addParameter(AccountRememberMeServices.DEFAULT_PARAMETER, "on");
 
-		services.loginSuccess(request, response, createAuthentication(user));
+		services.loginSuccess(request, response, createAuthentication(principal));
 
 		final var cookie = response.getCookie(AccountRememberMeServices.COOKIE_NAME);
 
@@ -227,7 +237,7 @@ class AccountRememberMeServicesTest {
 
 		assertThat(decode(cookie.getValue()).split(":"))
 				.hasSize(3)
-				.contains(user.getUsername(), Index.atIndex(0))
+				.contains(principal.getUsername(), Index.atIndex(0))
 				.satisfies(tokens -> assertThat(Long.parseLong(tokens[1]))
 						.isCloseTo(
 								System.currentTimeMillis() + AccountRememberMeServices.TOKEN_VALIDITY,
@@ -251,21 +261,29 @@ class AccountRememberMeServicesTest {
 	}
 
 	@Test
+	@DisplayName("should catch unknown signing algorithm exceptions")
+	public void shouldCatchUnknownAlgorithmExceptions() {
+		assertThatThrownBy(() -> AccountRememberMeServices.generateSignature("test", 1, "key", "unknown-algo"))
+				.isInstanceOf(IllegalStateException.class)
+				.hasRootCauseInstanceOf(NoSuchAlgorithmException.class);
+	}
+
+	@Test
 	@DisplayName("should disable setters")
 	public void testDisabledSetters() {
-		assertThatException().isThrownBy(() -> services.setAlwaysRemember(false))
+		assertThatThrownBy(() -> services.setAlwaysRemember(false))
 				.isInstanceOf(UnsupportedOperationException.class);
 
-		assertThatException().isThrownBy(() -> services.setCookieName("cookie name"))
+		assertThatThrownBy(() -> services.setCookieName("cookie name"))
 				.isInstanceOf(UnsupportedOperationException.class);
 
-		assertThatException().isThrownBy(() -> services.setUseSecureCookie(true))
+		assertThatThrownBy(() -> services.setUseSecureCookie(true))
 				.isInstanceOf(UnsupportedOperationException.class);
 
-		assertThatException().isThrownBy(() -> services.setParameter("parameter name"))
+		assertThatThrownBy(() -> services.setParameter("parameter name"))
 				.isInstanceOf(UnsupportedOperationException.class);
 
-		assertThatException().isThrownBy(() -> services.setTokenValiditySeconds(1238564))
+		assertThatThrownBy(() -> services.setTokenValiditySeconds(1238564))
 				.isInstanceOf(UnsupportedOperationException.class);
 
 		assertThat(services.getKey())
@@ -284,13 +302,12 @@ class AccountRememberMeServicesTest {
 	}
 
 	private static Cookie createCookie(long expiryTime, String username, String key) {
-		try {
-			final MessageDigest digest = MessageDigest.getInstance(AccountRememberMeServices.DIGEST_ALGORITHM);
-			final char[] signature = Hex.encode(digest.digest((username + ":" + expiryTime + ":" + key).getBytes()));
-			return createCookie(encode(username + ":" + expiryTime + ":" + new String(signature)));
-		} catch (NoSuchAlgorithmException ex) {
-			throw new IllegalStateException("No SHA-256 digest algorithm is available!");
-		}
+		return createCookie(expiryTime, username, key, AccountRememberMeServices.DIGEST_ALGORITHM);
+	}
+
+	private static Cookie createCookie(long expiryTime, String username, String key, String algorithm) {
+		final String signature = AccountRememberMeServices.generateSignature(username, expiryTime, key, algorithm);
+		return createCookie(encode(username + ":" + expiryTime + ":" + signature));
 	}
 
 	private static Cookie createCookie(String value) {

--- a/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
@@ -41,7 +41,7 @@ class AccountRememberMeServicesTest {
 	AccountRememberMeServices services;
 
 	@BeforeEach
-	public void createTokenBasedRememberMeServices() {
+	void createTokenBasedRememberMeServices() {
 		request = new MockHttpServletRequest();
 		response = new MockHttpServletResponse();
 		services = new AccountRememberMeServices(service);
@@ -49,7 +49,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when cookies are present in the request")
-	public void autoLoginReturnsNullIfNoCookiePresented() {
+	void autoLoginReturnsNullIfNoCookiePresented() {
 		assertThat(services.autoLogin(request, response))
 				.isNull();
 
@@ -59,7 +59,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when remember-me cookie is not present")
-	public void autoLoginIgnoresUnrelatedCookie() {
+	void autoLoginIgnoresUnrelatedCookie() {
 		request.setCookies(new Cookie("some", "cookie"));
 
 		assertThat(services.autoLogin(request, response))
@@ -71,7 +71,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when remember-me cookie is invalid and clear it")
-	public void autoLoginReturnsNullAndClearsCookieIfMissingThreeTokensInCookieValue() {
+	void autoLoginReturnsNullAndClearsCookieIfMissingThreeTokensInCookieValue() {
 		request.setCookies(createCookie(encode("x")));
 
 		assertThat(services.autoLogin(request, response))
@@ -84,7 +84,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when remember-me cookie is not Base64 encoded and clear it")
-	public void autoLoginClearsNonBase64EncodedCookie() {
+	void autoLoginClearsNonBase64EncodedCookie() {
 		request.setCookies(createCookie("non-encoded-value"));
 
 		assertThat(services.autoLogin(request, response))
@@ -97,7 +97,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when remember-me cookie is expired and clear it")
-	public void autoLoginReturnsNullForExpiredCookieAndClearsCookie() {
+	void autoLoginReturnsNullForExpiredCookieAndClearsCookie() {
 		request.setCookies(createCookie(System.currentTimeMillis() - 1000000, principal.getUsername()));
 
 		assertThat(services.autoLogin(request, response))
@@ -110,7 +110,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when remember-me cookie signature does not match and clear it")
-	public void autoLoginClearsCookieIfSignatureBlocksDoesNotMatchExpectedValue() {
+	void autoLoginClearsCookieIfSignatureBlocksDoesNotMatchExpectedValue() {
 		doReturn(principal).when(service).lookup(anyString());
 
 		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername(), "WRONG_KEY"));
@@ -125,7 +125,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when remember-me signing algorithm is different")
-	public void autoLoginClearsCookieIfSignatureAlgorithmDoesNotMatch() {
+	void autoLoginClearsCookieIfSignatureAlgorithmDoesNotMatch() {
 		doReturn(principal).when(service).lookup(anyString());
 
 		request.setCookies(createCookie(
@@ -142,7 +142,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when remember-me cookie expiry time is invalid and clear it")
-	public void autoLoginClearsCookieIfTokenDoesNotContainANumberInCookieValue() {
+	void autoLoginClearsCookieIfTokenDoesNotContainANumberInCookieValue() {
 		request.setCookies(createCookie(encode("username:NOT_A_NUMBER:signature")));
 
 		assertThat(services.autoLogin(request, response))
@@ -155,7 +155,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should return null when user account is not found and clear it")
-	public void autoLoginClearsCookieIfUserNotFound() {
+	void autoLoginClearsCookieIfUserNotFound() {
 		doThrow(UsernameNotFoundException.class).when(service).lookup(anyString());
 
 		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, "not-found"));
@@ -170,7 +170,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should throw internal service error when user service returns null")
-	public void autoLoginClearsCookieIfUserServiceMisconfigured() {
+	void autoLoginClearsCookieIfUserServiceMisconfigured() {
 		doReturn(null).when(service).lookup(anyString());
 
 		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername()));
@@ -181,7 +181,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should create authentication for valid cookie")
-	public void autoLoginWithValidTokenAndUserSucceeds() {
+	void autoLoginWithValidTokenAndUserSucceeds() {
 		doReturn(principal).when(service).lookup(anyString());
 
 		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername()));
@@ -195,7 +195,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should clear cookie when authentication fails")
-	public void loginFailClearsCookie() {
+	void loginFailClearsCookie() {
 		assertThatNoException().isThrownBy(() -> services.loginFail(request, response));
 
 		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
@@ -205,7 +205,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should create cookie even without remember-me parameter set")
-	public void loginSuccessWhenParameterNotSetOrFalse() {
+	void loginSuccessWhenParameterNotSetOrFalse() {
 		request.addParameter(AccountRememberMeServices.DEFAULT_PARAMETER, "false");
 
 		services.loginSuccess(request, response, createAuthentication(principal));
@@ -217,7 +217,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should create cookie with remember-me parameter set")
-	public void loginSuccessSetsCookie() {
+	void loginSuccessSetsCookie() {
 		request.addParameter(AccountRememberMeServices.DEFAULT_PARAMETER, "on");
 
 		services.loginSuccess(request, response, createAuthentication(principal));
@@ -252,7 +252,7 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should not create cookie without a valid principal in authentication")
-	public void loginSuccessWithoutAuthenticationName() {
+	void loginSuccessWithoutAuthenticationName() {
 		final var authentication = new TestingAuthenticationToken(null, "", "authority");
 		services.loginSuccess(request, response, authentication);
 
@@ -262,29 +262,39 @@ class AccountRememberMeServicesTest {
 
 	@Test
 	@DisplayName("should catch unknown signing algorithm exceptions")
-	public void shouldCatchUnknownAlgorithmExceptions() {
+	void shouldCatchUnknownAlgorithmExceptions() {
 		assertThatThrownBy(() -> AccountRememberMeServices.generateSignature("test", 1, "key", "unknown-algo"))
 				.isInstanceOf(IllegalStateException.class)
 				.hasRootCauseInstanceOf(NoSuchAlgorithmException.class);
 	}
 
 	@Test
-	@DisplayName("should disable setters")
-	public void testDisabledSetters() {
+	@DisplayName("should disable setters modifying the service behaviour")
+	void testDisabledSetters() {
 		assertThatThrownBy(() -> services.setAlwaysRemember(false))
-				.isInstanceOf(UnsupportedOperationException.class);
+				.isInstanceOf(UnsupportedOperationException.class)
+				.hasMessageContaining("It is not possible to set 'alwaysRemember' field")
+				.hasNoCause();
 
 		assertThatThrownBy(() -> services.setCookieName("cookie name"))
-				.isInstanceOf(UnsupportedOperationException.class);
+				.isInstanceOf(UnsupportedOperationException.class)
+				.hasMessageContaining("It is not possible to set 'cookieName' field")
+				.hasNoCause();
 
 		assertThatThrownBy(() -> services.setUseSecureCookie(true))
-				.isInstanceOf(UnsupportedOperationException.class);
+				.isInstanceOf(UnsupportedOperationException.class)
+				.hasMessageContaining("It is not possible to set 'useSecureCookie' field")
+				.hasNoCause();
 
 		assertThatThrownBy(() -> services.setParameter("parameter name"))
-				.isInstanceOf(UnsupportedOperationException.class);
+				.isInstanceOf(UnsupportedOperationException.class)
+				.hasMessageContaining("It is not possible to set 'parameter' field")
+				.hasNoCause();
 
 		assertThatThrownBy(() -> services.setTokenValiditySeconds(1238564))
-				.isInstanceOf(UnsupportedOperationException.class);
+				.isInstanceOf(UnsupportedOperationException.class)
+				.hasMessageContaining("It is not possible to set 'tokenValiditySeconds' field")
+				.hasNoCause();
 
 		assertThat(services.getKey())
 				.isEqualTo(AccountRememberMeServices.KEY);

--- a/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
@@ -20,6 +20,7 @@ import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.rememberme.AbstractRememberMeServices;
 
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
@@ -206,7 +207,7 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should create cookie even without remember-me parameter set")
 	void loginSuccessWhenParameterNotSetOrFalse() {
-		request.addParameter(AccountRememberMeServices.DEFAULT_PARAMETER, "false");
+		request.addParameter(AbstractRememberMeServices.DEFAULT_PARAMETER, "false");
 
 		services.loginSuccess(request, response, createAuthentication(principal));
 
@@ -218,7 +219,7 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should create cookie with remember-me parameter set")
 	void loginSuccessSetsCookie() {
-		request.addParameter(AccountRememberMeServices.DEFAULT_PARAMETER, "on");
+		request.addParameter(AbstractRememberMeServices.DEFAULT_PARAMETER, "on");
 
 		services.loginSuccess(request, response, createAuthentication(principal));
 
@@ -266,41 +267,6 @@ class AccountRememberMeServicesTest {
 		assertThatThrownBy(() -> AccountRememberMeServices.generateSignature("test", 1, "key", "unknown-algo"))
 				.isInstanceOf(IllegalStateException.class)
 				.hasRootCauseInstanceOf(NoSuchAlgorithmException.class);
-	}
-
-	@Test
-	@DisplayName("should disable setters modifying the service behaviour")
-	void testDisabledSetters() {
-		assertThatThrownBy(() -> services.setAlwaysRemember(false))
-				.isInstanceOf(UnsupportedOperationException.class)
-				.hasMessageContaining("It is not possible to set 'alwaysRemember' field")
-				.hasNoCause();
-
-		assertThatThrownBy(() -> services.setCookieName("cookie name"))
-				.isInstanceOf(UnsupportedOperationException.class)
-				.hasMessageContaining("It is not possible to set 'cookieName' field")
-				.hasNoCause();
-
-		assertThatThrownBy(() -> services.setUseSecureCookie(true))
-				.isInstanceOf(UnsupportedOperationException.class)
-				.hasMessageContaining("It is not possible to set 'useSecureCookie' field")
-				.hasNoCause();
-
-		assertThatThrownBy(() -> services.setParameter("parameter name"))
-				.isInstanceOf(UnsupportedOperationException.class)
-				.hasMessageContaining("It is not possible to set 'parameter' field")
-				.hasNoCause();
-
-		assertThatThrownBy(() -> services.setTokenValiditySeconds(1238564))
-				.isInstanceOf(UnsupportedOperationException.class)
-				.hasMessageContaining("It is not possible to set 'tokenValiditySeconds' field")
-				.hasNoCause();
-
-		assertThat(services.getKey())
-				.isEqualTo(AccountRememberMeServices.KEY);
-
-		assertThat(services.getParameter())
-				.isEqualTo(AccountRememberMeServices.DEFAULT_PARAMETER);
 	}
 
 	private static Authentication createAuthentication(UserDetails user) {

--- a/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
+++ b/konfigyr-security/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
@@ -262,6 +262,34 @@ class AccountRememberMeServicesTest {
 	}
 
 	@Test
+	@DisplayName("should remove cookie on successful logout")
+	void logoutShouldClearRememberMeCookies() {
+		request.setCookies(createCookie(System.currentTimeMillis() + 2000, principal.getUsername()));
+
+		services.logout(request, response, createAuthentication(principal));
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+	}
+
+	@Test
+	@DisplayName("should only remove the remember-me cookie")
+	void logoutShouldNotClearOtherCookies() {
+		response.addCookie(new Cookie("other-cookie", "x"));
+
+		services.logout(request, response, createAuthentication(principal));
+
+		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
+				.isNotNull()
+				.returns(0, Cookie::getMaxAge);
+
+		assertThat(response.getCookie("other-cookie"))
+				.isNotNull()
+				.returns(-1, Cookie::getMaxAge);
+	}
+
+	@Test
 	@DisplayName("should catch unknown signing algorithm exceptions")
 	void shouldCatchUnknownAlgorithmExceptions() {
 		assertThatThrownBy(() -> AccountRememberMeServices.generateSignature("test", 1, "key", "unknown-algo"))

--- a/konfigyr-security/src/test/resources/application.yml
+++ b/konfigyr-security/src/test/resources/application.yml
@@ -31,4 +31,5 @@ konfigyr:
 logging:
   level:
     com.konfigyr: DEBUG
+    org.jooq: DEBUG
     org.springframework.security: DEBUG

--- a/konfigyr-server/src/main/java/com/konfigyr/security/SecurityController.java
+++ b/konfigyr-server/src/main/java/com/konfigyr/security/SecurityController.java
@@ -1,5 +1,5 @@
 
-package com.konfigyr.controller;
+package com.konfigyr.security;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties;
@@ -27,14 +27,13 @@ import java.util.stream.Collectors;
  **/
 @Controller
 @RequiredArgsConstructor
-public class AuthenticationController {
+public class SecurityController {
 
 	private static final UriComponents REQUEST_PATTERN = UriComponentsBuilder
 		.fromPath(DefaultServerOAuth2AuthorizationRequestResolver.DEFAULT_AUTHORIZATION_REQUEST_PATTERN)
 		.build();
 
 	private final OAuth2ClientProperties properties;
-
 	private final ClientRegistrationRepository repository;
 
 	@GetMapping("/login")
@@ -52,6 +51,13 @@ public class AuthenticationController {
 		return "login";
 	}
 
+	/**
+	 * Record used by the template to render the authentication option based on the {@link ClientRegistration}.
+	 *
+	 * @param id unique option identifier, usually the {@link ClientRegistration#getRegistrationId()}
+	 * @param name display name of the option, usually the {@link ClientRegistration#getClientName()}
+	 * @param url location where the authentication would start
+	 */
 	record AuthenticationOption(String id, String name, URI url) {
 
 		static AuthenticationOption from(ClientRegistration registration) {

--- a/konfigyr-server/src/main/java/com/konfigyr/security/WebSecurityConfiguration.java
+++ b/konfigyr-server/src/main/java/com/konfigyr/security/WebSecurityConfiguration.java
@@ -1,5 +1,6 @@
 package com.konfigyr.security;
 
+import com.konfigyr.security.rememberme.AccountRememberMeServices;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.Customizer;
@@ -22,7 +23,7 @@ import org.springframework.security.web.util.matcher.AnyRequestMatcher;
 public class WebSecurityConfiguration {
 
 	@Bean
-	SecurityFilterChain konfigyrSecurityFilterChain(HttpSecurity http) throws Exception {
+	SecurityFilterChain konfigyrSecurityFilterChain(HttpSecurity http, PrincipalService detailsService) throws Exception {
 		return http
 				.authorizeHttpRequests(requests -> requests
 						.requestMatchers(
@@ -40,12 +41,16 @@ public class WebSecurityConfiguration {
 				.oauth2Login(oauth -> oauth
 						.loginPage(SecurityRequestMatchers.LOGIN_PAGE)
 				)
+				.rememberMe(remember -> remember
+						.rememberMeServices(new AccountRememberMeServices(detailsService))
+				)
 				.logout(Customizer.withDefaults())
 				.httpBasic(AbstractHttpConfigurer::disable)
 				.formLogin(AbstractHttpConfigurer::disable)
 				.anonymous(AbstractHttpConfigurer::disable)
 				.exceptionHandling(exceptions -> exceptions
-						.defaultAuthenticationEntryPointFor(loginAuthenticationEntryPoint(), AnyRequestMatcher.INSTANCE))
+						.defaultAuthenticationEntryPointFor(loginAuthenticationEntryPoint(), AnyRequestMatcher.INSTANCE)
+				)
 				.build();
 	}
 

--- a/konfigyr-server/src/main/resources/application.yml
+++ b/konfigyr-server/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     basename: messages/konfigyr, messages/validation
 
   cache:
-    cache-names: crypto-keysets
+    cache-names: crypto-keysets, user-cache
     caffeine:
       spec: expireAfterWrite=1h
 

--- a/konfigyr-test/src/main/resources/logback-test.xml
+++ b/konfigyr-test/src/main/resources/logback-test.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <!-- Import Spring's default Logback configuration -->
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <!-- Define the Console Appender log message pattern  -->
+    <property name="CONSOLE_LOG_PATTERN" value="%clr(%d{HH:mm:ss.SSS}){faint} %clr([%-20thread]) %clr(%-5level) [%mdc] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %marker %m%n"/>
+
+    <!-- Import Spring's Console Logback appender configurations -->
+    <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+
+    <!-- Use the shutdown hook so that we can close gracefully and finish the log drain -->
+    <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook"/>
+
+    <logger name="com.konfigyr" level="DEBUG" />
+
+    <!-- Define the root logger appender to use console and logtail appender -->
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,4 @@
+config.stopBubbling = true
+lombok.anyConstructor.addConstructorProperties = true
+lombok.addLombokGeneratedAnnotation = true
+lombok.addNullAnnotations = spring


### PR DESCRIPTION
Introduced the `AccountPrincipal` that should be used to create Spring `Authentications` when performing authentication on behalf of the user account.

The `PrincipalService` should be used to retrieve the `AccountPrincipal` and to register new accounts when using OAuth2 login flow. This caused a smaller refactor to the OAuth user service.

Configured the `rememberme` Spring Security filter to use a custom implementation of the `RememberMeServices` that is based on a Base-64 encoded token cookie. The `AccountRememberMeServices` differs from `TokenBasedRememberMeServices` in following:
 * it should always be applied
 * it omits the password token from the cookie
 * only supports `SHA-256` hashing algorithm

Added missing `refresh_token_expires_at` column to the `account_access_tokens` table.