### PR TITLE
Upgrade to PostgreSQL 18, Spring Boot 4.0.6 and migrate to UUIDv7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'io.freefair.lombok' version '9.2.0' apply false
-    id 'org.springframework.boot' version '4.0.5' apply false
+    id 'io.freefair.lombok' version '9.4.0' apply false
+    id 'org.springframework.boot' version '4.0.6' apply false
     id 'io.spring.dependency-management' version '1.1.7' apply false
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 ## Versions
-versions.spring.boot=4.0.4
+versions.spring.boot=4.0.6
 versions.spring.cloud=2025.1.1
-versions.spring.modulith=2.0.3
+versions.spring.modulith=2.0.6
 versions.spring.jmolecules=2025.0.2
 
 ## NodeJS Plugin configuration

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/ChangeHistory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/ChangeHistory.java
@@ -1,6 +1,5 @@
 package com.konfigyr.vault;
 
-import com.konfigyr.entity.EntityId;
 import org.jmolecules.ddd.annotation.ValueObject;
 import org.jspecify.annotations.NullMarked;
 
@@ -33,7 +32,7 @@ import java.time.OffsetDateTime;
 @NullMarked
 @ValueObject
 public record ChangeHistory(
-		EntityId id,
+		String id,
 		String revision,
 		String subject,
 		String description,

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/history/ChangeHistoryService.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/history/ChangeHistoryService.java
@@ -19,10 +19,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 import static com.konfigyr.data.tables.Services.SERVICES;
 import static com.konfigyr.data.tables.VaultChangeHistory.VAULT_CHANGE_HISTORY;
@@ -80,10 +77,9 @@ public class ChangeHistoryService implements VaultChronicle {
 		final ChangeHistoryOwnership ownership = lookupOwnership(profile);
 		final AuthenticatedPrincipal author = result.author();
 
-		final Long id = context.insertInto(VAULT_CHANGE_HISTORY)
+		final UUID id = context.insertInto(VAULT_CHANGE_HISTORY)
 				.set(
 						SettableRecord.of(context, VAULT_CHANGE_HISTORY)
-								.set(VAULT_CHANGE_HISTORY.ID, EntityId.generate().map(EntityId::get))
 								.set(VAULT_CHANGE_HISTORY.NAMESPACE_ID, ownership.namespace())
 								.set(VAULT_CHANGE_HISTORY.SERVICE_ID, ownership.service())
 								.set(VAULT_CHANGE_HISTORY.PROFILE_ID, ownership.profile())
@@ -290,7 +286,9 @@ public class ChangeHistoryService implements VaultChronicle {
 	@Override
 	@Transactional(label = "vault.trace-revision-changes", readOnly = true)
 	public List<PropertyHistory> traceRevision(ChangeHistory revision) {
-		return createPropertyHistoryQuery(VAULT_PROPERTY_HISTORY.CHANGE_ID.eq(revision.id().get()))
+		final UUID id = UUID.fromString(revision.id());
+
+		return createPropertyHistoryQuery(VAULT_PROPERTY_HISTORY.CHANGE_ID.eq(id))
 				.fetch(ChangeHistoryService::toPropertyHistory);
 	}
 
@@ -326,14 +324,14 @@ public class ChangeHistoryService implements VaultChronicle {
 				.orElseThrow(() -> new ProfileNotFoundException(profile));
 	}
 
-	private static CursorPageable encodeNextCursor(long identifier, OffsetDateTime timestamp, int size) {
+	private static CursorPageable encodeNextCursor(UUID identifier, OffsetDateTime timestamp, int size) {
 		return CursorPageable.of(
 				HistoryCursorToken.of(identifier, timestamp).value(),
 				size
 		);
 	}
 
-	private static CursorPageable encodePreviousCursor(long identifier, OffsetDateTime timestamp, int size) {
+	private static CursorPageable encodePreviousCursor(UUID identifier, OffsetDateTime timestamp, int size) {
 		return CursorPageable.of(
 				HistoryCursorToken.of(identifier, timestamp, true).value(),
 				size
@@ -342,7 +340,7 @@ public class ChangeHistoryService implements VaultChronicle {
 
 	private static ChangeHistory toChangeHistory(Record record) {
 		return new ChangeHistory(
-				record.get(VAULT_CHANGE_HISTORY.ID, EntityId.class),
+				record.get(VAULT_CHANGE_HISTORY.ID, String.class),
 				record.get(VAULT_CHANGE_HISTORY.REVISION),
 				record.get(VAULT_CHANGE_HISTORY.SUBJECT),
 				record.get(VAULT_CHANGE_HISTORY.DESCRIPTION),

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/history/HistoryCursorToken.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/history/HistoryCursorToken.java
@@ -11,22 +11,24 @@ import java.nio.ByteBuffer;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.UUID;
 
 @NullMarked
 @ValueObject
-record HistoryCursorToken(String value, long identifier, boolean reversed, OffsetDateTime timestamp) {
+record HistoryCursorToken(String value, UUID identifier, boolean reversed, OffsetDateTime timestamp) {
 
 	private static final byte VERSION = 0x1;
 
-	static HistoryCursorToken of(long identifier, OffsetDateTime timestamp) {
+	static HistoryCursorToken of(UUID identifier, OffsetDateTime timestamp) {
 		return of(identifier, timestamp, false);
 	}
 
-	static HistoryCursorToken of(long identifier, OffsetDateTime timestamp, boolean reversed) {
-		final ByteBuffer buffer = ByteBuffer.allocate(18);
+	static HistoryCursorToken of(UUID identifier, OffsetDateTime timestamp, boolean reversed) {
+		final ByteBuffer buffer = ByteBuffer.allocate(26);
 		buffer.put(VERSION);
 		buffer.put(reversed ? (byte) 0x1 : (byte) 0x0);
-		buffer.putLong(identifier);
+		buffer.putLong(identifier.getMostSignificantBits());
+		buffer.putLong(identifier.getLeastSignificantBits());
 		buffer.putLong(timestamp.toInstant().toEpochMilli());
 		return new HistoryCursorToken(Hex.encodeHexString(buffer.array()), identifier, reversed, timestamp);
 	}
@@ -38,7 +40,7 @@ record HistoryCursorToken(String value, long identifier, boolean reversed, Offse
 	}
 
 	static HistoryCursorToken decode(String encoded) {
-		if (encoded.length() != 36) {
+		if (encoded.length() != 52) {
 			throw new IllegalArgumentException("Invalid cursor token of: " + encoded);
 		}
 
@@ -55,15 +57,16 @@ record HistoryCursorToken(String value, long identifier, boolean reversed, Offse
 		// check if this is a reversed token
 		final byte reversed = buffer.get();
 
-		// read identifier and timestamp from the buffer...
-		final long identifier = buffer.getLong();
+		// read UUID most/least significant bits and timestamp from the buffer
+		final long mostSigBits = buffer.getLong();
+		final long leastSigBits = buffer.getLong();
 		final long timestamp = buffer.getLong();
 
-		if (identifier < 0 || timestamp < 0) {
+		if (timestamp < 0) {
 			throw new IllegalArgumentException("Invalid cursor token of: " + encoded);
 		}
 
-		return new HistoryCursorToken(encoded, identifier, reversed != 0,
+		return new HistoryCursorToken(encoded, new UUID(mostSigBits, leastSigBits), reversed != 0,
 				Instant.ofEpochMilli(timestamp).atOffset(ZoneOffset.UTC));
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/state/GitConverters.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/state/GitConverters.java
@@ -1,7 +1,6 @@
 package com.konfigyr.vault.state;
 
 import com.konfigyr.security.AuthenticatedPrincipal;
-import com.konfigyr.vault.ChangeHistory;
 import com.konfigyr.vault.PropertyChanges;
 import org.apache.commons.io.output.WriterOutputStream;
 import org.eclipse.jgit.diff.Sequence;
@@ -36,11 +35,11 @@ final class GitConverters {
 	}
 
 	/**
-	 * Attempts to convert the resolved {@link RevCommit} to a {@link ChangeHistory}.
+	 * Attempts to convert the resolved {@link RevCommit} to a {@link RepositoryState}.
 	 *
-	 * @param commit the Git commit to convert to a {@link ChangeHistory}, cannot be {@literal null}.
+	 * @param commit the Git commit to convert to a {@link RepositoryState}, cannot be {@literal null}.
 	 * @param contents the source of the configuration state contents, cannot be {@literal null}.
-	 * @return the converted {@link ChangeHistory}, never {@literal null}.
+	 * @return the converted {@link RepositoryState}, never {@literal null}.
 	 */
 	static RepositoryState convertToRepositoryState(RevCommit commit, InputStreamSource contents) {
 		return RepositoryState.builder()

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/controller/VaultControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/controller/VaultControllerTest.java
@@ -94,13 +94,13 @@ class VaultControllerTest extends AbstractControllerTest {
 				.hasSize(7)
 				.extracting(ChangeHistory::id, ChangeHistory::revision, ChangeHistory::subject)
 				.containsExactly(
-						tuple(EntityId.from(7), "last-revision", "Last change"),
-						tuple(EntityId.from(6), "sixth-revision", "Sixth change"),
-						tuple(EntityId.from(5), "fifth-revision", "Fifth change"),
-						tuple(EntityId.from(4), "fourth-revision", "Fourth change"),
-						tuple(EntityId.from(3), "third-revision", "Third change"),
-						tuple(EntityId.from(2), "second-revision", "Second change"),
-						tuple(EntityId.from(1), "first-revision", "First change")
+						tuple("019690a1-0007-7000-8000-000000000007", "last-revision", "Last change"),
+						tuple("019690a1-0006-7000-8000-000000000006", "sixth-revision", "Sixth change"),
+						tuple("019690a1-0005-7000-8000-000000000005", "fifth-revision", "Fifth change"),
+						tuple("019690a1-0004-7000-8000-000000000004", "fourth-revision", "Fourth change"),
+						tuple("019690a1-0003-7000-8000-000000000003", "third-revision", "Third change"),
+						tuple("019690a1-0002-7000-8000-000000000002", "second-revision", "Second change"),
+						tuple("019690a1-0001-7000-8000-000000000001", "first-revision", "First change")
 				);
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/history/ChangeHistoryServiceTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/history/ChangeHistoryServiceTest.java
@@ -249,7 +249,7 @@ class ChangeHistoryServiceTest extends AbstractIntegrationTest {
 		assertThat(chronicle.examine(profileFor(3), "first-revision"))
 				.isPresent()
 				.get()
-				.returns(EntityId.from(8), ChangeHistory::id)
+				.returns("019690a1-0008-7000-8000-000000000008", ChangeHistory::id)
 				.returns("first-revision", ChangeHistory::revision)
 				.returns("First change", ChangeHistory::subject)
 				.returns("Initial changes", ChangeHistory::description)

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/history/HistoryCursorTokenTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/history/HistoryCursorTokenTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -14,7 +15,7 @@ class HistoryCursorTokenTest {
 
 	@ValueSource(strings = {
 			"", "  ", "invalid", "AAABnUlDfTxkN2FlYWVlZTVhNmE1", "36136243474196827672847",
-			"AAABn312UlDfTxkN2FlYWVlZTVhNmE172847", "AAABnUlDfTxkN2FlYWVlZTVhNmE1ZTIwNGQ4Zj"
+			"AAABn312UlDfTxkN2FlYWVlZTVhNmE172847"
 	})
 	@ParameterizedTest(name = "cursor token = {0}")
 	@DisplayName("should fail to decode invalid cursor pagination tokens")
@@ -28,14 +29,14 @@ class HistoryCursorTokenTest {
 	@DisplayName("should encode and decode cursor pagination tokens")
 	void shouldEncodeAndDecodeTokens() {
 		final var token = HistoryCursorToken.of(
-				124097687512745L,
+				UUID.fromString("019690a1-0007-7000-8000-000000000007"),
 				OffsetDateTime.parse("2026-04-01T13:37:32.988Z")
 		);
 
 		assertThat(token)
-				.returns(124097687512745L, HistoryCursorToken::identifier)
+				.returns(UUID.fromString("019690a1-0007-7000-8000-000000000007"), HistoryCursorToken::identifier)
 				.returns(OffsetDateTime.parse("2026-04-01T13:37:32.988Z"), HistoryCursorToken::timestamp)
-				.returns("0100000070ddbe94e6a90000019d49437d3c", HistoryCursorToken::value);
+				.returns(false, HistoryCursorToken::reversed);
 
 		assertThat(HistoryCursorToken.decode(token.value()))
 				.isEqualTo(token);
@@ -45,15 +46,15 @@ class HistoryCursorTokenTest {
 	@DisplayName("should encode and decode reversed cursor pagination tokens")
 	void shouldEncodeAndDecodeReverseTokens() {
 		final var token = HistoryCursorToken.of(
-				9124582095215679363L,
+				UUID.fromString("019690a1-0003-7000-8000-000000000003"),
 				OffsetDateTime.parse("2026-04-07T12:15:11.352Z"),
 				true
 		);
 
 		assertThat(token)
-				.returns(9124582095215679363L, HistoryCursorToken::identifier)
+				.returns(UUID.fromString("019690a1-0003-7000-8000-000000000003"), HistoryCursorToken::identifier)
 				.returns(OffsetDateTime.parse("2026-04-07T12:15:11.352Z"), HistoryCursorToken::timestamp)
-				.returns("01017ea107124d3857830000019d67de3df8", HistoryCursorToken::value);
+				.returns(true, HistoryCursorToken::reversed);
 
 		assertThat(HistoryCursorToken.decode(token.value()))
 				.isEqualTo(token);

--- a/konfigyr-api/src/test/resources/data/vault.sql
+++ b/konfigyr-api/src/test/resources/data/vault.sql
@@ -13,26 +13,26 @@ SELECT create_property_history_partition(now() - interval '1 month');
 SELECT create_property_history_partition(now() - interval '2 month');
 
 INSERT INTO vault_change_history(id, namespace_id, service_id, profile_id, revision, previous_revision, subject, description, change_count, author_id, author_type, author_name, created_at) VALUES
-(1, 2, 2, 4, 'first-revision', NULL, 'First change', 'Initial changes', 1, 1, 'USER', 'John Doe', now() - interval '34 days'),
-(2, 2, 2, 4, 'second-revision', 'first-revision', 'Second change', NULL, 2, 2, 'USER', 'Jane Doe', now() - interval '27 days'),
-(3, 2, 2, 4, 'third-revision', 'second-revision', 'Third change', NULL, 1, 1, 'USER', 'John Doe', now() - interval '18 days'),
-(4, 2, 2, 4, 'fourth-revision', 'third-revision', 'Fourth change', 'A while longer...', 1, 1, 'USER', 'John Doe', now() - interval '12 days'),
-(5, 2, 2, 4, 'fifth-revision', 'fourth-revision', 'Fifth change', NULL, 1, 2, 'OAUTH_CLIENT', 'Konfigyr active app', now() - interval '9 days'),
-(6, 2, 2, 4, 'sixth-revision', 'fifth-revision', 'Sixth change', 'The next one does it...', 1, 1, 'USER', 'John Doe', now() - interval '3 days'),
-(7, 2, 2, 4, 'last-revision', 'sixth-revision', 'Last change', 'Got no more', 1, 1, 'USER', 'John Doe', now() - interval '2 days'),
-(8, 2, 2, 3, 'first-revision', NULL, 'First change', 'Initial changes', 1, 1, 'USER', 'John Doe', now() - interval '2 days'),
-(9, 1, 1, 5, 'first-revision', NULL, 'Testing', NULL, 1, 1, 'USER', 'John Doe', now() - interval '7 days');
+('019690a1-0001-7000-8000-000000000001', 2, 2, 4, 'first-revision', NULL, 'First change', 'Initial changes', 1, 1, 'USER', 'John Doe', now() - interval '34 days'),
+('019690a1-0002-7000-8000-000000000002', 2, 2, 4, 'second-revision', 'first-revision', 'Second change', NULL, 2, 2, 'USER', 'Jane Doe', now() - interval '27 days'),
+('019690a1-0003-7000-8000-000000000003', 2, 2, 4, 'third-revision', 'second-revision', 'Third change', NULL, 1, 1, 'USER', 'John Doe', now() - interval '18 days'),
+('019690a1-0004-7000-8000-000000000004', 2, 2, 4, 'fourth-revision', 'third-revision', 'Fourth change', 'A while longer...', 1, 1, 'USER', 'John Doe', now() - interval '12 days'),
+('019690a1-0005-7000-8000-000000000005', 2, 2, 4, 'fifth-revision', 'fourth-revision', 'Fifth change', NULL, 1, 2, 'OAUTH_CLIENT', 'Konfigyr active app', now() - interval '9 days'),
+('019690a1-0006-7000-8000-000000000006', 2, 2, 4, 'sixth-revision', 'fifth-revision', 'Sixth change', 'The next one does it...', 1, 1, 'USER', 'John Doe', now() - interval '3 days'),
+('019690a1-0007-7000-8000-000000000007', 2, 2, 4, 'last-revision', 'sixth-revision', 'Last change', 'Got no more', 1, 1, 'USER', 'John Doe', now() - interval '2 days'),
+('019690a1-0008-7000-8000-000000000008', 2, 2, 3, 'first-revision', NULL, 'First change', 'Initial changes', 1, 1, 'USER', 'John Doe', now() - interval '2 days'),
+('019690a1-0009-7000-8000-000000000009', 1, 1, 5, 'first-revision', NULL, 'Testing', NULL, 1, 1, 'USER', 'John Doe', now() - interval '7 days');
 
 INSERT INTO vault_property_history(change_id, profile_id, property_name, change_operation, new_value_checksum, new_value_cipher, old_value_checksum, old_value_cipher, created_at) VALUES
-(1, 4, 'spring.application.name', 'ADDED', '1234567890', '1234567890', NULL, NULL, now() - interval '34 days'),
-(2, 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '27 days'),
-(2, 4, 'spring.application.group', 'ADDED', '1234567890', '1234567890', NULL, NULL, now() - interval '27 days'),
-(3, 4, 'spring.application.group', 'REMOVED', NULL, NULL, '1234567890', '1234567890', now() - interval '18 days'),
-(4, 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '12 days'),
-(5, 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '9 days'),
-(6, 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '3 days'),
-(7, 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '2 days'),
-(9, 5, 'spring.application.name', 'ADDED', '1234567890', '1234567890', NULL, NULL, now() - interval '7 days');
+('019690a1-0001-7000-8000-000000000001', 4, 'spring.application.name', 'ADDED', '1234567890', '1234567890', NULL, NULL, now() - interval '34 days'),
+('019690a1-0002-7000-8000-000000000002', 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '27 days'),
+('019690a1-0002-7000-8000-000000000002', 4, 'spring.application.group', 'ADDED', '1234567890', '1234567890', NULL, NULL, now() - interval '27 days'),
+('019690a1-0003-7000-8000-000000000003', 4, 'spring.application.group', 'REMOVED', NULL, NULL, '1234567890', '1234567890', now() - interval '18 days'),
+('019690a1-0004-7000-8000-000000000004', 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '12 days'),
+('019690a1-0005-7000-8000-000000000005', 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '9 days'),
+('019690a1-0006-7000-8000-000000000006', 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '3 days'),
+('019690a1-0007-7000-8000-000000000007', 4, 'spring.application.name', 'UPDATED', '1234567890', '1234567890', '1234567890', '1234567890', now() - interval '2 days'),
+('019690a1-0009-7000-8000-000000000009', 5, 'spring.application.name', 'ADDED', '1234567890', '1234567890', NULL, NULL, now() - interval '7 days');
 
 INSERT INTO vault_change_requests(id, service_id, profile_id, number, state, merge_status, change_count, branch_name, base_revision, head_revision, subject, description_checksum, description, created_by, created_at, updated_at) VALUES
 -- MERGED (clean flow)

--- a/konfigyr-data/src/main/resources/migrations/audit/audit-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/audit/audit-1.0.0.xml
@@ -14,7 +14,7 @@
         <comment>Cross-domain audit event log table, partitioned by month on created_at</comment>
 
         <createTable tableName="audit_events">
-            <column name="id" type="uuid" defaultValueComputed="gen_random_uuid()">
+            <column name="id" type="uuid" defaultValueComputed="uuidv7()">
                 <constraints nullable="false" primaryKey="true" />
             </column>
 

--- a/konfigyr-data/src/main/resources/migrations/vault/vault-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/vault/vault-1.0.0.xml
@@ -81,7 +81,7 @@
 		<comment>Vault change history table</comment>
 
 		<createTable tableName="vault_change_history">
-			<column name="id" type="bigint">
+			<column name="id" type="uuid" defaultValueComputed="uuidv7()">
 				<constraints nullable="false" primaryKey="true" />
 			</column>
 
@@ -222,7 +222,7 @@
 		<comment>Vault property change history table</comment>
 
 		<createTable tableName="vault_property_history">
-			<column name="change_id" type="bigint">
+			<column name="change_id" type="uuid">
 				<constraints nullable="false" primaryKey="true" />
 			</column>
 
@@ -458,7 +458,7 @@
 		<comment>Vault Change Request events table</comment>
 
 		<createTable tableName="vault_change_request_events" remarks="Stores events that occurred during change request lifecycle.">
-			<column name="id" type="uuid" defaultValueComputed="gen_random_uuid()">
+			<column name="id" type="uuid" defaultValueComputed="uuidv7()">
 				<constraints nullable="false" primaryKey="true" />
 			</column>
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/OidcAccountIdentityUser.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/OidcAccountIdentityUser.java
@@ -1,14 +1,13 @@
 package com.konfigyr.identity.authentication;
 
-import lombok.RequiredArgsConstructor;
 import lombok.Value;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Implementation of the {@link AccountIdentityUser} that is able to load, or create, the {@link AccountIdentity}
@@ -18,11 +17,23 @@ import java.util.Map;
  * @since 1.0.0
  */
 @Value
-@RequiredArgsConstructor
 class OidcAccountIdentityUser implements AccountIdentityUser, OidcUser {
 
 	AccountIdentity accountIdentity;
 	OidcUser delegate;
+	Collection<? extends GrantedAuthority> authorities;
+
+	OidcAccountIdentityUser(AccountIdentity accountIdentity, OidcUser delegate) {
+		this.accountIdentity = accountIdentity;
+		this.delegate = delegate;
+
+		// the OIDC granted authority is never added to the authentication by the provider
+		// for us to store the factor issue time, we need to create one here
+		final Set<GrantedAuthority> authorities = new LinkedHashSet<>(accountIdentity.getAuthorities());
+		authorities.add(FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.AUTHORIZATION_CODE_AUTHORITY));
+
+		this.authorities = Collections.unmodifiableCollection(authorities);
+	}
 
 	@Override
 	public Map<String, Object> getClaims() {
@@ -44,8 +55,4 @@ class OidcAccountIdentityUser implements AccountIdentityUser, OidcUser {
 		return delegate.getAttributes();
 	}
 
-	@Override
-	public Collection<? extends GrantedAuthority> getAuthorities() {
-		return accountIdentity.getAuthorities();
-	}
 }

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/rememberme/AccountRememberMeServices.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/rememberme/AccountRememberMeServices.java
@@ -6,9 +6,11 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.log.LogMessage;
-import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.authentication.RememberMeAuthenticationToken;
 import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -25,20 +27,21 @@ import org.springframework.util.StringUtils;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Objects;
+import java.time.Instant;
+import java.util.*;
 
 /**
  * Implementation of the {@link RememberMeServices} that
  * is based on the {@link org.springframework.security.web.authentication.rememberme.TokenBasedRememberMeServices}.
  * <p>
  * The difference here is that we are not using the password of the {@link UserDetails user} to generate
- * the cookie token value. User accounts within this application do not use passwords.
+ * the cookie token value. User accounts within this application do not use passwords, but we do require
+ * the {@link FactorGrantedAuthority} to be present in the {@link Authentication} that should be stored by
+ * this implementation.
  * <p>
  * The cookie encoded by this implementation adopts the following form:
  * <pre>
- * username + ":" + expiryTime + HEX(SHA-256(username + ":" + expiryTime + ":" + key))
+ * username + ":" + factor + ":" + issuedTime + ":" + expiryTime + HEX(SHA-256(username + ":" + expiryTime + ":" + key))
  * </pre>
  * <p>
  * Keep in mind that this implementation of the {@link RememberMeServices} would <strong>always</strong>
@@ -57,6 +60,7 @@ public class AccountRememberMeServices implements RememberMeServices, LogoutHand
 	 */
 	public static final String KEY = EntityId.from(123456789).serialize();
 
+	static final String STORED_FACTOR_GRANTED_AUTHORITY = AccountRememberMeServices.class.getName() + "#FACTOR_GRANTED_AUTHORITY";
 	static final String COOKIE_NAME = "konfigyr.account";
 	static final String DIGEST_ALGORITHM = "SHA-256";
 	static final Duration TOKEN_VALIDITY = Duration.ofDays(14);
@@ -99,8 +103,8 @@ public class AccountRememberMeServices implements RememberMeServices, LogoutHand
 		delegate.logout(request, response, authentication);
 	}
 
-	static String generateSignature(String username, long tokenExpiryTime, String key, String algorithm) {
-		final String data = username + ":" + tokenExpiryTime + ":" + key;
+	static String generateSignature(String username, String factor, long issuedTime, long tokenExpiryTime, String key, String algorithm) {
+		final String data = username + ":" + ":" + factor + ":" + issuedTime + ":" + tokenExpiryTime + ":" + key;
 
 		try {
 			final MessageDigest digest = MessageDigest.getInstance(algorithm);
@@ -114,11 +118,26 @@ public class AccountRememberMeServices implements RememberMeServices, LogoutHand
 		return MessageDigest.isEqual(Utf8.encode(expected), Utf8.encode(actual));
 	}
 
+	static FactorGrantedAuthority resolveFactorGrantedAuthority(Authentication authentication) {
+		FactorGrantedAuthority authority = null;
+		for (GrantedAuthority grantedAuthority : authentication.getAuthorities()) {
+			if (grantedAuthority instanceof FactorGrantedAuthority factorGrantedAuthority) {
+				if (authority == null || factorGrantedAuthority.getIssuedAt().isAfter(authority.getIssuedAt())) {
+					authority = factorGrantedAuthority;
+				}
+			}
+		}
+		if (authority == null) {
+			throw new IllegalStateException("No FactorGrantedAuthority found in Authentication: " + authentication);
+		}
+		return authority;
+	}
+
 	/**
 	 * This class is intentionally made internal as we do not wish to expose the API of the
 	 * {@link AbstractRememberMeServices} via {@link AccountRememberMeServices}. We should prevent
 	 * any customization, i.e. different cookie names or max age..., of the {@link RememberMeServices}
-	 * that would be registered in Spring HTTP security filter chain.
+	 * that would be registered in a Spring HTTP security filter chain.
 	 */
 	private static final class InternalRememberMeServices extends AbstractRememberMeServices {
 
@@ -139,10 +158,13 @@ public class AccountRememberMeServices implements RememberMeServices, LogoutHand
 				return;
 			}
 
+			final FactorGrantedAuthority factor = resolveFactorGrantedAuthority(authentication);
 			final long expiryTime = System.currentTimeMillis() + (1000L * getTokenValiditySeconds());
-			final String signature = generateSignature(username, expiryTime, getKey(), DIGEST_ALGORITHM);
+			final String signature = generateSignature(username, factor.getAuthority(), factor.getIssuedAt().toEpochMilli(),
+					expiryTime, getKey(), DIGEST_ALGORITHM);
 
-			setCookie(new String[] { username, Long.toString(expiryTime), signature }, getTokenValiditySeconds(), request, response);
+			setCookie(new String[] { username, factor.getAuthority(), Long.toString(factor.getIssuedAt().toEpochMilli()),
+							Long.toString(expiryTime), signature }, getTokenValiditySeconds(), request, response);
 
 			if (this.logger.isDebugEnabled()) {
 				this.logger.debug(LogMessage.format(
@@ -159,48 +181,58 @@ public class AccountRememberMeServices implements RememberMeServices, LogoutHand
 				HttpServletRequest request,
 				HttpServletResponse response
 		) throws RememberMeAuthenticationException, UsernameNotFoundException {
-			if (tokens.length != 3) {
-				throw new InvalidCookieException("Cookie needs to contain 3 tokens: '" + Arrays.asList(tokens) + "'");
+			if (tokens.length != 5) {
+				throw new InvalidCookieException("Cookie needs to contain 5 tokens: '" + Arrays.asList(tokens) + "'");
 			}
 
-			final long tokenExpiryTime = extractTokenExpiryTime(tokens);
-			final UserDetails user = retrieveUserDetails(tokens[0]);
+			final long factorIssuedTime = extractTokenTimestamp(tokens, 2);
+			final long tokenExpiryTime = extractTokenTimestamp(tokens, 3);
 
-			// Generate the signature to check if it matches the signature of token
-			final String signature = generateSignature(user.getUsername(), tokenExpiryTime, getKey(), DIGEST_ALGORITHM);
+			if (tokenExpiryTime < System.currentTimeMillis()) {
+				throw new InvalidCookieException("Cookie has expired (expired on '" + new Date(tokenExpiryTime) + "')");
+			}
 
-			if (signaturesMatch(signature, tokens[2])) {
-				return user;
+			// a workaround that would pass the FactorGrantedAuthority to the resulting authentication
+			request.setAttribute(STORED_FACTOR_GRANTED_AUTHORITY, FactorGrantedAuthority.withAuthority(tokens[1])
+					.issuedAt(Instant.ofEpochMilli(factorIssuedTime))
+					.build()
+			);
+
+			// Generate the signature to check if it matches the signature of the token
+			final String signature = generateSignature(tokens[0], tokens[1], factorIssuedTime, tokenExpiryTime, getKey(), DIGEST_ALGORITHM);
+
+			if (signaturesMatch(signature, tokens[4])) {
+				return getUserDetailsService().loadUserByUsername(tokens[0]);
 			}
 
 			throw new InvalidCookieException("Cookie contained signature '" + tokens[2] + "' but expected '" + signature + "'");
 		}
 
-		private long extractTokenExpiryTime(String[] tokens) {
-			final long expiryTime;
+		@Override
+		protected Authentication createSuccessfulAuthentication(HttpServletRequest request, UserDetails user) {
+			final Collection<GrantedAuthority> mappedAuthorities = new LinkedHashSet<>(user.getAuthorities());
+			// use the FactorGrantedAuthority that was stored in the request and extracted from the cookie
+			mappedAuthorities.add((FactorGrantedAuthority) request.getAttribute(STORED_FACTOR_GRANTED_AUTHORITY));
+			// clear the attribute as it is no longer required
+			request.removeAttribute(STORED_FACTOR_GRANTED_AUTHORITY);
+
+			final RememberMeAuthenticationToken authentication = new RememberMeAuthenticationToken(
+					getKey(), user, mappedAuthorities
+			);
+			authentication.setDetails(getAuthenticationDetailsSource().buildDetails(request));
+			return authentication;
+		}
+
+		private long extractTokenTimestamp(String[] tokens, int index) {
+			final long timestamp;
 
 			try {
-				expiryTime = Long.parseLong(tokens[1]);
+				timestamp = Long.parseLong(tokens[index]);
 			} catch (NumberFormatException nfe) {
 				throw new InvalidCookieException("Cookie did not contain a valid number (contained '" + tokens[1] + "')");
 			}
 
-			if (expiryTime < System.currentTimeMillis()) {
-				throw new InvalidCookieException("Cookie has expired (expired on '" + new Date(expiryTime) + "')");
-			}
-
-			return expiryTime;
-		}
-
-		private UserDetails retrieveUserDetails(String username) {
-			final UserDetails userDetails = getUserDetailsService().loadUserByUsername(username);
-
-			if (userDetails == null) {
-				throw new InternalAuthenticationServiceException("User details service returned null for username '"
-						+ username + "'. This is considered as an interface contract violation.");
-			}
-
-			return userDetails;
+			return timestamp;
 		}
 
 		@Nullable

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/AuthorizationServerIntegrationTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/AuthorizationServerIntegrationTest.java
@@ -21,6 +21,8 @@ import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.OAuth2Error;
@@ -629,8 +631,11 @@ class AuthorizationServerIntegrationTest {
 		return request -> {
 			final var response = new MockHttpServletResponse();
 
+			final List<GrantedAuthority> authorities = new ArrayList<>(identity.getAuthorities());
+			authorities.add(FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.AUTHORIZATION_CODE_AUTHORITY));
+
 			services.loginSuccess(request, response, new UsernamePasswordAuthenticationToken(
-					identity, identity.getPassword(), identity.getAuthorities()
+					identity, identity.getPassword(), authorities
 			));
 
 			request.setCookies(response.getCookies());

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/acceptance/AuthorizationCodeAcceptanceTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/acceptance/AuthorizationCodeAcceptanceTest.java
@@ -22,6 +22,8 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.authentication.TestingAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
@@ -35,7 +37,9 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -160,7 +164,11 @@ class AuthorizationCodeAcceptanceTest {
 	static Cookie generateRememberMeCookie(AccountIdentity identity) {
 		final var request = new MockHttpServletRequest();
 		final var response = new MockHttpServletResponse();
-		final var authentication = new TestingAuthenticationToken(identity, "", identity.getAuthorities());
+
+		final List<GrantedAuthority> authorities = new ArrayList<>(identity.getAuthorities());
+		authorities.add(FactorGrantedAuthority.fromAuthority(FactorGrantedAuthority.AUTHORIZATION_CODE_AUTHORITY));
+
+		final var authentication = new TestingAuthenticationToken(identity, "", authorities);
 
 		services.loginSuccess(request, response, authentication);
 

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authentication/AccountIdentityTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authentication/AccountIdentityTest.java
@@ -7,6 +7,7 @@ import com.konfigyr.test.OAuth2AccessTokens;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.oauth2.core.oidc.IdTokenClaimNames;
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser;
@@ -109,11 +110,15 @@ class AccountIdentityTest {
 				.returns(identity, OidcAccountIdentityUser::getAccountIdentity)
 				.returns(identity.getId(), OidcAccountIdentityUser::getId)
 				.returns(identity.getName(), OidcAccountIdentityUser::getName)
-				.returns(identity.getAuthorities(), OidcAccountIdentityUser::getAuthorities)
 				.returns(token, OidcAccountIdentityUser::getIdToken)
 				.returns(claims, OidcAccountIdentityUser::getClaims)
 				.returns(claims, OidcAccountIdentityUser::getAttributes)
-				.returns(null, OidcAccountIdentityUser::getUserInfo);
+				.returns(null, OidcAccountIdentityUser::getUserInfo)
+				.satisfies(it -> assertThat(it.getAuthorities())
+						.hasSize(2)
+						.extracting(GrantedAuthority::getAuthority)
+						.containsExactlyInAnyOrder("jane", FactorGrantedAuthority.AUTHORIZATION_CODE_AUTHORITY)
+				);
 	}
 
 	@Test

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authentication/rememberme/AccountRememberMeServicesTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authentication/rememberme/AccountRememberMeServicesTest.java
@@ -2,6 +2,7 @@ package com.konfigyr.identity.authentication.rememberme;
 
 import com.konfigyr.entity.EntityId;
 import jakarta.servlet.http.Cookie;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.data.Index;
 import org.assertj.core.data.Offset;
 import org.junit.jupiter.api.BeforeEach;
@@ -12,10 +13,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
-import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.authentication.TestingAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.FactorGrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
@@ -24,7 +26,10 @@ import org.springframework.security.web.authentication.rememberme.AbstractRememb
 
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 
 import static org.mockito.Mockito.*;
 import static org.assertj.core.api.Assertions.*;
@@ -115,8 +120,6 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should return null when remember-me cookie signature does not match and clear it")
 	void autoLoginClearsCookieIfSignatureBlocksDoesNotMatchExpectedValue() {
-		doReturn(principal).when(service).loadUserByUsername(anyString());
-
 		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername(), "WRONG_KEY"));
 
 		assertThat(services.autoLogin(request, response))
@@ -130,8 +133,6 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should return null when remember-me signing algorithm is different")
 	void autoLoginClearsCookieIfSignatureAlgorithmDoesNotMatch() {
-		doReturn(principal).when(service).loadUserByUsername(anyString());
-
 		request.setCookies(createCookie(
 				System.currentTimeMillis() + 1000000, principal.getUsername(), AccountRememberMeServices.KEY, "MD5"
 		));
@@ -147,7 +148,7 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should return null when remember-me cookie expiry time is invalid and clear it")
 	void autoLoginClearsCookieIfTokenDoesNotContainANumberInCookieValue() {
-		request.setCookies(createCookie(encode("username:NOT_A_NUMBER:signature")));
+		request.setCookies(createCookie(encode("username:factor:NOT_A_NUMBER:NOT_A_NUMBER:signature")));
 
 		assertThat(services.autoLogin(request, response))
 				.isNull();
@@ -173,30 +174,29 @@ class AccountRememberMeServicesTest {
 	}
 
 	@Test
-	@DisplayName("should throw internal service error when user service returns null")
-	void autoLoginClearsCookieIfUserServiceMisconfigured() {
-		doReturn(null).when(service).loadUserByUsername(anyString());
-
-		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername()));
-
-		assertThatThrownBy(() -> this.services.autoLogin(request, response))
-				.isInstanceOf(InternalAuthenticationServiceException.class);
-	}
-
-	@Test
 	@DisplayName("should create authentication for valid cookie")
 	void autoLoginWithValidTokenAndUserSucceeds() {
+		final long issuedAt = System.currentTimeMillis();
 		doReturn(principal).when(service).loadUserByUsername(anyString());
 
-		request.setCookies(createCookie(System.currentTimeMillis() + 1000000, principal.getUsername()));
+		request.setCookies(createCookie(issuedAt, issuedAt + 1000000, principal.getUsername()));
 
 		assertThat(services.autoLogin(request, response))
 				.isNotNull()
 				.returns(principal, Authentication::getPrincipal)
 				.returns(principal.getUsername(), Authentication::getName)
 				.satisfies(it -> assertThat(it.getAuthorities())
-						.extracting(GrantedAuthority::getAuthority)
-						.containsExactly("konfigyr-account"));
+						.hasSize(2)
+						.asInstanceOf(InstanceOfAssertFactories.iterable(GrantedAuthority.class))
+						.containsExactlyInAnyOrder(
+								new SimpleGrantedAuthority("konfigyr-account"),
+								FactorGrantedAuthority.withAuthority("factor")
+										.issuedAt(Instant.ofEpochMilli(issuedAt))
+										.build()
+						));
+
+		assertThat(request.getAttribute(AccountRememberMeServices.STORED_FACTOR_GRANTED_AUTHORITY))
+				.isNull();
 	}
 
 	@Test
@@ -210,11 +210,24 @@ class AccountRememberMeServicesTest {
 	}
 
 	@Test
+	@DisplayName("should fail to create cookie without issued factor granted authority")
+	void loginSuccessWithoutFactorAuthority() {
+		request.addParameter(AbstractRememberMeServices.DEFAULT_PARAMETER, "on");
+
+		final var authentication = createAuthentication(principal);
+
+		assertThatIllegalStateException()
+				.isThrownBy(() -> services.loginSuccess(request, response, authentication))
+				.withMessageContaining("No FactorGrantedAuthority found in Authentication: %s", authentication)
+				.withNoCause();
+	}
+
+	@Test
 	@DisplayName("should create cookie even without remember-me parameter set")
 	void loginSuccessWhenParameterNotSetOrFalse() {
 		request.addParameter(AbstractRememberMeServices.DEFAULT_PARAMETER, "false");
 
-		services.loginSuccess(request, response, createAuthentication(principal));
+		services.loginSuccess(request, response, createAuthentication(principal, FactorGrantedAuthority.PASSWORD_AUTHORITY));
 
 		assertThat(response.getCookie(AccountRememberMeServices.COOKIE_NAME))
 				.isNotNull()
@@ -226,7 +239,7 @@ class AccountRememberMeServicesTest {
 	void loginSuccessSetsCookie() {
 		request.addParameter(AbstractRememberMeServices.DEFAULT_PARAMETER, "on");
 
-		services.loginSuccess(request, response, createAuthentication(principal));
+		services.loginSuccess(request, response, createAuthentication(principal, FactorGrantedAuthority.AUTHORIZATION_CODE_AUTHORITY));
 
 		final var cookie = response.getCookie(AccountRememberMeServices.COOKIE_NAME);
 
@@ -242,15 +255,22 @@ class AccountRememberMeServicesTest {
 				.isBase64();
 
 		assertThat(decode(cookie.getValue()).split(":"))
-				.hasSize(3)
+				.hasSize(5)
 				.contains(principal.getUsername(), Index.atIndex(0))
-				.satisfies(tokens -> assertThat(Long.parseLong(tokens[1]))
+				.contains(FactorGrantedAuthority.AUTHORIZATION_CODE_AUTHORITY, Index.atIndex(1))
+				.satisfies(tokens -> assertThat(Long.parseLong(tokens[2]))
 						.isCloseTo(
-								System.currentTimeMillis() + Duration.ofDays(14).toMillis(),
-								Offset.offset(300L) // should not take more than 300ms to generate cookie
+								System.currentTimeMillis(),
+								Offset.offset(300L) // should not take more than 300ms to generate the cookie
 						)
 				)
-				.satisfies(tokens -> assertThat(tokens[2])
+				.satisfies(tokens -> assertThat(Long.parseLong(tokens[3]))
+						.isCloseTo(
+								System.currentTimeMillis() + Duration.ofDays(14).toMillis(),
+								Offset.offset(300L) // should not take more than 300ms to generate the cookie
+						)
+				)
+				.satisfies(tokens -> assertThat(tokens[4])
 						.isNotBlank()
 						.isHexadecimal()
 				);
@@ -297,7 +317,7 @@ class AccountRememberMeServicesTest {
 	@Test
 	@DisplayName("should catch unknown signing algorithm exceptions")
 	void shouldCatchUnknownAlgorithmExceptions() {
-		assertThatThrownBy(() -> AccountRememberMeServices.generateSignature("test", 1, "key", "unknown-algo"))
+		assertThatThrownBy(() -> AccountRememberMeServices.generateSignature("test", "factor", 1, 1, "key", "unknown-algo"))
 				.isInstanceOf(IllegalStateException.class)
 				.hasRootCauseInstanceOf(NoSuchAlgorithmException.class);
 	}
@@ -306,8 +326,18 @@ class AccountRememberMeServicesTest {
 		return new TestingAuthenticationToken(user, user.getPassword(), user.getAuthorities());
 	}
 
+	private static Authentication createAuthentication(UserDetails user, String factor) {
+		final List<GrantedAuthority> authorities = new ArrayList<>(user.getAuthorities());
+		authorities.add(FactorGrantedAuthority.fromAuthority(factor));
+		return new TestingAuthenticationToken(user, user.getPassword(), authorities);
+	}
+
 	private static Cookie createCookie(long expiryTime, String username) {
 		return createCookie(expiryTime, username, AccountRememberMeServices.KEY);
+	}
+
+	private static Cookie createCookie(long issuedTime, long expiryTime, String username) {
+		return createCookie(issuedTime, expiryTime, username, AccountRememberMeServices.KEY, AccountRememberMeServices.DIGEST_ALGORITHM);
 	}
 
 	private static Cookie createCookie(long expiryTime, String username, String key) {
@@ -315,8 +345,12 @@ class AccountRememberMeServicesTest {
 	}
 
 	private static Cookie createCookie(long expiryTime, String username, String key, String algorithm) {
-		final String signature = AccountRememberMeServices.generateSignature(username, expiryTime, key, algorithm);
-		return createCookie(encode(username + ":" + expiryTime + ":" + signature));
+		return createCookie(System.currentTimeMillis(), expiryTime, username, key, algorithm);
+	}
+
+	private static Cookie createCookie(long issuedTime, long expiryTime, String username, String key, String algorithm) {
+		final String signature = AccountRememberMeServices.generateSignature(username, "factor", issuedTime, expiryTime, key, algorithm);
+		return createCookie(encode(username + ":factor:" + issuedTime + ":" + expiryTime + ":" + signature));
 	}
 
 	private static Cookie createCookie(String value) {

--- a/konfigyr-jooq-extensions/src/main/java/com/konfigyr/jooq/KonfigyrDatabase.java
+++ b/konfigyr-jooq-extensions/src/main/java/com/konfigyr/jooq/KonfigyrDatabase.java
@@ -39,7 +39,7 @@ public class KonfigyrDatabase extends PostgresDatabase {
 
 	private static final String CHANGELOG = "src/main/resources/migrations";
 	private static final String CHANGELOG_NAME = "changelog.xml";
-	private static final String POSTGRESQL_IMAGE = "postgres:17.2-alpine";
+	private static final String POSTGRESQL_IMAGE = "postgres:18-alpine";
 
 	private final JooqLogger logger = JooqLogger.getLogger(KonfigyrDatabase.class);
 	private final File changelogs;

--- a/konfigyr-test/src/main/java/com/konfigyr/test/TestContainers.java
+++ b/konfigyr-test/src/main/java/com/konfigyr/test/TestContainers.java
@@ -23,7 +23,7 @@ public interface TestContainers {
 	 */
 	@Container
 	@ServiceConnection
-	PostgreSQLContainer postresql = new PostgreSQLContainer("postgres:16.2")
+	PostgreSQLContainer postresql = new PostgreSQLContainer("postgres:18-alpine")
 			.withDatabaseName("konfigyr");
 
 }


### PR DESCRIPTION
- **PostgreSQL 18**: Bump test containers and jOOQ code-generation image from `postgres:16.2`/`postgres:17.2-alpine` to `postgres:18-alpine`                                                                                                                                         
- **UUIDv7 migration**: Replace `gen_random_uuid()` with PG18-native `uuidv7()` for `audit_events.id` and `vault_change_request_events.id`; migrate `vault_change_history.id` from `bigint` to `uuid` with DB-side `uuidv7()` generation; update `vault_property_history.change_id` foreign key from `bigint` to `uuid`                                                                                                                                                                                                                                                    
- **Cursor token update**: `HistoryCursorToken` encoding widened from 18 to 26 bytes to hold UUID most/least significant bits instead of a long                                                                                                                                      
- **Spring Boot 4.0.6**: Bump Spring Boot (4.0.5 → 4.0.6), Spring Modulith (2.0.3 → 2.0.6), Lombok plugin (9.2.0 → 9.4.0)                                                                                                                                                            
- **FactorGrantedAuthority**: `OidcAccountIdentityUser` now creates and exposes a `FactorGrantedAuthority` for the authorization code factor; `AccountRememberMeServices` cookie expanded from 3 to 5 tokens (adds factor authority + issued time) with updated signature generation and extraction on remember-me authentication                                                                                                                                                                                                                                           