### PR TITLE
Markdown support in change history

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -17,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.springframework.context.event.EventListener;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 
@@ -261,7 +262,8 @@ class AuditEventListener {
 		);
 	}
 
-	@TransactionalEventListener(id = "audit.changes-applied", classes = VaultEvent.ChangesApplied.class)
+	// the VaultEvent.ChangesApplied event is never published within a transaction
+	@EventListener(id = "audit.changes-applied", classes = VaultEvent.ChangesApplied.class)
 	void on(VaultEvent.ChangesApplied event) {
 		insert(event, builder -> builder
 				.entityType("profile")

--- a/konfigyr-api/src/main/java/com/konfigyr/markdown/MarkdownContents.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/markdown/MarkdownContents.java
@@ -2,7 +2,9 @@ package com.konfigyr.markdown;
 
 import com.konfigyr.io.ByteArray;
 import lombok.EqualsAndHashCode;
+import org.apache.commons.lang3.StringUtils;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 import java.nio.charset.StandardCharsets;
@@ -65,6 +67,19 @@ public final class MarkdownContents implements CharSequence {
 
 		this.value = value;
 		this.checksum = checksum;
+	}
+
+	/**
+	 * Creates a new {@code MarkdownContents} from the given raw Markdown string. In case the given
+	 * Markdown string is be {@code null} or blank, this method returns {@code null}.
+	 *
+	 * @param value the raw Markdown string; can be {@code null}
+	 * @return a new {@code MarkdownContents} instance or {@code null} if {@code value} is {@code null} or blank
+	 * @throws IllegalStateException if the {@code SHA-256} digest algorithm is not supported
+	 */
+	@Nullable
+	public static MarkdownContents ofNullable(@Nullable String value) {
+		return StringUtils.isBlank(value) ? null : of(value);
 	}
 
 	/**

--- a/konfigyr-api/src/main/java/com/konfigyr/markdown/MarkdownModule.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/markdown/MarkdownModule.java
@@ -80,7 +80,7 @@ class MarkdownModule extends SimpleModule {
 		@Override
 		public MarkdownContents deserialize(JsonParser parser, DeserializationContext ctx) throws JacksonException {
 			if (parser.currentToken() == JsonToken.VALUE_STRING) {
-				return MarkdownContents.of(parser.getValueAsString());
+				return MarkdownContents.ofNullable(parser.getValueAsString());
 			}
 
 			if (parser.currentToken() == JsonToken.START_OBJECT) {
@@ -96,7 +96,7 @@ class MarkdownModule extends SimpleModule {
 				}
 
 				if (markdown != null) {
-					return MarkdownContents.of(markdown);
+					return MarkdownContents.ofNullable(markdown);
 				}
 			}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/ChangeHistory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/ChangeHistory.java
@@ -1,7 +1,9 @@
 package com.konfigyr.vault;
 
+import com.konfigyr.markdown.MarkdownContents;
 import org.jmolecules.ddd.annotation.ValueObject;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 import java.time.OffsetDateTime;
@@ -35,7 +37,7 @@ public record ChangeHistory(
 		String id,
 		String revision,
 		String subject,
-		String description,
+		@Nullable MarkdownContents description,
 		int count,
 		String appliedBy,
 		OffsetDateTime appliedAt

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/history/ChangeHistoryService.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/history/ChangeHistoryService.java
@@ -6,6 +6,7 @@ import com.konfigyr.data.Routines;
 import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.io.ByteArray;
+import com.konfigyr.markdown.MarkdownContents;
 import com.konfigyr.security.AuthenticatedPrincipal;
 import com.konfigyr.vault.*;
 import lombok.RequiredArgsConstructor;
@@ -36,6 +37,7 @@ public class ChangeHistoryService implements VaultChronicle {
 			VAULT_CHANGE_HISTORY.REVISION,
 			VAULT_CHANGE_HISTORY.SUBJECT,
 			VAULT_CHANGE_HISTORY.DESCRIPTION,
+			VAULT_CHANGE_HISTORY.DESCRIPTION_CHECKSUM,
 			VAULT_CHANGE_HISTORY.CHANGE_COUNT,
 			VAULT_CHANGE_HISTORY.AUTHOR_NAME,
 			VAULT_CHANGE_HISTORY.CREATED_AT
@@ -76,6 +78,7 @@ public class ChangeHistoryService implements VaultChronicle {
 	void commit(EntityId profile, ApplyResult result) {
 		final ChangeHistoryOwnership ownership = lookupOwnership(profile);
 		final AuthenticatedPrincipal author = result.author();
+		final MarkdownContents description = MarkdownContents.ofNullable(result.description());
 
 		final UUID id = context.insertInto(VAULT_CHANGE_HISTORY)
 				.set(
@@ -84,7 +87,8 @@ public class ChangeHistoryService implements VaultChronicle {
 								.set(VAULT_CHANGE_HISTORY.SERVICE_ID, ownership.service())
 								.set(VAULT_CHANGE_HISTORY.PROFILE_ID, ownership.profile())
 								.set(VAULT_CHANGE_HISTORY.SUBJECT, result.subject())
-								.set(VAULT_CHANGE_HISTORY.DESCRIPTION, result.description())
+								.set(VAULT_CHANGE_HISTORY.DESCRIPTION, description, MarkdownContents::value)
+								.set(VAULT_CHANGE_HISTORY.DESCRIPTION_CHECKSUM, description, MarkdownContents::checksum)
 								.set(VAULT_CHANGE_HISTORY.CHANGE_COUNT, result.changes().size())
 								.set(VAULT_CHANGE_HISTORY.AUTHOR_ID, author.get())
 								.set(VAULT_CHANGE_HISTORY.AUTHOR_TYPE, author.getType().name())
@@ -339,11 +343,21 @@ public class ChangeHistoryService implements VaultChronicle {
 	}
 
 	private static ChangeHistory toChangeHistory(Record record) {
+		MarkdownContents description = null;
+
+		if (record.get(VAULT_CHANGE_HISTORY.DESCRIPTION) != null
+				&& record.get(VAULT_CHANGE_HISTORY.DESCRIPTION_CHECKSUM) != null) {
+			description = new MarkdownContents(
+					record.get(VAULT_CHANGE_HISTORY.DESCRIPTION),
+					record.get(VAULT_CHANGE_HISTORY.DESCRIPTION_CHECKSUM)
+			);
+		}
+
 		return new ChangeHistory(
 				record.get(VAULT_CHANGE_HISTORY.ID, String.class),
 				record.get(VAULT_CHANGE_HISTORY.REVISION),
 				record.get(VAULT_CHANGE_HISTORY.SUBJECT),
-				record.get(VAULT_CHANGE_HISTORY.DESCRIPTION),
+				description,
 				record.get(VAULT_CHANGE_HISTORY.CHANGE_COUNT),
 				record.get(VAULT_CHANGE_HISTORY.AUTHOR_NAME),
 				record.get(VAULT_CHANGE_HISTORY.CREATED_AT)

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerCoverageTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerCoverageTest.java
@@ -5,9 +5,10 @@ import org.jmolecules.event.annotation.DomainEvent;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.annotation.MergedAnnotations;
 import org.springframework.core.type.filter.AnnotationTypeFilter;
 import org.springframework.core.type.filter.AssignableTypeFilter;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -70,14 +71,15 @@ class AuditEventListenerCoverageTest {
 	}
 
 	/**
-	 * Collects all event classes referenced in {@link TransactionalEventListener#classes()}
+	 * Collects all event classes referenced in {@link EventListener#classes()}
 	 * annotations on methods of {@link AuditEventListener}.
 	 */
 	private static Set<Class<?>> findAuditedEventClasses() {
 		return Arrays.stream(AuditEventListener.class.getDeclaredMethods())
-				.filter(method -> method.isAnnotationPresent(TransactionalEventListener.class))
-				.map(method -> method.getAnnotation(TransactionalEventListener.class))
-				.flatMap(annotation -> Arrays.stream(annotation.classes()))
+				.map(MergedAnnotations::from)
+				.filter(annotations -> annotations.isPresent(EventListener.class))
+				.map(annotations -> annotations.get(EventListener.class))
+				.flatMap(annotation -> Arrays.stream(annotation.getClassArray("classes")))
 				.collect(Collectors.toSet());
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/markdown/MarkdownModuleTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/markdown/MarkdownModuleTest.java
@@ -1,5 +1,6 @@
 package com.konfigyr.markdown;
 
+import com.konfigyr.io.ByteArray;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,12 +24,21 @@ class MarkdownModuleTest {
 				.isEqualTo("{\"markdown\":\"# Hello world\",\"html\":\"<h1>Hello world</h1>\\n\"}");
 	}
 
-	@ValueSource(strings = { "", " ", "  ", "# Hello world" })
+	@ValueSource(strings = { "\"\"", "\" \"", "\"  \"", "\"\\n\"", "\"\\t\\n\"", "{\"markdown\": \" \"}"})
+	@DisplayName("should not deserialize empty or blank markdown contents")
+	@ParameterizedTest(name = "should not deserialize markdown contents: {0}")
+	void deserializeEmptyMarkdownContents(String json) {
+		assertThat(mapper.readValue(json, MarkdownContents.class))
+				.as("Blank markdown contents should be ignored")
+				.isNull();
+	}
+
+	@Test
 	@DisplayName("should deserialize markdown contents")
-	@ParameterizedTest(name = "should deserialize markdown contents: {0}")
-	void deserializeMarkdown(String markdown) {
-		assertThat(mapper.readValue(StringNode.valueOf(markdown).toString(), MarkdownContents.class))
-				.isEqualTo(MarkdownContents.of(markdown));
+	void deserializeMarkdown() {
+		assertThat(mapper.readValue(StringNode.valueOf("# Hello world").toString(), MarkdownContents.class))
+				.isEqualTo(new MarkdownContents("# Hello world",
+						ByteArray.fromBase64String("DBhrmNU1qJf6XV1gfLxwmLHQNtQylWkCOv5FWbbJc2I=")));
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/history/ChangeHistoryServiceTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/history/ChangeHistoryServiceTest.java
@@ -4,6 +4,7 @@ import com.konfigyr.data.CursorPage;
 import com.konfigyr.data.CursorPageable;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.io.ByteArray;
+import com.konfigyr.markdown.MarkdownContents;
 import com.konfigyr.security.AuthenticatedPrincipal;
 import com.konfigyr.test.AbstractIntegrationTest;
 import com.konfigyr.test.TestPrincipals;
@@ -70,9 +71,9 @@ class ChangeHistoryServiceTest extends AbstractIntegrationTest {
 				.as("Created revision should exist for profile")
 				.isPresent()
 				.get()
-				.returns(result.revision(), ChangeHistory::revision)
-				.returns(result.subject(), ChangeHistory::subject)
-				.returns(result.description(), ChangeHistory::description)
+				.returns("new-revision", ChangeHistory::revision)
+				.returns("Subject of changes", ChangeHistory::subject)
+				.returns(MarkdownContents.of("Description of changes"), ChangeHistory::description)
 				.returns("John Doe", ChangeHistory::appliedBy)
 				.satisfies(it -> assertThat(it.appliedAt())
 						.isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.SECONDS))
@@ -252,7 +253,7 @@ class ChangeHistoryServiceTest extends AbstractIntegrationTest {
 				.returns("019690a1-0008-7000-8000-000000000008", ChangeHistory::id)
 				.returns("first-revision", ChangeHistory::revision)
 				.returns("First change", ChangeHistory::subject)
-				.returns("Initial changes", ChangeHistory::description)
+				.returns(MarkdownContents.of("Initial changes"), ChangeHistory::description)
 				.returns("John Doe", ChangeHistory::appliedBy)
 				.satisfies(it -> assertThat(it.appliedAt())
 						.isCloseTo(OffsetDateTime.now().minusDays(2), within(5, ChronoUnit.MINUTES))

--- a/konfigyr-api/src/test/resources/data/vault.sql
+++ b/konfigyr-api/src/test/resources/data/vault.sql
@@ -12,16 +12,16 @@ SELECT create_change_history_partition(now() - interval '2 month');
 SELECT create_property_history_partition(now() - interval '1 month');
 SELECT create_property_history_partition(now() - interval '2 month');
 
-INSERT INTO vault_change_history(id, namespace_id, service_id, profile_id, revision, previous_revision, subject, description, change_count, author_id, author_type, author_name, created_at) VALUES
-('019690a1-0001-7000-8000-000000000001', 2, 2, 4, 'first-revision', NULL, 'First change', 'Initial changes', 1, 1, 'USER', 'John Doe', now() - interval '34 days'),
-('019690a1-0002-7000-8000-000000000002', 2, 2, 4, 'second-revision', 'first-revision', 'Second change', NULL, 2, 2, 'USER', 'Jane Doe', now() - interval '27 days'),
-('019690a1-0003-7000-8000-000000000003', 2, 2, 4, 'third-revision', 'second-revision', 'Third change', NULL, 1, 1, 'USER', 'John Doe', now() - interval '18 days'),
-('019690a1-0004-7000-8000-000000000004', 2, 2, 4, 'fourth-revision', 'third-revision', 'Fourth change', 'A while longer...', 1, 1, 'USER', 'John Doe', now() - interval '12 days'),
-('019690a1-0005-7000-8000-000000000005', 2, 2, 4, 'fifth-revision', 'fourth-revision', 'Fifth change', NULL, 1, 2, 'OAUTH_CLIENT', 'Konfigyr active app', now() - interval '9 days'),
-('019690a1-0006-7000-8000-000000000006', 2, 2, 4, 'sixth-revision', 'fifth-revision', 'Sixth change', 'The next one does it...', 1, 1, 'USER', 'John Doe', now() - interval '3 days'),
-('019690a1-0007-7000-8000-000000000007', 2, 2, 4, 'last-revision', 'sixth-revision', 'Last change', 'Got no more', 1, 1, 'USER', 'John Doe', now() - interval '2 days'),
-('019690a1-0008-7000-8000-000000000008', 2, 2, 3, 'first-revision', NULL, 'First change', 'Initial changes', 1, 1, 'USER', 'John Doe', now() - interval '2 days'),
-('019690a1-0009-7000-8000-000000000009', 1, 1, 5, 'first-revision', NULL, 'Testing', NULL, 1, 1, 'USER', 'John Doe', now() - interval '7 days');
+INSERT INTO vault_change_history(id, namespace_id, service_id, profile_id, revision, previous_revision, subject, description, description_checksum, change_count, author_id, author_type, author_name, created_at) VALUES
+('019690a1-0001-7000-8000-000000000001', 2, 2, 4, 'first-revision', NULL, 'First change', 'Initial changes', decode('+vp2HL1n71E4qQdvy4P+L7lgozAKaZOk/1CIkSYx9tw=', 'base64'), 1, 1, 'USER', 'John Doe', now() - interval '34 days'),
+('019690a1-0002-7000-8000-000000000002', 2, 2, 4, 'second-revision', 'first-revision', 'Second change', NULL, NULL, 2, 2, 'USER', 'Jane Doe', now() - interval '27 days'),
+('019690a1-0003-7000-8000-000000000003', 2, 2, 4, 'third-revision', 'second-revision', 'Third change', NULL, NULL, 1, 1, 'USER', 'John Doe', now() - interval '18 days'),
+('019690a1-0004-7000-8000-000000000004', 2, 2, 4, 'fourth-revision', 'third-revision', 'Fourth change', 'A while longer...', decode('n7K0v18UUdlyQG739xqJ4qEa6vS4GCntEwSOUEqtdig=', 'base64'), 1, 1, 'USER', 'John Doe', now() - interval '12 days'),
+('019690a1-0005-7000-8000-000000000005', 2, 2, 4, 'fifth-revision', 'fourth-revision', 'Fifth change', NULL, NULL, 1, 2, 'OAUTH_CLIENT', 'Konfigyr active app', now() - interval '9 days'),
+('019690a1-0006-7000-8000-000000000006', 2, 2, 4, 'sixth-revision', 'fifth-revision', 'Sixth change', 'The next one does it...', decode('Y886gTHHWnEKsEjQiLagysjIFF/ElUg+23HU2PtbGJs=', 'base64'), 1, 1, 'USER', 'John Doe', now() - interval '3 days'),
+('019690a1-0007-7000-8000-000000000007', 2, 2, 4, 'last-revision', 'sixth-revision', 'Last change', 'Got no more', decode('PMH/bdTmnnI5KoOb3epBwfOiF6/oynAfDCGRmSqHON8=', 'base64'), 1, 1, 'USER', 'John Doe', now() - interval '2 days'),
+('019690a1-0008-7000-8000-000000000008', 2, 2, 3, 'first-revision', NULL, 'First change', 'Initial changes', decode('+vp2HL1n71E4qQdvy4P+L7lgozAKaZOk/1CIkSYx9tw=', 'base64'), 1, 1, 'USER', 'John Doe', now() - interval '2 days'),
+('019690a1-0009-7000-8000-000000000009', 1, 1, 5, 'first-revision', NULL, 'Testing', NULL, NULL, 1, 1, 'USER', 'John Doe', now() - interval '7 days');
 
 INSERT INTO vault_property_history(change_id, profile_id, property_name, change_operation, new_value_checksum, new_value_cipher, old_value_checksum, old_value_cipher, created_at) VALUES
 ('019690a1-0001-7000-8000-000000000001', 4, 'spring.application.name', 'ADDED', '1234567890', '1234567890', NULL, NULL, now() - interval '34 days'),

--- a/konfigyr-data/src/main/resources/migrations/vault/vault-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/vault/vault-1.0.0.xml
@@ -111,6 +111,10 @@
 				<constraints nullable="true"/>
 			</column>
 
+			<column name="description_checksum" type="bytea">
+				<constraints nullable="true"/>
+			</column>
+
 			<column name="change_count" type="integer">
 				<constraints nullable="false" />
 			</column>

--- a/konfigyr-frontend/src/components/vault/change-history/change-history-sidebar.tsx
+++ b/konfigyr-frontend/src/components/vault/change-history/change-history-sidebar.tsx
@@ -9,6 +9,7 @@ import { MissingPropertyDescriptionLabel } from '@konfigyr/components/artifactor
 import { RelativeDate } from '@konfigyr/components/messages/relative-date';
 import { ChangesCountLabel } from '@konfigyr/components/vault/messages';
 import { Badge } from '@konfigyr/components/ui/badge';
+import { HtmlContents } from '@konfigyr/components/ui/content';
 import {
   Sheet,
   SheetContent,
@@ -40,9 +41,21 @@ export interface ChangeHistorySidebar {
   profile: Profile;
 }
 
+function ChangeHistoryDescription({ history }: { history: ChangeHistory }) {
+  if (history.description && history.description.html) {
+    return (
+      <HtmlContents html={history.description.html} />
+    );
+  }
+
+  return (
+    <MissingPropertyDescriptionLabel />
+  );
+}
+
 function ChangeHistoryTimestamp({ history }: { history: ChangeHistory }) {
   return (
-    <>
+    <p>
       <FormattedDate
         value={history.appliedAt}
         year="numeric"
@@ -55,7 +68,7 @@ function ChangeHistoryTimestamp({ history }: { history: ChangeHistory }) {
       <small className="text-xs text-muted-foreground ml-1">
         (<RelativeDate value={history.appliedAt} />)
       </small>
-    </>
+    </p>
   );
 }
 
@@ -65,9 +78,9 @@ function ChangeHistoryStat({ label, value }: { label: ReactNode, value: ReactNod
       <p className="text-xs font-heading font-medium text-muted-foreground">
         {label}
       </p>
-      <p className="text-sm text-foreground">
+      <div className="text-sm text-foreground">
         {value}
-      </p>
+      </div>
     </div>
   );
 }
@@ -178,7 +191,7 @@ export function ChangeHistorySidebar({
                   description="Label for the description of a change history record"
                 />
               }
-              value={history.description ?? <MissingPropertyDescriptionLabel />}
+              value={<ChangeHistoryDescription history={history} />}
             />
 
             <div className="flex justify-between items-center">

--- a/konfigyr-frontend/src/components/vault/change-request/change-request-timeline.tsx
+++ b/konfigyr-frontend/src/components/vault/change-request/change-request-timeline.tsx
@@ -146,7 +146,7 @@ function ChangeRequestTimelineItem({ history, isLast }: { history: ChangeRequest
         <div className="flex items-baseline justify-between gap-2 text-xs">
           <span><ChangeRequestTimelineSummary history={history} /></span>
         </div>
-        {history.comment && (
+        {history.comment && history.comment.html && (
           <div className="px-4 py-2 mt-2 rounded-md border text-sm">
             <HtmlContents html={history.comment.html} />
           </div>

--- a/konfigyr-frontend/src/hooks/vault/types.ts
+++ b/konfigyr-frontend/src/hooks/vault/types.ts
@@ -180,7 +180,7 @@ export interface ChangeHistory {
   id: string;
   revision: string;
   subject: string;
-  description?: string;
+  description?: MarkdownContents;
   count: number;
   appliedBy: string;
   appliedAt: string;

--- a/konfigyr-frontend/test/components/vault/change-history/change-history-sidebar.test.tsx
+++ b/konfigyr-frontend/test/components/vault/change-history/change-history-sidebar.test.tsx
@@ -8,7 +8,10 @@ const history = {
   id: 'first-change',
   revision: '9eadce4691d8fcd863aeeb07ef81d8146083d814',
   subject: 'First change',
-  description: 'The first change to the configuration',
+  description: {
+    markdown: 'The **first change** to the *configuration*',
+    html: 'The first change to the configuration',
+  },
   count: 2,
   appliedBy: 'John Doe',
   appliedAt: new Date(Date.now() - 1000 * 60 * 60 * 3).toISOString(),
@@ -43,7 +46,7 @@ describe('components | vault | change-history | <ChangeHistorySidebar/>', () => 
 
     expect(getByRole('dialog', { name: history.subject })).toBeInTheDocument();
     expect(getByText(history.revision)).toBeInTheDocument();
-    expect(getByText(history.description)).toBeInTheDocument();
+    expect(getByText(history.description.html)).toBeInTheDocument();
     expect(getByText(history.appliedBy)).toBeInTheDocument();
   });
 

--- a/konfigyr-frontend/test/helpers/server/vault.ts
+++ b/konfigyr-frontend/test/helpers/server/vault.ts
@@ -11,6 +11,8 @@ import {
   services,
 } from '../mocks';
 
+import type { ChangeHistory, ChangeHistoryRecord, CursorResponse, PageResponse } from '@konfigyr/hooks/types';
+
 const getProfiles = http.get('http://localhost/api/namespaces/:namespace/services/:service/profiles', ({ params }) => {
   const { namespace, service } = params;
 
@@ -267,8 +269,11 @@ const getHistory = http.get('http://localhost/api/namespaces/:namespace/services
       id: '9eadce4691d8fcd863aeeb07ef81d8146083d814',
       revision: '9eadce4691d8fcd863aeeb07ef81d8146083d814',
       subject: 'Changeset draft',
-      description: 'Changeset draft',
-      changes: 4,
+      description: {
+        markdown: 'Changeset draft',
+        html: 'Changeset draft',
+      },
+      count: 4,
       appliedBy: 'Test User <test.user@ebf.com>',
       appliedAt,
     }],
@@ -277,7 +282,7 @@ const getHistory = http.get('http://localhost/api/namespaces/:namespace/services
       previous: uri.searchParams.has('token') && 'previous-token',
       next: 'next-token',
     },
-  });
+  } as CursorResponse<ChangeHistory>);
 });
 
 const getHistoryDetails = http.get('http://localhost/api/namespaces/:namespace/services/:service/profiles/:profile/history/:revision', ({ params }) => {
@@ -343,7 +348,7 @@ const getHistoryDetails = http.get('http://localhost/api/namespaces/:namespace/s
       appliedAt: new Date(Date.now() - 1000 * 60 * 12).toISOString(),
       appliedBy: 'jane.doe@konfigyr.com',
     }],
-  });
+  } as PageResponse<ChangeHistoryRecord>);
 });
 
 const getPropertyHistory = http.get('http://localhost/api/namespaces/:namespace/services/:service/profiles/:profile/property/:name/history', ({ params, request }) => {
@@ -407,7 +412,7 @@ const getPropertyHistory = http.get('http://localhost/api/namespaces/:namespace/
       previous: uri.searchParams.has('token') && 'previous-token',
       next: 'next-token',
     },
-  });
+  } as CursorResponse<ChangeHistoryRecord>);
 });
 
 export default [


### PR DESCRIPTION
This includes a bugfix for the Vault changes applied audit event listener. This event is never triggered from within a DB transaction