### PR TITLE
Security improvements and membership events

### DIFF
--- a/konfigyr/src/main/java/com/konfigyr/KonfigyrApplication.java
+++ b/konfigyr/src/main/java/com/konfigyr/KonfigyrApplication.java
@@ -4,7 +4,9 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.modulith.Modulith;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 /**
  * Konfigyr Spring server application main class.
@@ -12,9 +14,11 @@ import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHtt
  * @author Vladimir Spasic
  * @since 1.0.0
  **/
+@EnableAsync
 @EnableCaching
 @EnableJdbcHttpSession
 @SpringBootApplication
+@EnableTransactionManagement
 @Modulith(systemName = "Konfigyr")
 public class KonfigyrApplication {
 

--- a/konfigyr/src/main/java/com/konfigyr/jooq/JooqCustomizerConfiguration.java
+++ b/konfigyr/src/main/java/com/konfigyr/jooq/JooqCustomizerConfiguration.java
@@ -1,0 +1,32 @@
+package com.konfigyr.jooq;
+
+import org.jooq.ConverterProvider;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.jooq.DefaultConfigurationCustomizer;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConversionService;
+
+@Configuration(proxyBeanMethods = false)
+class JooqCustomizerConfiguration {
+
+	/**
+	 * Registers the {@link DefaultConfigurationCustomizer} that would register a customer jOOQ
+	 * {@link ConverterProvider} that would use the {@link ConversionService} to provide additional
+	 * {@link org.jooq.Converter conveters}.
+	 *
+	 * @param conversionService Spring conversion service
+	 * @return configuration customizer
+	 */
+	@Bean
+	DefaultConfigurationCustomizer conversionServiceConverterConfigurationCustomizer(
+			final ObjectProvider<ConversionService> conversionService
+	) {
+		final ConverterProvider converterProvider = new SpringConverterProvider(
+				() -> conversionService.getIfAvailable(ApplicationConversionService::getSharedInstance)
+		);
+
+		return configuration -> configuration.set(converterProvider);
+	}
+}

--- a/konfigyr/src/main/java/com/konfigyr/jooq/SpringConverterProvider.java
+++ b/konfigyr/src/main/java/com/konfigyr/jooq/SpringConverterProvider.java
@@ -1,0 +1,48 @@
+package com.konfigyr.jooq;
+
+import lombok.RequiredArgsConstructor;
+import org.jooq.Converter;
+import org.jooq.ConverterProvider;
+import org.jooq.impl.DefaultConverterProvider;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.lang.Nullable;
+
+import java.util.function.Supplier;
+
+@RequiredArgsConstructor
+final class SpringConverterProvider implements ConverterProvider {
+
+	private final ConverterProvider delegate = new DefaultConverterProvider();
+	private final Supplier<ConversionService> conversionService;
+
+	@Nullable
+	@Override
+	public <T, U> Converter<T, U> provide(Class<T> tType, Class<U> uType) {
+		Converter<T, U> converter = delegate.provide(tType, uType);
+
+		if (converter == null) {
+			converter = provide(conversionService.get(), tType, uType);
+		}
+
+		return converter;
+	}
+
+	@Nullable
+	private static <T, U> Converter<T, U> provide(ConversionService converter, Class<T> tType, Class<U> uType) {
+		if (converter.canConvert(tType, uType)) {
+			if (converter.canConvert(uType, tType)) {
+				return Converter.of(
+						tType,
+						uType,
+						t -> converter.convert(t, uType),
+						u -> converter.convert(u, tType)
+				);
+			} else {
+				return Converter.from(tType, uType, t -> converter.convert(t, uType));
+			}
+		}
+
+		return null;
+	}
+
+}

--- a/konfigyr/src/main/java/com/konfigyr/namespace/DefaultInvitations.java
+++ b/konfigyr/src/main/java/com/konfigyr/namespace/DefaultInvitations.java
@@ -184,6 +184,10 @@ class DefaultInvitations implements Invitations {
 				.execute();
 
 		publisher.publishEvent(new InvitationEvent.Accepted(invitation.namespace(), invitation.key()));
+
+		publisher.publishEvent(new NamespaceEvent.MemberAdded(
+				invitation.namespace(), EntityId.from(recipient.get()), invitation.role()
+		));
 	}
 
 	/**

--- a/konfigyr/src/main/java/com/konfigyr/namespace/DefaultNamespaceManager.java
+++ b/konfigyr/src/main/java/com/konfigyr/namespace/DefaultNamespaceManager.java
@@ -164,6 +164,7 @@ class DefaultNamespaceManager implements NamespaceManager {
 
 	@NonNull
 	@Override
+	@Transactional(label = "namespace-update-member")
 	public Member updateMember(@NonNull EntityId id, @NonNull NamespaceRole role) {
 		context.update(NAMESPACE_MEMBERS)
 				.set(NAMESPACE_MEMBERS.ROLE, role.name())
@@ -176,6 +177,10 @@ class DefaultNamespaceManager implements NamespaceManager {
 
 		log.info("Successfully updated member role: [id={}, namespace={}, account={}, role={}]",
 				member.id(), member.namespace(), member.account(), member.role());
+
+		publisher.publishEvent(new NamespaceEvent.MemberUpdated(
+				member.namespace(), member.account(), member.role()
+		));
 
 		return member;
 	}
@@ -191,6 +196,11 @@ class DefaultNamespaceManager implements NamespaceManager {
 		if (result != null) {
 			log.info("Successfully removed member: [id={}, namespace={}, account={}]",
 					member.get(), result.get(NAMESPACE_MEMBERS.NAMESPACE_ID), result.get(NAMESPACE_MEMBERS.ACCOUNT_ID));
+
+			publisher.publishEvent(new NamespaceEvent.MemberRemoved(
+					result.get(NAMESPACE_MEMBERS.NAMESPACE_ID, EntityId.class),
+					result.get(NAMESPACE_MEMBERS.ACCOUNT_ID, EntityId.class)
+			));
 		}
 	}
 

--- a/konfigyr/src/main/java/com/konfigyr/namespace/NamespaceEvent.java
+++ b/konfigyr/src/main/java/com/konfigyr/namespace/NamespaceEvent.java
@@ -5,6 +5,7 @@ import com.konfigyr.entity.EntityId;
 import com.konfigyr.support.Slug;
 import org.jmolecules.event.annotation.DomainEvent;
 import org.springframework.lang.NonNull;
+import org.springframework.util.Assert;
 
 /**
  * Abstract event type that should be used for all {@link Namespace} related events.
@@ -13,7 +14,7 @@ import org.springframework.lang.NonNull;
  * @since 1.0.0
  **/
 public abstract sealed class NamespaceEvent extends EntityEvent
-		permits NamespaceEvent.Created, NamespaceEvent.Renamed, NamespaceEvent.Deleted {
+		permits NamespaceEvent.Created, NamespaceEvent.Renamed, NamespaceEvent.Deleted, NamespaceEvent.MembershipEvent {
 
 	protected NamespaceEvent(EntityId id) {
 		super(id);
@@ -81,7 +82,7 @@ public abstract sealed class NamespaceEvent extends EntityEvent
 	}
 
 	/**
-	 * Event that would be published when a new {@link Namespace} is deleted.
+	 * Event that would be published when an existing {@link Namespace} is deleted.
 	 */
 	@DomainEvent(name = "deleted", namespace = "namespaces")
 	public static final class Deleted extends NamespaceEvent {
@@ -94,6 +95,116 @@ public abstract sealed class NamespaceEvent extends EntityEvent
 		 */
 		public Deleted(EntityId id) {
 			super(id);
+		}
+	}
+
+	/**
+	 * Abstract event that would be used for all {@link Member} related changes of a {@link Namespace}.
+	 */
+	public static abstract sealed class MembershipEvent extends NamespaceEvent
+			permits NamespaceEvent.MemberAdded, NamespaceEvent.MemberUpdated, NamespaceEvent.MemberRemoved {
+
+		private final EntityId account;
+
+		protected MembershipEvent(EntityId id, EntityId account) {
+			super(id);
+
+			Assert.notNull(account, "Entity identifier of the member user account can not be null");
+			this.account = account;
+		}
+
+		/**
+		 * The entity identifier of the {@link com.konfigyr.account.Account} that was the subject of
+		 * the change within the given {@link Namespace}.
+		 *
+		 * @return account entity identifier, never {@literal null}
+		 */
+		@NonNull
+		public EntityId account() {
+			return account;
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + "[id=" + id + ", account=" + account + ", timestamp=" + timestamp + ']';
+		}
+	}
+
+	/**
+	 * Event that would be published when a new {@link Member} is added to the {@link Namespace}.
+	 */
+	@DomainEvent(name = "member-added", namespace = "namespaces")
+	public static final class MemberAdded extends MembershipEvent {
+
+		private final NamespaceRole role;
+
+		/**
+		 * Create a new {@link MemberAdded} event with the {@link EntityId entity identifier} of the
+		 * {@link Namespace}, {@link com.konfigyr.account.Account} that was added as a new {@link Member}
+		 * and the {@link NamespaceRole} that was assigned to it.
+		 *
+		 * @param id entity identifier of the namespace
+		 * @param account entity identifier of the user account that was added as a member
+		 * @param role namespace role assigned to the new member
+		 */
+		public MemberAdded(EntityId id, EntityId account, NamespaceRole role) {
+			super(id, account);
+
+			Assert.notNull(role, "Namespace role assigned to the member can not be null");
+			this.role = role;
+		}
+
+		@NonNull
+		public NamespaceRole role() {
+			return role;
+		}
+	}
+
+	/**
+	 * Event that would be published when an existing {@link Member} was updated within the {@link Namespace}.
+	 */
+	@DomainEvent(name = "member-updated", namespace = "namespaces")
+	public static final class MemberUpdated extends MembershipEvent {
+
+		private final NamespaceRole role;
+
+		/**
+		 * Create an {@link MemberUpdated} event with the {@link EntityId entity identifier} of the
+		 * {@link Namespace}, {@link com.konfigyr.account.Account} for which the membership was updated
+		 * and the {@link NamespaceRole} that was changed.
+		 *
+		 * @param id entity identifier of the namespace
+		 * @param account entity identifier of the user account for which the membership was updated
+		 * @param role namespace role changed for the member
+		 */
+		public MemberUpdated(EntityId id, EntityId account, NamespaceRole role) {
+			super(id, account);
+
+			Assert.notNull(role, "Namespace role that was updated for the member can not be null");
+			this.role = role;
+		}
+
+		@NonNull
+		public NamespaceRole role() {
+			return role;
+		}
+	}
+
+	/**
+	 * Event that would be published when an existing {@link Member} was removed from the {@link Namespace}.
+	 */
+	@DomainEvent(name = "member-removed", namespace = "namespaces")
+	public static final class MemberRemoved extends MembershipEvent {
+
+		/**
+		 * Create an {@link MemberRemoved} event with the {@link EntityId entity identifier} of the
+		 * {@link Namespace} and the {@link com.konfigyr.account.Account} that was removed from the namespace.
+		 *
+		 * @param id entity identifier of the namespace
+		 * @param account entity identifier of the user account that was removed as a namespace member
+		 */
+		public MemberRemoved(EntityId id, EntityId account) {
+			super(id, account);
 		}
 	}
 

--- a/konfigyr/src/main/java/com/konfigyr/security/SecurityAutoConfiguration.java
+++ b/konfigyr/src/main/java/com/konfigyr/security/SecurityAutoConfiguration.java
@@ -2,6 +2,7 @@ package com.konfigyr.security;
 
 import com.konfigyr.account.AccountManager;
 import com.konfigyr.crypto.KeysetOperationsFactory;
+import com.konfigyr.namespace.NamespaceManager;
 import com.konfigyr.security.access.KonfigyrMethodSecurityExpressionHandler;
 import com.konfigyr.security.access.KonfigyrWebSecurityExpressionHandler;
 import com.konfigyr.security.oauth.AuthorizedClientService;
@@ -52,9 +53,13 @@ public class SecurityAutoConfiguration {
 	}
 
 	@Bean
-	PrincipalService accountPrincipalService(AccountManager accountManager, ObjectProvider<UserCache> cacheProvider) {
+	PrincipalService accountPrincipalService(
+			AccountManager accountManager,
+			NamespaceManager namespaceManager,
+			ObjectProvider<UserCache> cacheProvider
+	) {
 		final UserCache userCache = cacheProvider.getIfAvailable(NullUserCache::new);
-		return new AccountPrincipalService(accountManager, userCache);
+		return new AccountPrincipalService(accountManager, namespaceManager, userCache);
 	}
 
 	@Bean

--- a/konfigyr/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
+++ b/konfigyr/src/main/java/com/konfigyr/security/rememberme/AccountRememberMeServices.java
@@ -74,7 +74,6 @@ public class AccountRememberMeServices implements RememberMeServices, LogoutHand
 		this.delegate = new InternalRememberMeServices(KEY, service::lookup);
 		delegate.setTokenValiditySeconds((int) TOKEN_VALIDITY.toSeconds());
 		delegate.setCookieName(COOKIE_NAME);
-		delegate.setUseSecureCookie(true);
 		delegate.setAlwaysRemember(true);
 		delegate.afterPropertiesSet();
 	}

--- a/konfigyr/src/main/resources/application.yml
+++ b/konfigyr/src/main/resources/application.yml
@@ -24,6 +24,13 @@ spring:
   mvc:
     static-path-pattern: /assets/**
 
+  security:
+    oauth2:
+      client:
+        provider:
+          github:
+            user-name-attribute: email
+
   web:
     resources:
       static-locations:

--- a/konfigyr/src/test/java/com/konfigyr/KonfigyrServerModulesTest.java
+++ b/konfigyr/src/test/java/com/konfigyr/KonfigyrServerModulesTest.java
@@ -1,10 +1,8 @@
 package com.konfigyr;
 
-import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.JavaClass;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.lang.NonNull;
 import org.springframework.modulith.core.ApplicationModules;
 import org.springframework.modulith.docs.Documenter;
 
@@ -12,13 +10,13 @@ class KonfigyrServerModulesTest {
 
 	private final ApplicationModules modules = ApplicationModules.of(
 			KonfigyrApplication.class,
-			DescribedPredicate.or(
-					ignore("com.konfigyr.data"),
-					ignore("com.konfigyr.jooq"),
-					ignore("com.konfigyr.io"),
-					ignore("com.konfigyr.security"),
-					ignore("com.konfigyr.support"),
-					ignore("com.konfigyr.web")
+			JavaClass.Predicates.resideInAnyPackage(
+					"com.konfigyr.data..",
+					"com.konfigyr.jooq..",
+					"com.konfigyr.io..",
+					"com.konfigyr.security..",
+					"com.konfigyr.support..",
+					"com.konfigyr.web.."
 			)
 	);
 
@@ -35,13 +33,6 @@ class KonfigyrServerModulesTest {
 				.writeModuleCanvases()
 				.writeModulesAsPlantUml()
 				.writeIndividualModulesAsPlantUml();
-	}
-
-	private static DescribedPredicate<JavaClass> ignore(@NonNull String name) {
-		return DescribedPredicate.describe(
-				"Ignoring '" + name + "' package",
-				type -> type.getPackage().getName().startsWith(name)
-		);
 	}
 
 }

--- a/konfigyr/src/test/java/com/konfigyr/integration/IntegrationManagerTest.java
+++ b/konfigyr/src/test/java/com/konfigyr/integration/IntegrationManagerTest.java
@@ -47,8 +47,6 @@ class IntegrationManagerTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should lookup an integration for namespace")
 	void shouldLookupIntegrationForNamespace() {
-		final var id = EntityId.from(1);
-
 		assertThat(manager.get("konfigyr", EntityId.from(2)))
 				.isPresent()
 				.get()

--- a/konfigyr/src/test/java/com/konfigyr/jooq/SpringConverterProviderTest.java
+++ b/konfigyr/src/test/java/com/konfigyr/jooq/SpringConverterProviderTest.java
@@ -1,0 +1,89 @@
+package com.konfigyr.jooq;
+
+import com.konfigyr.entity.EntityId;
+import org.jooq.ConverterProvider;
+import org.jooq.exception.DataTypeException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.convert.support.GenericConversionService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class SpringConverterProviderTest {
+
+	GenericConversionService conversionService;
+	ConverterProvider converterProvider;
+
+	@BeforeEach
+	void setup() {
+		conversionService = spy(new GenericConversionService());
+		converterProvider = new SpringConverterProvider(() -> conversionService);
+	}
+
+	@Test
+	@DisplayName("should use default conversion provider")
+	void shouldUseDefaultConversionProvider() {
+		assertThat(converterProvider.provide(String.class, Long.class))
+				.isNotNull()
+				.returns("1", it -> it.to(1L))
+				.returns(1L, it -> it.from("1"));
+
+		verifyNoInteractions(conversionService);
+	}
+
+	@Test
+	@DisplayName("should use spring conversion service to create read/write converter")
+	void shouldCreateReadWriteConverter() {
+		conversionService.addConverter(Long.class, EntityId.class, EntityId::from);
+		conversionService.addConverter(EntityId.class, Long.class, EntityId::get);
+
+		final var id = EntityId.from(123568125L);
+
+		assertThat(converterProvider.provide(Long.class, EntityId.class))
+				.isNotNull()
+				.returns(id.get(), it -> it.to(id))
+				.returns(id, it -> it.from(id.get()))
+				.returns(null, it -> it.to(null))
+				.returns(null, it -> it.from(null));
+
+		verify(conversionService).canConvert(Long.class, EntityId.class);
+		verify(conversionService).canConvert(EntityId.class, Long.class);
+		verify(conversionService).convert(id, Long.class);
+		verify(conversionService).convert(id.get(), EntityId.class);
+	}
+
+	@Test
+	@DisplayName("should use spring conversion service to create read only converter")
+	void shouldCreateReadOnlyConverter() {
+		conversionService.addConverter(String.class, EntityId.class, EntityId::from);
+
+		final var id = EntityId.from(98126512354L);
+
+		assertThat(converterProvider.provide(String.class, EntityId.class))
+				.isNotNull()
+				.returns(id, it -> it.from(id.serialize()))
+				.returns(null, it -> it.from(null))
+				.satisfies(it -> assertThatThrownBy(() -> it.to(id))
+						.isInstanceOf(DataTypeException.class)
+						.hasMessageContaining("not implemented")
+				);
+
+		verify(conversionService).canConvert(String.class, EntityId.class);
+		verify(conversionService).canConvert(EntityId.class, String.class);
+		verify(conversionService).convert(id.serialize(), EntityId.class);
+		verify(conversionService, times(0)).convert(id, String.class);
+	}
+
+	@Test
+	@DisplayName("should fail to find converter")
+	void shouldNotFindConverter() {
+		assertThat(converterProvider.provide(String.class, EntityId.class)).isNull();
+
+		verify(conversionService).canConvert(String.class, EntityId.class);
+		verify(conversionService, times(0)).canConvert(EntityId.class, String.class);
+	}
+
+}

--- a/konfigyr/src/test/java/com/konfigyr/namespace/InvitationsTest.java
+++ b/konfigyr/src/test/java/com/konfigyr/namespace/InvitationsTest.java
@@ -341,6 +341,12 @@ class InvitationsTest extends AbstractIntegrationTest {
 				.matching(event -> invitation.get().namespace().equals(event.id()))
 				.matching(event -> invitation.get().namespace().equals(event.namespace()))
 				.matching(event -> invitation.get().key().equals(event.key()));
+
+		events.assertThat()
+				.contains(NamespaceEvent.MemberAdded.class)
+				.matching(event -> invitation.get().namespace().equals(event.id()))
+				.matching(event -> recipient.equals(event.account()))
+				.matching(event -> invitation.get().role().equals(event.role()));
 	}
 
 	@Test

--- a/konfigyr/src/test/java/com/konfigyr/security/SecurityAutoConfigurationTest.java
+++ b/konfigyr/src/test/java/com/konfigyr/security/SecurityAutoConfigurationTest.java
@@ -2,11 +2,11 @@ package com.konfigyr.security;
 
 import com.konfigyr.account.AccountManager;
 import com.konfigyr.crypto.*;
+import com.konfigyr.namespace.NamespaceManager;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.autoconfigure.web.client.RestTemplateAutoConfiguration;
@@ -22,6 +22,7 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 
 import java.util.List;
 
+import static org.mockito.Mockito.mock;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(MockitoExtension.class)
@@ -32,27 +33,16 @@ class SecurityAutoConfigurationTest {
 			RestTemplateAutoConfiguration.class
 	);
 
-	@Mock
-	DSLContext context;
-
-	@Mock
-	AccountManager manager;
-
-	@Mock
-	KeysetOperationsFactory operationsFactory;
-
-	@Mock
-	ClientRegistrationRepository registrationRepository;
-
 	ApplicationContextRunner runner;
 
 	@BeforeEach
 	void setup() {
 		runner = new ApplicationContextRunner().withConfiguration(configurations)
-				.withBean(DSLContext.class, () -> context)
-				.withBean(AccountManager.class, () -> manager)
-				.withBean(KeysetOperationsFactory.class, () -> operationsFactory)
-				.withBean(ClientRegistrationRepository.class, () -> registrationRepository);
+				.withBean(DSLContext.class, () -> mock(DSLContext.class))
+				.withBean(AccountManager.class, () -> mock(AccountManager.class))
+				.withBean(NamespaceManager.class, () -> mock(NamespaceManager.class))
+				.withBean(KeysetOperationsFactory.class, () -> mock(KeysetOperationsFactory.class))
+				.withBean(ClientRegistrationRepository.class, () -> mock(ClientRegistrationRepository.class));
 	}
 
 	@Test

--- a/konfigyr/src/test/java/com/konfigyr/security/oauth/OAuth2UserServiceTest.java
+++ b/konfigyr/src/test/java/com/konfigyr/security/oauth/OAuth2UserServiceTest.java
@@ -2,6 +2,7 @@ package com.konfigyr.security.oauth;
 
 import com.konfigyr.account.Account;
 import com.konfigyr.account.AccountManager;
+import com.konfigyr.namespace.NamespaceManager;
 import com.konfigyr.namespace.NamespaceType;
 import com.konfigyr.security.AccountPrincipal;
 import com.konfigyr.security.AccountPrincipalService;
@@ -49,7 +50,9 @@ class OAuth2UserServiceTest {
 	@BeforeEach
 	void setup() {
 		account = TestAccounts.john().avatar("https://example.com/avatar.svg").build();
-		service = new PrincipalAccountOAuth2UserService(new AccountPrincipalService(manager), delegate);
+		service = new PrincipalAccountOAuth2UserService(
+				new AccountPrincipalService(manager, mock(NamespaceManager.class)), delegate
+		);
 	}
 
 	@Test

--- a/konfigyr/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
+++ b/konfigyr/src/test/java/com/konfigyr/security/rememberme/AccountRememberMeServicesTest.java
@@ -232,7 +232,7 @@ class AccountRememberMeServicesTest {
 		assertThat(cookie)
 				.isNotNull()
 				.returns((int) Duration.ofDays(14).toSeconds(), Cookie::getMaxAge)
-				.returns(true, Cookie::getSecure)
+				.returns(request.isSecure(), Cookie::getSecure)
 				.returns("/", Cookie::getPath)
 				.returns(null, Cookie::getDomain);
 


### PR DESCRIPTION
### Namespaces
* introduce namespace member added, updated and removed events
* added missing transactional annotation when updating members

### Security updates
* do not use `HttpSessionSecurityContextRepository` to store security context in session
* clear security user cache on namespace deleted and namespace member events
* use `SessionCreationPolicy.ALWAYS` in Spring security filter chain
* fix remember-me cookie issue with `secure` set by checking the HTTP request

### jOOQ
* use Spring `ConversionService` to provide additional conversion options for jOOQ record mapping

