### PR TITLE
Improve telemetry

### DIFF
--- a/konfigyr-api/build.gradle
+++ b/konfigyr-api/build.gradle
@@ -52,3 +52,7 @@ dependencies {
     testImplementation 'org.wiremock.integrations:wiremock-spring-boot'
     testImplementation 'org.springframework.boot:spring-boot-starter-batch-jdbc-test'
 }
+
+springBoot {
+    buildInfo()
+}

--- a/konfigyr-api/build.gradle
+++ b/konfigyr-api/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(':konfigyr-mail')
 
     /* Spring Boot starter */
+    implementation 'org.springframework.boot:spring-boot-starter-aspectj'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-batch-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-security-oauth2-resource-server'
@@ -22,6 +23,7 @@ dependencies {
 
     /* Tracing and observability */
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-opentelemetry'
     implementation 'io.micrometer:micrometer-observation'
 
     /* Spring Common libraries */
@@ -51,6 +53,7 @@ dependencies {
     testImplementation 'com.icegreen:greenmail'
     testImplementation 'org.wiremock.integrations:wiremock-spring-boot'
     testImplementation 'org.springframework.boot:spring-boot-starter-batch-jdbc-test'
+    testImplementation 'org.springframework.boot:spring-boot-starter-micrometer-metrics-test'
 }
 
 springBoot {

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactCoordinates.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactCoordinates.java
@@ -2,7 +2,8 @@ package com.konfigyr.artifactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.konfigyr.version.Version;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 import java.io.Serializable;
 
@@ -16,23 +17,90 @@ import java.io.Serializable;
  * @author Vladimir Spasic
  * @since 1.0.0
  */
+@NullMarked
 public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Serializable {
 
+	/**
+	 * Parses the given textual representation of Maven coordinates and creates an
+	 * {@link ArtifactCoordinates} instance.
+	 * <p>
+	 * The expected format is {@code groupId:artifactId:version}.
+	 *
+	 * @param coordinates the textual representation of the coordinates to parse, can be {@literal null}
+	 * @return the parsed artifact coordinates, never {@literal null}
+	 * @throws IllegalArgumentException if the coordinates string is invalid or cannot be parsed
+	 */
 	@JsonCreator
-	static ArtifactCoordinates parse(String coordinates) {
+	static ArtifactCoordinates parse(@Nullable String coordinates) {
 		return SimpleArtifactCoordinates.parse(coordinates);
 	}
 
+	/**
+	 * Creates an {@link ArtifactCoordinates} instance from the given {@link Artifact}.
+	 *
+	 * @param artifact the artifact from which to extract coordinates, can't be {@literal null}
+	 * @return the artifact coordinates, never {@literal null}
+	 */
 	static ArtifactCoordinates of(Artifact artifact) {
 		return new SimpleArtifactCoordinates(artifact.groupId(), artifact.artifactId(), artifact.version());
 	}
 
+	/**
+	 * Creates an {@link ArtifactCoordinates} instance from the given Maven coordinate components.
+	 *
+	 * @param groupId    the group identifier, can't be {@literal null}
+	 * @param artifactId the artifact identifier, can't be {@literal null}
+	 * @param version    the version as a string, can't be {@literal null}
+	 * @return the artifact coordinates, never {@literal null}
+	 */
 	static ArtifactCoordinates of(String groupId, String artifactId, String version) {
 		return new SimpleArtifactCoordinates(groupId, artifactId, version);
 	}
 
+	/**
+	 * Creates an {@link ArtifactCoordinates} instance from the given Maven coordinate components.
+	 *
+	 * @param groupId    the group identifier, can't be {@literal null}
+	 * @param artifactId the artifact identifier, can't be {@literal null}
+	 * @param version    the version object, can't be {@literal null}
+	 * @return the artifact coordinates, never {@literal null}
+	 */
 	static ArtifactCoordinates of(String groupId, String artifactId, Version version) {
 		return new SimpleArtifactCoordinates(groupId, artifactId, version);
+	}
+
+	/**
+	 * Formats the given {@link Artifact} into a textual representation of Maven coordinates.
+	 *
+	 * @param artifact the artifact to format, can't be {@literal null}
+	 * @return the formatted coordinates string in the format {@code groupId:artifactId:version}, never {@literal null}
+	 */
+	static String format(Artifact artifact) {
+		return format(artifact.groupId(), artifact.artifactId(), artifact.version());
+	}
+
+	/**
+	 * Formats the given Maven coordinate components into a textual representation.
+	 *
+	 * @param groupId    the group identifier, can't be {@literal null}
+	 * @param artifactId the artifact identifier, can't be {@literal null}
+	 * @param version    the version as a string, can't be {@literal null}
+	 * @return the formatted coordinates string in the format {@code groupId:artifactId:version}, never {@literal null}
+	 */
+	static String format(String groupId, String artifactId, String version) {
+		return String.format("%s:%s:%s", groupId, artifactId, version);
+	}
+
+	/**
+	 * Formats the given Maven coordinate components into a textual representation.
+	 *
+	 * @param groupId    the group identifier, can't be {@literal null}
+	 * @param artifactId the artifact identifier, can't be {@literal null}
+	 * @param version    the version object, can't be {@literal null}
+	 * @return the formatted coordinates string in the format {@code groupId:artifactId:version}, never {@literal null}
+	 */
+	static String format(String groupId, String artifactId, Version version) {
+		return format(groupId, artifactId, version.get());
 	}
 
 	/**
@@ -43,7 +111,7 @@ public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Se
 	 * @return a negative integer, zero, or a positive integer as the first coordinates are less than, equal to,
 	 * or greater than the second.
 	 */
-	static int compare(@NonNull ArtifactCoordinates a, @NonNull ArtifactCoordinates b) {
+	static int compare(ArtifactCoordinates a, ArtifactCoordinates b) {
 		return SimpleArtifactCoordinates.COMPARATOR.compare(a, b);
 	}
 
@@ -52,7 +120,6 @@ public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Se
 	 *
 	 * @return the {@code groupId} Maven coordinate, can't be {@literal null}
 	 */
-	@NonNull
 	String groupId();
 
 	/**
@@ -60,7 +127,6 @@ public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Se
 	 *
 	 * @return the {@code artifactId} Maven coordinate, can't be {@literal null}
 	 */
-	@NonNull
 	String artifactId();
 
 	/**
@@ -68,7 +134,6 @@ public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Se
 	 *
 	 * @return the {@code version} Maven coordinate, can't be {@literal null}
 	 */
-	@NonNull
 	Version version();
 
 	/**
@@ -76,13 +141,12 @@ public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Se
 	 *
 	 * @return the textual representation for the coordinates, can't be {@literal null}
 	 */
-	@NonNull
 	default String format() {
-		return String.format("%s:%s:%s", groupId(), artifactId(), version().get());
+		return format(groupId(), artifactId(), version());
 	}
 
 	@Override
-	default int compareTo(@NonNull ArtifactCoordinates o) {
+	default int compareTo(ArtifactCoordinates o) {
 		return compare(this, o);
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryAutoConfiguration.java
@@ -31,6 +31,7 @@ public class ArtifactoryAutoConfiguration implements WebMvcConfigurer {
 		registry.addConverter(Version.class, String.class, Version::toString);
 		registry.addConverter(String.class, ArtifactCoordinates.class, ArtifactCoordinates::parse);
 		registry.addConverter(ArtifactCoordinates.class, String.class, ArtifactCoordinates::toString);
+		registry.addConverter(Artifact.class, String.class, ArtifactCoordinates::format);
 	}
 
 	@Bean

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
@@ -5,6 +5,7 @@ import com.konfigyr.data.Keys;
 import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.io.ByteArray;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.output.ByteArrayOutputStream;
@@ -79,6 +80,7 @@ class DefaultArtifactory implements Artifactory {
 	}
 
 	@Override
+	@Observed(name = "artifactory.release")
 	@Transactional(label = "artifactory.release-artifact-component")
 	public VersionedArtifact release(@NonNull ArtifactMetadata metadata) {
 		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(metadata);

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
@@ -5,6 +5,7 @@ import com.konfigyr.data.Keys;
 import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.io.ByteArray;
+import io.micrometer.observation.annotation.ObservationKeyValue;
 import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -80,9 +81,13 @@ class DefaultArtifactory implements Artifactory {
 	}
 
 	@Override
-	@Observed(name = "artifactory.release")
+	@Observed(name = "konfigyr.artifactory.release")
 	@Transactional(label = "artifactory.release-artifact-component")
-	public VersionedArtifact release(@NonNull ArtifactMetadata metadata) {
+	public VersionedArtifact release(
+			@NonNull
+			@ObservationKeyValue(key = "konfigyr.artifactory.artifact", expression = "#this")
+			ArtifactMetadata metadata
+	) {
 		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(metadata);
 
 		if (exists(coordinates)) {

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/provenance/DefaultProvenanceEvaluator.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/provenance/DefaultProvenanceEvaluator.java
@@ -5,6 +5,8 @@ import com.konfigyr.artifactory.VersionedArtifact;
 import com.konfigyr.artifactory.digest.PropertyDescriptorChecksumGenerator;
 import com.konfigyr.io.ByteArray;
 import com.konfigyr.version.Version;
+import io.micrometer.observation.annotation.ObservationKeyValue;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -76,8 +78,12 @@ public class DefaultProvenanceEvaluator implements ProvenanceEvaluator {
 
 	@NonNull
 	@Override
+	@Observed(name = "konfigyr.artifactory.provenance-evaluation")
 	@Transactional(readOnly = true, label = "provenance-evaluator.evaluate", isolation = Isolation.SERIALIZABLE)
-	public EvaluationResult evaluate(@NonNull VersionedArtifact version, @NonNull PropertyDescriptor property) {
+	public EvaluationResult evaluate(
+			@NonNull @ObservationKeyValue(key = "artifact", expression = "#version.coordinates().format()") VersionedArtifact version,
+			@NonNull @ObservationKeyValue(key = "property", expression = "#property.name()") PropertyDescriptor property
+	) {
 		final ByteArray checksum = generator.generate(property);
 
 		log.debug("Evaluating provenance for artifact version '{}' and property '[name={}, checksum={}]'",

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/provenance/DefaultProvenanceEvaluator.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/provenance/DefaultProvenanceEvaluator.java
@@ -81,8 +81,8 @@ public class DefaultProvenanceEvaluator implements ProvenanceEvaluator {
 	@Observed(name = "konfigyr.artifactory.provenance-evaluation")
 	@Transactional(readOnly = true, label = "provenance-evaluator.evaluate", isolation = Isolation.SERIALIZABLE)
 	public EvaluationResult evaluate(
-			@NonNull @ObservationKeyValue(key = "artifact", expression = "#version.coordinates().format()") VersionedArtifact version,
-			@NonNull @ObservationKeyValue(key = "property", expression = "#property.name()") PropertyDescriptor property
+			@NonNull @ObservationKeyValue(key = "konfigyr.artifactory.artifact", expression = "coordinates") VersionedArtifact version,
+			@NonNull @ObservationKeyValue(key = "konfigyr.artifactory.property", expression = "name") PropertyDescriptor property
 	) {
 		final ByteArray checksum = generator.generate(property);
 

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditAutoConfiguration.java
@@ -1,6 +1,7 @@
 package com.konfigyr.audit;
 
 import com.konfigyr.entity.EntityId;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -52,8 +53,12 @@ public class AuditAutoConfiguration {
 	}
 
 	@Bean
-	AuditEventListener auditEventListener(AuditEventListener.NamespaceResolver resolver, AuditEventRepository repository) {
-		return new AuditEventListener(resolver, repository);
+	AuditEventListener auditEventListener(
+			AuditEventListener.NamespaceResolver resolver,
+			AuditEventRepository repository,
+			ObservationRegistry registry
+	) {
+		return new AuditEventListener(repository, resolver, registry);
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -13,6 +13,7 @@ import com.konfigyr.security.PrincipalType;
 import com.konfigyr.vault.Profile;
 import com.konfigyr.vault.ProfileEvent;
 import com.konfigyr.vault.VaultEvent;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -52,6 +53,7 @@ import static com.konfigyr.data.tables.Services.SERVICES;
 @RequiredArgsConstructor
 class AuditEventListener {
 
+	static final String OBSERVATION_NAME = "audit.event.listener";
 	static final Actor SYSTEM_ACTOR = new Actor("system", PrincipalType.SYSTEM.name(), "Konfigyr");
 
 	private final NamespaceResolver resolver;
@@ -59,6 +61,7 @@ class AuditEventListener {
 
 	// ── Account events ──────────────────────────────────────────────────────
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "account.updated" })
 	@TransactionalEventListener(id = "audit.account-updated", classes = AccountEvent.Updated.class)
 	void on(AccountEvent.Updated event) {
 		insert(event, builder -> builder
@@ -68,6 +71,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "account.deleted" })
 	@TransactionalEventListener(id = "audit.account-deleted", classes = AccountEvent.Deleted.class)
 	void on(AccountEvent.Deleted event) {
 		insert(event, builder -> builder
@@ -79,6 +83,7 @@ class AuditEventListener {
 
 	// ── Namespace events ────────────────────────────────────────────────────
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.created" })
 	@TransactionalEventListener(id = "audit.namespace-created", classes = NamespaceEvent.Created.class)
 	void on(NamespaceEvent.Created event) {
 		insert(event, builder -> builder
@@ -89,6 +94,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.renamed" })
 	@TransactionalEventListener(id = "audit.namespace-renamed", classes = NamespaceEvent.Renamed.class)
 	void on(NamespaceEvent.Renamed event) {
 		insert(event, builder -> builder
@@ -101,6 +107,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.deleted" })
 	@TransactionalEventListener(id = "audit.namespace-deleted", classes = NamespaceEvent.Deleted.class)
 	void on(NamespaceEvent.Deleted event) {
 		insert(event, builder -> builder
@@ -111,6 +118,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.member.added" })
 	@TransactionalEventListener(id = "audit.namespace-member-added", classes = NamespaceEvent.MemberAdded.class)
 	void on(NamespaceEvent.MemberAdded event) {
 		insert(event, builder -> builder
@@ -123,6 +131,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.member.updated" })
 	@TransactionalEventListener(id = "audit.namespace-member-updated", classes = NamespaceEvent.MemberUpdated.class)
 	void on(NamespaceEvent.MemberUpdated event) {
 		insert(event, builder -> builder
@@ -135,6 +144,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.member.removed" })
 	@TransactionalEventListener(id = "audit.namespace-member-removed", classes = NamespaceEvent.MemberRemoved.class)
 	void on(NamespaceEvent.MemberRemoved event) {
 		insert(event, builder -> builder
@@ -148,6 +158,7 @@ class AuditEventListener {
 
 	// ── Namespace invitation events ───────────────────────────────────────────────────
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.invitation.sent" })
 	@TransactionalEventListener(id = "audit.invitation-created", classes = InvitationEvent.Created.class)
 	void on(InvitationEvent.Created event) {
 		insert(event, builder -> builder
@@ -159,6 +170,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.invitation.accepted" })
 	@TransactionalEventListener(id = "audit.invitation-accepted", classes = InvitationEvent.Accepted.class)
 	void on(InvitationEvent.Accepted event) {
 		insert(event, builder -> builder
@@ -170,6 +182,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.invitation.canceled" })
 	@TransactionalEventListener(id = "audit.invitation-canceled", classes = InvitationEvent.Canceled.class)
 	void on(InvitationEvent.Canceled event) {
 		insert(event, builder -> builder
@@ -183,6 +196,7 @@ class AuditEventListener {
 
 	// ── Service events ──────────────────────────────────────────────────────
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.service.created" })
 	@TransactionalEventListener(id = "audit.service-created", classes = ServiceEvent.Created.class)
 	void on(ServiceEvent.Created event) {
 		insert(event, builder -> builder
@@ -193,6 +207,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.service.renamed" })
 	@TransactionalEventListener(id = "audit.service-renamed", classes = ServiceEvent.Renamed.class)
 	void on(ServiceEvent.Renamed event) {
 		insert(event, builder -> builder
@@ -205,6 +220,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.service.published" })
 	@TransactionalEventListener(id = "audit.service-published", classes = ServiceEvent.Published.class)
 	void on(ServiceEvent.Published event) {
 		insert(event, builder -> {
@@ -221,6 +237,7 @@ class AuditEventListener {
 		});
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.service.deleted" })
 	@TransactionalEventListener(id = "audit.service-deleted", classes = ServiceEvent.Deleted.class)
 	void on(ServiceEvent.Deleted event) {
 		insert(event, builder -> builder
@@ -232,6 +249,7 @@ class AuditEventListener {
 
 	// ── Vault events ──────────────────────────────────────────────
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "vault.profile.created" })
 	@TransactionalEventListener(id = "audit.profile-created", classes = ProfileEvent.Created.class)
 	void on(ProfileEvent.Created event) {
 		insert(event, builder -> builder
@@ -242,6 +260,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "vault.profile.updated" })
 	@TransactionalEventListener(id = "audit.profile-updated", classes = ProfileEvent.Updated.class)
 	void on(ProfileEvent.Updated event) {
 		insert(event, builder -> builder
@@ -252,6 +271,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "vault.profile.deleted" })
 	@TransactionalEventListener(id = "audit.profile-deleted", classes = ProfileEvent.Deleted.class)
 	void on(ProfileEvent.Deleted event) {
 		insert(event, builder -> builder
@@ -262,6 +282,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "vault.changes-applied" })
 	// the VaultEvent.ChangesApplied event is never published within a transaction
 	@EventListener(id = "audit.changes-applied", classes = VaultEvent.ChangesApplied.class)
 	void on(VaultEvent.ChangesApplied event) {
@@ -276,6 +297,7 @@ class AuditEventListener {
 
 	// ── KMS events ──────────────────────────────────────────────────────────
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.created" })
 	@TransactionalEventListener(id = "audit.keyset-created", classes = KeysetManagementEvent.Created.class)
 	void on(KeysetManagementEvent.Created event) {
 		insert(event, builder -> builder
@@ -285,6 +307,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.rotated" })
 	@TransactionalEventListener(id = "audit.keyset-rotated", classes = KeysetManagementEvent.Rotated.class)
 	void on(KeysetManagementEvent.Rotated event) {
 		insert(event, builder -> builder
@@ -294,6 +317,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.disabled" })
 	@TransactionalEventListener(id = "audit.keyset-disabled", classes = KeysetManagementEvent.Disabled.class)
 	void on(KeysetManagementEvent.Disabled event) {
 		insert(event, builder -> builder
@@ -303,6 +327,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.activated" })
 	@TransactionalEventListener(id = "audit.keyset-activated", classes = KeysetManagementEvent.Activated.class)
 	void on(KeysetManagementEvent.Activated event) {
 		insert(event, builder -> builder
@@ -313,6 +338,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.removed" })
 	@TransactionalEventListener(id = "audit.keyset-removed", classes = KeysetManagementEvent.Removed.class)
 	void on(KeysetManagementEvent.Removed event) {
 		insert(event, builder -> builder
@@ -322,6 +348,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.destroyed" })
 	@TransactionalEventListener(id = "audit.keyset-destroyed", classes = KeysetManagementEvent.Destroyed.class)
 	void on(KeysetManagementEvent.Destroyed event) {
 		insert(event, builder -> builder
@@ -333,6 +360,7 @@ class AuditEventListener {
 
 	// ── Artifactory events ──────────────────────────────────────────────────
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "artifactory.release.created" })
 	@TransactionalEventListener(id = "audit.release-created", classes = ArtifactoryEvent.ReleaseCreated.class)
 	void on(ArtifactoryEvent.ReleaseCreated event) {
 		insert(event, builder -> builder
@@ -343,6 +371,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "artifactory.release.completed" })
 	@TransactionalEventListener(id = "audit.release-completed", classes = ArtifactoryEvent.ReleaseCompleted.class)
 	void on(ArtifactoryEvent.ReleaseCompleted event) {
 		insert(event, builder -> builder
@@ -353,6 +382,7 @@ class AuditEventListener {
 		);
 	}
 
+	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "artifactory.release.failed" })
 	@TransactionalEventListener(id = "audit.release-failed", classes = ArtifactoryEvent.ReleaseFailed.class)
 	void on(ArtifactoryEvent.ReleaseFailed event) {
 		insert(event, builder -> builder

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -13,7 +13,7 @@ import com.konfigyr.security.PrincipalType;
 import com.konfigyr.vault.Profile;
 import com.konfigyr.vault.ProfileEvent;
 import com.konfigyr.vault.VaultEvent;
-import io.micrometer.observation.annotation.Observed;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -53,15 +53,14 @@ import static com.konfigyr.data.tables.Services.SERVICES;
 @RequiredArgsConstructor
 class AuditEventListener {
 
-	static final String OBSERVATION_NAME = "audit.event.listener";
 	static final Actor SYSTEM_ACTOR = new Actor("system", PrincipalType.SYSTEM.name(), "Konfigyr");
 
-	private final NamespaceResolver resolver;
-	private final AuditEventRepository repository;
+	private final AuditEventRepository auditEventRepository;
+	private final NamespaceResolver namespaceResolver;
+	private final ObservationRegistry observationRegistry;
 
 	// ── Account events ──────────────────────────────────────────────────────
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "account.updated" })
 	@TransactionalEventListener(id = "audit.account-updated", classes = AccountEvent.Updated.class)
 	void on(AccountEvent.Updated event) {
 		insert(event, builder -> builder
@@ -71,7 +70,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "account.deleted" })
 	@TransactionalEventListener(id = "audit.account-deleted", classes = AccountEvent.Deleted.class)
 	void on(AccountEvent.Deleted event) {
 		insert(event, builder -> builder
@@ -83,7 +81,6 @@ class AuditEventListener {
 
 	// ── Namespace events ────────────────────────────────────────────────────
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.created" })
 	@TransactionalEventListener(id = "audit.namespace-created", classes = NamespaceEvent.Created.class)
 	void on(NamespaceEvent.Created event) {
 		insert(event, builder -> builder
@@ -94,7 +91,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.renamed" })
 	@TransactionalEventListener(id = "audit.namespace-renamed", classes = NamespaceEvent.Renamed.class)
 	void on(NamespaceEvent.Renamed event) {
 		insert(event, builder -> builder
@@ -107,7 +103,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.deleted" })
 	@TransactionalEventListener(id = "audit.namespace-deleted", classes = NamespaceEvent.Deleted.class)
 	void on(NamespaceEvent.Deleted event) {
 		insert(event, builder -> builder
@@ -118,7 +113,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.member.added" })
 	@TransactionalEventListener(id = "audit.namespace-member-added", classes = NamespaceEvent.MemberAdded.class)
 	void on(NamespaceEvent.MemberAdded event) {
 		insert(event, builder -> builder
@@ -131,7 +125,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.member.updated" })
 	@TransactionalEventListener(id = "audit.namespace-member-updated", classes = NamespaceEvent.MemberUpdated.class)
 	void on(NamespaceEvent.MemberUpdated event) {
 		insert(event, builder -> builder
@@ -144,7 +137,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.member.removed" })
 	@TransactionalEventListener(id = "audit.namespace-member-removed", classes = NamespaceEvent.MemberRemoved.class)
 	void on(NamespaceEvent.MemberRemoved event) {
 		insert(event, builder -> builder
@@ -158,7 +150,6 @@ class AuditEventListener {
 
 	// ── Namespace invitation events ───────────────────────────────────────────────────
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.invitation.sent" })
 	@TransactionalEventListener(id = "audit.invitation-created", classes = InvitationEvent.Created.class)
 	void on(InvitationEvent.Created event) {
 		insert(event, builder -> builder
@@ -170,7 +161,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.invitation.accepted" })
 	@TransactionalEventListener(id = "audit.invitation-accepted", classes = InvitationEvent.Accepted.class)
 	void on(InvitationEvent.Accepted event) {
 		insert(event, builder -> builder
@@ -182,7 +172,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.invitation.canceled" })
 	@TransactionalEventListener(id = "audit.invitation-canceled", classes = InvitationEvent.Canceled.class)
 	void on(InvitationEvent.Canceled event) {
 		insert(event, builder -> builder
@@ -196,7 +185,6 @@ class AuditEventListener {
 
 	// ── Service events ──────────────────────────────────────────────────────
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.service.created" })
 	@TransactionalEventListener(id = "audit.service-created", classes = ServiceEvent.Created.class)
 	void on(ServiceEvent.Created event) {
 		insert(event, builder -> builder
@@ -207,7 +195,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.service.renamed" })
 	@TransactionalEventListener(id = "audit.service-renamed", classes = ServiceEvent.Renamed.class)
 	void on(ServiceEvent.Renamed event) {
 		insert(event, builder -> builder
@@ -220,7 +207,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.service.published" })
 	@TransactionalEventListener(id = "audit.service-published", classes = ServiceEvent.Published.class)
 	void on(ServiceEvent.Published event) {
 		insert(event, builder -> {
@@ -237,7 +223,6 @@ class AuditEventListener {
 		});
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "namespace.service.deleted" })
 	@TransactionalEventListener(id = "audit.service-deleted", classes = ServiceEvent.Deleted.class)
 	void on(ServiceEvent.Deleted event) {
 		insert(event, builder -> builder
@@ -249,7 +234,6 @@ class AuditEventListener {
 
 	// ── Vault events ──────────────────────────────────────────────
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "vault.profile.created" })
 	@TransactionalEventListener(id = "audit.profile-created", classes = ProfileEvent.Created.class)
 	void on(ProfileEvent.Created event) {
 		insert(event, builder -> builder
@@ -260,7 +244,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "vault.profile.updated" })
 	@TransactionalEventListener(id = "audit.profile-updated", classes = ProfileEvent.Updated.class)
 	void on(ProfileEvent.Updated event) {
 		insert(event, builder -> builder
@@ -271,7 +254,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "vault.profile.deleted" })
 	@TransactionalEventListener(id = "audit.profile-deleted", classes = ProfileEvent.Deleted.class)
 	void on(ProfileEvent.Deleted event) {
 		insert(event, builder -> builder
@@ -282,7 +264,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "vault.changes-applied" })
 	// the VaultEvent.ChangesApplied event is never published within a transaction
 	@EventListener(id = "audit.changes-applied", classes = VaultEvent.ChangesApplied.class)
 	void on(VaultEvent.ChangesApplied event) {
@@ -297,7 +278,6 @@ class AuditEventListener {
 
 	// ── KMS events ──────────────────────────────────────────────────────────
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.created" })
 	@TransactionalEventListener(id = "audit.keyset-created", classes = KeysetManagementEvent.Created.class)
 	void on(KeysetManagementEvent.Created event) {
 		insert(event, builder -> builder
@@ -307,7 +287,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.rotated" })
 	@TransactionalEventListener(id = "audit.keyset-rotated", classes = KeysetManagementEvent.Rotated.class)
 	void on(KeysetManagementEvent.Rotated event) {
 		insert(event, builder -> builder
@@ -317,7 +296,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.disabled" })
 	@TransactionalEventListener(id = "audit.keyset-disabled", classes = KeysetManagementEvent.Disabled.class)
 	void on(KeysetManagementEvent.Disabled event) {
 		insert(event, builder -> builder
@@ -327,7 +305,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.activated" })
 	@TransactionalEventListener(id = "audit.keyset-activated", classes = KeysetManagementEvent.Activated.class)
 	void on(KeysetManagementEvent.Activated event) {
 		insert(event, builder -> builder
@@ -338,7 +315,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.removed" })
 	@TransactionalEventListener(id = "audit.keyset-removed", classes = KeysetManagementEvent.Removed.class)
 	void on(KeysetManagementEvent.Removed event) {
 		insert(event, builder -> builder
@@ -348,7 +324,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "kms.keyset.destroyed" })
 	@TransactionalEventListener(id = "audit.keyset-destroyed", classes = KeysetManagementEvent.Destroyed.class)
 	void on(KeysetManagementEvent.Destroyed event) {
 		insert(event, builder -> builder
@@ -360,7 +335,6 @@ class AuditEventListener {
 
 	// ── Artifactory events ──────────────────────────────────────────────────
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "artifactory.release.created" })
 	@TransactionalEventListener(id = "audit.release-created", classes = ArtifactoryEvent.ReleaseCreated.class)
 	void on(ArtifactoryEvent.ReleaseCreated event) {
 		insert(event, builder -> builder
@@ -371,7 +345,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "artifactory.release.completed" })
 	@TransactionalEventListener(id = "audit.release-completed", classes = ArtifactoryEvent.ReleaseCompleted.class)
 	void on(ArtifactoryEvent.ReleaseCompleted event) {
 		insert(event, builder -> builder
@@ -382,7 +355,6 @@ class AuditEventListener {
 		);
 	}
 
-	@Observed(name = OBSERVATION_NAME, lowCardinalityKeyValues = { "type", "artifactory.release.failed" })
 	@TransactionalEventListener(id = "audit.release-failed", classes = ArtifactoryEvent.ReleaseFailed.class)
 	void on(ArtifactoryEvent.ReleaseFailed event) {
 		insert(event, builder -> builder
@@ -394,21 +366,23 @@ class AuditEventListener {
 	}
 
 	private void insert(EntityEvent event, Consumer<AuditEvent.Builder> factory) {
-		try {
-			final AuditEvent.Builder builder = AuditEvent.builder()
-					.namespace(resolver.resolve(event));
+		AuditObservation.create(observationRegistry, event).observe(() -> {
+			try {
+				final AuditEvent.Builder builder = AuditEvent.builder()
+						.namespace(namespaceResolver.resolve(event));
 
-			AuthenticatedPrincipal.fromSecurityContext().ifPresentOrElse(
-					builder::actor,
-					() -> builder.actor(SYSTEM_ACTOR)
-			);
+				AuthenticatedPrincipal.fromSecurityContext().ifPresentOrElse(
+						builder::actor,
+						() -> builder.actor(SYSTEM_ACTOR)
+				);
 
-			factory.accept(builder);
+				factory.accept(builder);
 
-			repository.insert(builder.build());
-		} catch (Exception ex) {
-			log.error("Failed to persist audit event: {}", event, ex);
-		}
+				auditEventRepository.insert(builder.build());
+			} catch (Exception ex) {
+				log.error("Failed to persist audit event: {}", event, ex);
+			}
+		});
 	}
 
 	/**

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditObservation.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditObservation.java
@@ -1,0 +1,76 @@
+package com.konfigyr.audit;
+
+import com.konfigyr.entity.EntityEvent;
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.ObservationRegistry;
+import org.jmolecules.event.annotation.DomainEvent;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.util.Assert;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@NullMarked
+final class AuditObservation {
+
+	private static final Map<Class<?>, String> EVENT_TYPE_CACHE = new ConcurrentHashMap<>(16);
+
+	static final String OBSERVATION_NAME = "konfigyr.audit.event.listener";
+
+	static Observation create(ObservationRegistry registry, EntityEvent event) {
+		return Observation.createNotStarted(Convention.INSTANCE, () -> new Context(event), registry);
+	}
+
+	static final class Context extends Observation.Context {
+		private final String id;
+		private final String eventType;
+
+		Context(EntityEvent event) {
+			this.id = event.id().serialize();
+			this.eventType = EVENT_TYPE_CACHE.computeIfAbsent(event.getClass(), Context::resolveEventType);
+		}
+
+		static String resolveEventType(Class<?> eventType) {
+			final DomainEvent event = AnnotationUtils.findAnnotation(eventType, DomainEvent.class);
+			Assert.notNull(event, "The event type " + eventType + " is not annotated with @DomainEvent");
+			Assert.hasText(event.namespace(), "You must provide a namespace for the event type " + eventType);
+			Assert.hasText(event.name(), "You must provide a name for the event type " + eventType);
+
+			return String.format("%s.%s", event.namespace(), event.name());
+		}
+	}
+
+	static final class Convention implements ObservationConvention<Context> {
+
+		static final ObservationConvention<Context> INSTANCE = new Convention();
+
+		@Override
+		public String getName() {
+			return OBSERVATION_NAME;
+		}
+
+		@Override
+		public String getContextualName(Context context) {
+			return "audit listener event with '" + context.eventType + "' type and '" + context.id + "' resource identifier";
+		}
+
+		@Override
+		public KeyValues getLowCardinalityKeyValues(Context context) {
+			return KeyValues.of("konfigyr.audit.event.type", context.eventType);
+		}
+
+		@Override
+		public KeyValues getHighCardinalityKeyValues(Context context) {
+			return KeyValues.of("konfigyr.audit.event.id", context.id);
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return context instanceof Context;
+		}
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditObservation.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditObservation.java
@@ -20,6 +20,10 @@ final class AuditObservation {
 
 	static final String OBSERVATION_NAME = "konfigyr.audit.event.listener";
 
+	private AuditObservation() {
+		// prevent instantiation
+	}
+
 	static Observation create(ObservationRegistry registry, EntityEvent event) {
 		return Observation.createNotStarted(Convention.INSTANCE, () -> new Context(event), registry);
 	}

--- a/konfigyr-api/src/main/java/com/konfigyr/batch/BatchAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/batch/BatchAutoConfiguration.java
@@ -1,12 +1,17 @@
 package com.konfigyr.batch;
 
 
+import io.micrometer.common.KeyValue;
+import io.micrometer.observation.ObservationFilter;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.batch.core.configuration.JobRegistry;
+import org.springframework.batch.core.observability.BatchMetrics;
 import org.springframework.beans.factory.ListableBeanFactory;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.batch.jdbc.autoconfigure.BatchJdbcAutoConfiguration;
 import org.springframework.context.annotation.Bean;
+
+import java.util.Objects;
 
 @NullMarked
 @AutoConfiguration(before = BatchJdbcAutoConfiguration.class)
@@ -15,6 +20,21 @@ public class BatchAutoConfiguration {
 	@Bean
 	JobRegistry listableJobRegistry(ListableBeanFactory listableBeanFactory) {
 		return new ListableJobRegistry(listableBeanFactory);
+	}
+
+	@Bean
+	ObservationFilter batchItemProcessStatusFilter() {
+		return context -> {
+			if (Objects.equals(BatchMetrics.METRICS_PREFIX + "item.process", context.getName())) {
+				// Ensure the status key exists to maintain a consistent key set. Metrics backends
+				// like Prometheus or Stackdriver reject this because they require every metric to
+				// have the exact same tag keys to allow for proper aggregation.
+				return context.addLowCardinalityKeyValue(KeyValue.of(
+						BatchMetrics.METRICS_PREFIX + "item.process.status", "STARTED"
+				));
+			}
+			return context;
+		};
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/kms/DefaultKeysetManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/kms/DefaultKeysetManager.java
@@ -6,6 +6,7 @@ import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.NamespaceNotFoundException;
 import com.konfigyr.support.SearchQuery;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.*;
@@ -142,6 +143,7 @@ class DefaultKeysetManager implements KeysetManager {
 
 	@Override
 	@Transactional(label = "kms.create")
+	@Observed(name = "konfigyr.kms.keyset.create")
 	public KeysetMetadata create(KeysetMetadataDefinition definition) {
 		log.debug("Creating KMS keyset with: {}", definition);
 
@@ -204,6 +206,7 @@ class DefaultKeysetManager implements KeysetManager {
 
 	@Override
 	@Transactional(label = "kms.transition")
+	@Observed(name = "konfigyr.kms.keyset.transition")
 	public KeysetMetadata transition(EntityId id, KeysetMetadataState state) {
 		if (KeysetMetadataState.DESTROYED == state) {
 			throw new IllegalArgumentException("Can not transition keyset metadata to destroyed state");
@@ -255,6 +258,7 @@ class DefaultKeysetManager implements KeysetManager {
 
 	@Override
 	@Transactional(label = "kms.rotate")
+	@Observed(name = "konfigyr.kms.keyset.rotate")
 	public KeysetMetadata rotate(EntityId id) {
 		final KeysetInformation information = lookupKeysetInformation(KMS_KEYSET_METADATA.ID.eq(id.get()))
 				.orElseThrow(() -> new KeysetNotFoundException(id));

--- a/konfigyr-api/src/main/java/com/konfigyr/kms/DefaultKeysetManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/kms/DefaultKeysetManager.java
@@ -291,6 +291,7 @@ class DefaultKeysetManager implements KeysetManager {
 
 	@Override
 	@Transactional(label = "kms.delete")
+	@Observed(name = "konfigyr.kms.keyset.delete")
 	public void delete(EntityId id) {
 		final KeysetInformation information = lookupKeysetInformation(KMS_KEYSET_METADATA.ID.eq(id.get()))
 				.orElseThrow(() -> new KeysetNotFoundException(id));

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
@@ -227,7 +227,7 @@ public class DefaultServices implements Services {
 	@NonNull
 	@Override
 	@Transactional(label = "service-release")
-	@Observed(name = "namespace.service.publish")
+	@Observed(name = "konfigyr.namespace.service.publish")
 	public Manifest publish(@NonNull Service service, @NonNull Collection<? extends ArtifactCoordinates> artifacts) {
 		final Long releaseId = context.insertInto(SERVICE_RELEASES)
 				.set(

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
@@ -228,7 +228,7 @@ public class DefaultServices implements Services {
 	@Override
 	@Transactional(label = "service-release")
 	@Observed(name = "namespace.service.publish")
-	public Manifest publish( @NonNull Service service, @NonNull Collection<? extends ArtifactCoordinates> artifacts) {
+	public Manifest publish(@NonNull Service service, @NonNull Collection<? extends ArtifactCoordinates> artifacts) {
 		final Long releaseId = context.insertInto(SERVICE_RELEASES)
 				.set(
 						SettableRecord.of(context, SERVICE_RELEASES)

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
@@ -8,6 +8,7 @@ import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.catalog.ServiceCatalogSource;
 import com.konfigyr.support.SearchQuery;
 import com.konfigyr.support.Slug;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.*;
@@ -226,7 +227,8 @@ public class DefaultServices implements Services {
 	@NonNull
 	@Override
 	@Transactional(label = "service-release")
-	public Manifest publish(@NonNull Service service, @NonNull Collection<? extends ArtifactCoordinates> artifacts) {
+	@Observed(name = "namespace.service.publish")
+	public Manifest publish( @NonNull Service service, @NonNull Collection<? extends ArtifactCoordinates> artifacts) {
 		final Long releaseId = context.insertInto(SERVICE_RELEASES)
 				.set(
 						SettableRecord.of(context, SERVICE_RELEASES)

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/catalog/ServiceCatalogWorker.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/catalog/ServiceCatalogWorker.java
@@ -1,8 +1,6 @@
 package com.konfigyr.namespace.catalog;
 
 import com.konfigyr.entity.EntityId;
-import io.micrometer.observation.annotation.ObservationKeyValue;
-import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -83,8 +81,7 @@ class ServiceCatalogWorker {
 	 * @param release the release entity identifier, can't be {@literal null}
 	 */
 	@Transactional(isolation = Isolation.SERIALIZABLE, label = "service-catalog-worker.build")
-	@Observed(name = "konfigyr.namespace.service-catalog-worker")
-	void build(@ObservationKeyValue(key = "release") EntityId release) {
+	void build(EntityId release) {
 		assertReleaseExists(release);
 
 		final long dropped = context.deleteFrom(SERVICE_CONFIGURATION_CATALOG)

--- a/konfigyr-api/src/main/java/com/konfigyr/queue/QueueObservation.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/queue/QueueObservation.java
@@ -7,10 +7,14 @@ import io.micrometer.observation.ObservationRegistry;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-class QueueObservation {
+final class QueueObservation {
 
 	static final String CONSUME_OBSERVATION_NAME = "konfigyr.queue.consume";
 	static final String PROCESS_OBSERVATION_NAME = "konfigyr.queue.process";
+
+	private QueueObservation() {
+		// prevent instantiation
+	}
 
 	static Observation consume(ObservationRegistry registry) {
 		return Observation.createNotStarted(CONSUME_OBSERVATION_NAME, registry);
@@ -35,7 +39,7 @@ class QueueObservation {
 			return task.queueName();
 		}
 	}
-	
+
 	static final class ProcessorConvention implements ObservationConvention<ProcessorContext> {
 
 		static final ObservationConvention<ProcessorContext> INSTANCE = new ProcessorConvention();
@@ -65,5 +69,5 @@ class QueueObservation {
 			return context instanceof ProcessorContext;
 		}
 	}
-	
+
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/queue/QueueObservation.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/queue/QueueObservation.java
@@ -1,0 +1,69 @@
+package com.konfigyr.queue;
+
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+class QueueObservation {
+
+	static final String CONSUME_OBSERVATION_NAME = "konfigyr.queue.consume";
+	static final String PROCESS_OBSERVATION_NAME = "konfigyr.queue.process";
+
+	static Observation consume(ObservationRegistry registry) {
+		return Observation.createNotStarted(CONSUME_OBSERVATION_NAME, registry);
+	}
+
+	static Observation process(ObservationRegistry registry, QueuedTask task) {
+		return Observation.createNotStarted(ProcessorConvention.INSTANCE, () -> new ProcessorContext(task), registry);
+	}
+
+	static final class ProcessorContext extends Observation.Context {
+		private final QueuedTask task;
+
+		ProcessorContext(QueuedTask task) {
+			this.task = task;
+		}
+
+		String entity() {
+			return task.entityId().serialize();
+		}
+
+		String queueName() {
+			return task.queueName();
+		}
+	}
+	
+	static final class ProcessorConvention implements ObservationConvention<ProcessorContext> {
+
+		static final ObservationConvention<ProcessorContext> INSTANCE = new ProcessorConvention();
+
+		@Override
+		public String getName() {
+			return PROCESS_OBSERVATION_NAME;
+		}
+
+		@Override
+		public String getContextualName(ProcessorContext context) {
+			return "processing queued task in '" + context.queueName() + "' queue with '" + context.entity() + "' resource identifier";
+		}
+
+		@Override
+		public KeyValues getLowCardinalityKeyValues(ProcessorContext context) {
+			return KeyValues.of("konfigyr.queue.name", context.queueName());
+		}
+
+		@Override
+		public KeyValues getHighCardinalityKeyValues(ProcessorContext context) {
+			return KeyValues.of("konfigyr.queue.entity", context.entity());
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return context instanceof ProcessorContext;
+		}
+	}
+	
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/queue/WorkerQueueAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/queue/WorkerQueueAutoConfiguration.java
@@ -1,5 +1,6 @@
 package com.konfigyr.queue;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.jooq.DSLContext;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -26,8 +27,8 @@ public class WorkerQueueAutoConfiguration {
 
 	@Bean
 	@ConditionalOnBean(QueueRegistrar.class)
-	WorkerQueueScheduler workerQueueScheduler(WorkerQueue queue, QueueRegistrar registrar) {
-		return new WorkerQueueScheduler(queue, registrar);
+	WorkerQueueScheduler workerQueueScheduler(WorkerQueue queue, QueueRegistrar registrar, ObservationRegistry registry) {
+		return new WorkerQueueScheduler(queue, registrar, registry);
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/queue/WorkerQueueScheduler.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/queue/WorkerQueueScheduler.java
@@ -1,5 +1,7 @@
 package com.konfigyr.queue;
 
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.slf4j.Logger;
@@ -56,9 +58,10 @@ class WorkerQueueScheduler implements InitializingBean, DisposableBean {
 	private final Logger logger;
 	private final WorkerQueue workerQueue;
 	private final QueueRegistrar queueRegistrar;
+	private final ObservationRegistry observationRegistry;
 
-	WorkerQueueScheduler(WorkerQueue workerQueue, QueueRegistrar queueRegistrar) {
-		this(LoggerFactory.getLogger(WorkerQueueScheduler.class), workerQueue, queueRegistrar);
+	WorkerQueueScheduler(WorkerQueue workerQueue, QueueRegistrar queueRegistrar, ObservationRegistry observationRegistry) {
+		this(LoggerFactory.getLogger(WorkerQueueScheduler.class), workerQueue, queueRegistrar, observationRegistry);
 	}
 
 	@Override
@@ -78,7 +81,8 @@ class WorkerQueueScheduler implements InitializingBean, DisposableBean {
 	 */
 	@Scheduled(cron = "${konfigyr.scheduler.cron-expression:* * * * * *}")
 	void schedule() {
-		final List<QueuedTask> tasks = workerQueue.consume();
+		final List<QueuedTask> tasks = QueueObservation.consume(observationRegistry)
+				.observe(workerQueue::consume);
 
 		if (logger.isTraceEnabled()) {
 			logger.trace("Received {} tasks from the queue", tasks.size());
@@ -95,7 +99,10 @@ class WorkerQueueScheduler implements InitializingBean, DisposableBean {
 				logger.trace("Executing {} with configuration: {}", task, configuration);
 			}
 
-			final QueueProcessor processor = configuration.queueProcessor();
+			final QueueProcessor processor = decorate(
+					QueueObservation.process(observationRegistry, task),
+					configuration.queueProcessor()
+			);
 
 			CompletableFuture.runAsync(() -> processor.process(task.entityId()), configuration.taskExecutor())
 					.orTimeout(configuration.timeout().toMillis(), TimeUnit.MILLISECONDS)
@@ -134,4 +141,9 @@ class WorkerQueueScheduler implements InitializingBean, DisposableBean {
 			}
 		}
 	}
+
+	private static QueueProcessor decorate(Observation observation, QueueProcessor processor) {
+		return id -> observation.observe(() -> processor.process(id));
+	}
+
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/security/AuthenticatedPrincipalContextFilter.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/AuthenticatedPrincipalContextFilter.java
@@ -1,0 +1,34 @@
+package com.konfigyr.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@NullMarked
+class AuthenticatedPrincipalContextFilter extends OncePerRequestFilter {
+
+	static final String ACTOR_KEY = "actor";
+	static final String ACTOR_TYPE_KEY = "actor.type";
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+		try {
+			AuthenticatedPrincipal.fromSecurityContext().ifPresent(principal -> {
+				MDC.put(ACTOR_KEY, principal.get());
+				MDC.put(ACTOR_TYPE_KEY, principal.getType().name());
+			});
+
+			chain.doFilter(request, response);
+		} finally {
+			MDC.remove(ACTOR_KEY);
+			MDC.remove(ACTOR_TYPE_KEY);
+		}
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/security/WebSecurityConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/WebSecurityConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.userdetails.cache.SpringCacheBasedUserC
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.context.DelegatingSecurityContextRepository;
 import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
@@ -80,6 +81,7 @@ public class WebSecurityConfiguration {
 						.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 				)
 				.authenticationProvider(provider)
+				.addFilterAfter(new AuthenticatedPrincipalContextFilter(), AuthorizationFilter.class)
 				.build();
 	}
 
@@ -118,6 +120,7 @@ public class WebSecurityConfiguration {
 						.defaultAuthenticationEntryPointFor(exceptionHandler, AnyRequestMatcher.INSTANCE)
 						.defaultAccessDeniedHandlerFor(exceptionHandler, AnyRequestMatcher.INSTANCE)
 				)
+				.addFilterAfter(new AuthenticatedPrincipalContextFilter(), AuthorizationFilter.class)
 				.build();
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/security/access/AccessControlRepository.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/access/AccessControlRepository.java
@@ -2,12 +2,14 @@ package com.konfigyr.security.access;
 
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.NamespaceRole;
+import io.micrometer.observation.annotation.ObservationKeyValue;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.impl.DSL;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.CollectionUtils;
 
@@ -22,13 +24,19 @@ import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
 import static com.konfigyr.data.tables.OauthApplications.OAUTH_APPLICATIONS;
 
 @Slf4j
+@NullMarked
 @RequiredArgsConstructor
 class AccessControlRepository {
 
 	private final DSLContext context;
 
+	@Observed(name = "konfigyr.security.access-control")
 	@Transactional(readOnly = true, label = "access-control-repository.get")
-	AccessControl get(@NonNull ObjectIdentity identity) throws ObjectIdentityNotFound {
+	AccessControl get(
+			@ObservationKeyValue(key = "identity.id", expression = "#identity.id()")
+			@ObservationKeyValue(key = "identity.type", expression = "#identity.type()")
+			ObjectIdentity identity
+	) throws ObjectIdentityNotFound {
 		if (log.isDebugEnabled()) {
 			log.debug("Looking up access control grants for: {}", identity);
 		}
@@ -45,7 +53,7 @@ class AccessControlRepository {
 		return new KonfigyrAccessControl(identity, grants);
 	}
 
-	private Collection<AccessGrant> namespace(@NonNull ObjectIdentity identity) {
+	private Collection<AccessGrant> namespace(ObjectIdentity identity) {
 		final Condition condition = switch (identity.id()) {
 			case String slug -> NAMESPACES.SLUG.eq(slug);
 			case EntityId id -> NAMESPACES.ID.eq(id.get());
@@ -60,7 +68,7 @@ class AccessControlRepository {
 		return Collections.unmodifiableSet(grants);
 	}
 
-	private Collection<AccessGrant> namespaceMembershipGrants(@NonNull Condition condition) {
+	private Collection<AccessGrant> namespaceMembershipGrants(Condition condition) {
 		return context.select(NAMESPACE_MEMBERS.ACCOUNT_ID, NAMESPACE_MEMBERS.ROLE)
 				.from(NAMESPACE_MEMBERS)
 				.innerJoin(NAMESPACES)
@@ -72,7 +80,7 @@ class AccessControlRepository {
 				));
 	}
 
-	private Collection<AccessGrant> namespaceApplicationGrants(@NonNull Condition condition) {
+	private Collection<AccessGrant> namespaceApplicationGrants(Condition condition) {
 		return context.select(OAUTH_APPLICATIONS.CLIENT_ID)
 				.from(OAUTH_APPLICATIONS)
 				.innerJoin(NAMESPACES)

--- a/konfigyr-api/src/main/java/com/konfigyr/security/access/AccessControlRepository.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/access/AccessControlRepository.java
@@ -4,6 +4,7 @@ import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.NamespaceRole;
 import io.micrometer.observation.annotation.ObservationKeyValue;
 import io.micrometer.observation.annotation.Observed;
+import io.micrometer.observation.aop.Cardinality;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.Condition;
@@ -33,8 +34,8 @@ class AccessControlRepository {
 	@Observed(name = "konfigyr.security.access-control")
 	@Transactional(readOnly = true, label = "access-control-repository.get")
 	AccessControl get(
-			@ObservationKeyValue(key = "identity.id", expression = "#identity.id()")
-			@ObservationKeyValue(key = "identity.type", expression = "#identity.type()")
+			@ObservationKeyValue(key = "konfigyr.identity.id", expression = "id")
+			@ObservationKeyValue(key = "konfigyr.identity.type", expression = "type", cardinality = Cardinality.LOW)
 			ObjectIdentity identity
 	) throws ObjectIdentityNotFound {
 		if (log.isDebugEnabled()) {

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/GitRepositoryHealthIndicator.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/GitRepositoryHealthIndicator.java
@@ -1,0 +1,66 @@
+package com.konfigyr.vault;
+
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.boot.health.contributor.AbstractHealthIndicator;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.util.unit.DataUnit;
+
+import java.nio.file.FileStore;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@NullMarked
+@RequiredArgsConstructor
+class GitRepositoryHealthIndicator extends AbstractHealthIndicator {
+
+	static DataUnit[] DATA_UNITS = {
+			DataUnit.KILOBYTES,
+			DataUnit.MEGABYTES,
+			DataUnit.GIGABYTES,
+			DataUnit.TERABYTES
+	};
+
+	private final Path repositoryDirectory;
+
+	@Override
+	protected void doHealthCheck(Health.Builder builder) throws Exception {
+		if (!Files.exists(repositoryDirectory)) {
+			builder.down()
+					.withDetail("directory", repositoryDirectory.toString())
+					.withDetail("reason", "Repository directory does not exist");
+			return;
+		}
+
+		if (!Files.isReadable(repositoryDirectory)) {
+			builder.down()
+					.withDetail("directory", repositoryDirectory.toString())
+					.withDetail("reason", "Repository directory is not readable");
+			return;
+		}
+
+		final FileStore store = Files.getFileStore(repositoryDirectory);
+
+		builder.up()
+				.withDetail("directory", repositoryDirectory.toString())
+				.withDetail("usableSpace", formatBytes(store.getUsableSpace()))
+				.withDetail("totalSpace", formatBytes(store.getTotalSpace()));
+	}
+
+	private static String formatBytes(long bytes) {
+		if (bytes < 1024) {
+			return bytes + " B";
+		}
+
+		int index = 0;
+		double value = bytes / 1024.0;
+
+		while (value >= 1024 && index < DATA_UNITS.length - 1) {
+			value /= 1024;
+			index++;
+		}
+
+		return String.format("%.2f %s", value, DATA_UNITS[index]);
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/VaultAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/VaultAutoConfiguration.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.health.autoconfigure.contributor.ConditionalOnEnabledHealthIndicator;
+import org.springframework.boot.health.contributor.HealthIndicator;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 
@@ -43,6 +45,12 @@ public class VaultAutoConfiguration {
 	@Bean
 	StateRepositoryEventListener stateRepositoryEventListener(Services services, StateRepositoryFactory factory) {
 		return new StateRepositoryEventListener(services, factory);
+	}
+
+	@Bean
+	@ConditionalOnEnabledHealthIndicator("git")
+	HealthIndicator gitRepositoryHealthIndicator() {
+		return new GitRepositoryHealthIndicator(properties.getRepositoryDirectory());
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/changes/ChangeRequestEvaluator.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/changes/ChangeRequestEvaluator.java
@@ -3,8 +3,6 @@ package com.konfigyr.vault.changes;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.vault.ChangeRequestMergeStatus;
 import com.konfigyr.vault.gatekeeper.ChangeRequestGatekeeper;
-import io.micrometer.observation.annotation.ObservationKeyValue;
-import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
@@ -64,8 +62,7 @@ class ChangeRequestEvaluator {
 	 * @param changeRequestId the identifier of the change request to evaluate, must not be {@literal null}
 	 */
 	@Transactional(isolation = Isolation.SERIALIZABLE, label = "vault.change-request.evaluator")
-	@Observed(name = "konfigyr.vault.change-request.evaluator")
-	void evaluate(@ObservationKeyValue(key = "changeRequest") EntityId changeRequestId) {
+	void evaluate(EntityId changeRequestId) {
 		final ChangeRequestMergeStatus status = gatekeeper.evaluate(changeRequestId);
 
 		context.update(VAULT_CHANGE_REQUESTS)

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentConfiguration.java
@@ -2,6 +2,7 @@ package com.konfigyr.vault.environment;
 
 import com.konfigyr.vault.ProfileManager;
 import com.konfigyr.vault.VaultAccessor;
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,8 +20,9 @@ public class ConfigurationEnvironmentConfiguration {
 	ConfigurationEnvironmentLocator configurationEnvironmentLocator(
 			VaultAccessor vaultAccessor,
 			ProfileManager profileManager,
-			ConfigurationCache configurationCache
+			ConfigurationCache configurationCache,
+			ObservationRegistry observationRegistry
 	) {
-		return new ConfigurationEnvironmentLocator(vaultAccessor, profileManager, configurationCache);
+		return new ConfigurationEnvironmentLocator(vaultAccessor, profileManager, configurationCache, observationRegistry);
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentLocator.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentLocator.java
@@ -5,6 +5,8 @@ import com.konfigyr.security.AuthenticatedPrincipal;
 import com.konfigyr.vault.*;
 import com.konfigyr.vault.Properties;
 import com.konfigyr.vault.state.RepositoryStateException;
+import io.micrometer.observation.annotation.ObservationKeyValue;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
@@ -23,15 +25,30 @@ public class ConfigurationEnvironmentLocator {
 	private final ProfileManager profileManager;
 	private final ConfigurationCache configurationCache;
 
-	public ConfigurationEnvironment locate(AuthenticatedPrincipal principal, Service service, String profile) {
+	@Observed(name = "konfigyr.vault.environment.locator")
+	public ConfigurationEnvironment locate(
+			AuthenticatedPrincipal principal,
+			@ObservationKeyValue(key = "service", expression = "service.id.serialize()") Service service,
+			@ObservationKeyValue(key = "profiles") String profile
+	) {
 		return locate(principal, service, Collections.singleton(profile));
 	}
 
-	public ConfigurationEnvironment locate(AuthenticatedPrincipal principal, Service service, String... profiles) {
+	@Observed(name = "konfigyr.vault.environment.locator")
+	public ConfigurationEnvironment locate(
+			AuthenticatedPrincipal principal,
+			@ObservationKeyValue(key = "service", expression = "service.id.serialize()") Service service,
+			@ObservationKeyValue(key = "profiles") String... profiles
+	) {
 		return locate(principal, service, List.of(profiles));
 	}
 
-	public ConfigurationEnvironment locate(AuthenticatedPrincipal principal, Service service, Collection<String> profileNames) {
+	@Observed(name = "konfigyr.vault.environment.locator")
+	public ConfigurationEnvironment locate(
+			AuthenticatedPrincipal principal,
+			@ObservationKeyValue(key = "service", expression = "service.id.serialize()") Service service,
+			@ObservationKeyValue(key = "profiles") Collection<String> profileNames
+	) {
 		if (CollectionUtils.isEmpty(profileNames)) {
 			return new ConfigurationEnvironment(service.slug(), List.of(), List.of());
 		}

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentLocator.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentLocator.java
@@ -5,13 +5,12 @@ import com.konfigyr.security.AuthenticatedPrincipal;
 import com.konfigyr.vault.*;
 import com.konfigyr.vault.Properties;
 import com.konfigyr.vault.state.RepositoryStateException;
-import io.micrometer.observation.annotation.ObservationKeyValue;
-import io.micrometer.observation.annotation.Observed;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.util.CollectionUtils;
-import org.springframework.util.StringUtils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.*;
@@ -24,51 +23,46 @@ public class ConfigurationEnvironmentLocator {
 	private final VaultAccessor vaultAccessor;
 	private final ProfileManager profileManager;
 	private final ConfigurationCache configurationCache;
+	private final ObservationRegistry observationRegistry;
 
-	@Observed(name = "konfigyr.vault.environment.locator")
-	public ConfigurationEnvironment locate(
-			AuthenticatedPrincipal principal,
-			@ObservationKeyValue(key = "service", expression = "service.id.serialize()") Service service,
-			@ObservationKeyValue(key = "profiles") String profile
-	) {
+	public ConfigurationEnvironment locate(AuthenticatedPrincipal principal, Service service, String profile) {
 		return locate(principal, service, Collections.singleton(profile));
 	}
 
-	@Observed(name = "konfigyr.vault.environment.locator")
-	public ConfigurationEnvironment locate(
-			AuthenticatedPrincipal principal,
-			@ObservationKeyValue(key = "service", expression = "service.id.serialize()") Service service,
-			@ObservationKeyValue(key = "profiles") String... profiles
-	) {
+	public ConfigurationEnvironment locate(AuthenticatedPrincipal principal, Service service, String... profiles) {
 		return locate(principal, service, List.of(profiles));
 	}
 
-	@Observed(name = "konfigyr.vault.environment.locator")
-	public ConfigurationEnvironment locate(
-			AuthenticatedPrincipal principal,
-			@ObservationKeyValue(key = "service", expression = "service.id.serialize()") Service service,
-			@ObservationKeyValue(key = "profiles") Collection<String> profileNames
-	) {
+	public ConfigurationEnvironment locate(AuthenticatedPrincipal principal, Service service, Collection<String> profileNames) {
 		if (CollectionUtils.isEmpty(profileNames)) {
-			return new ConfigurationEnvironment(service.slug(), List.of(), List.of());
+			return new ConfigurationEnvironment(service.slug(), Collections.emptyList(), Collections.emptyList());
 		}
 
-		final List<PropertySource> properties = new ArrayList<>(profileNames.size());
+		final Observation observation = ConfigurationEnvironmentObservation.create(observationRegistry, service);
 
-		for (String profileName : profileNames) {
-			profileManager.get(service, profileName).map(profile -> createPropertySource(
-					principal, service, profile)
-			).ifPresentOrElse(properties::add, () -> log.warn(
-					"Profile '{}' not found for service '{}'", profileName, service.slug()
-			));
-		}
+		return observation.observe(() -> {
+			final List<PropertySource> properties = new ArrayList<>(profileNames.size());
 
-		if (log.isDebugEnabled()) {
-			log.debug("Successfully located configuration environment for '{}' service and {} profiles: {}",
-					service, StringUtils.collectionToCommaDelimitedString(profileNames), properties);
-		}
+			for (String profileName : profileNames) {
+				profileManager.get(service, profileName).map(profile -> {
+					final PropertySource source = createPropertySource(principal, service, profile);
+					observation.event(ConfigurationEnvironmentObservation.located(profileName));
 
-		return new ConfigurationEnvironment(service.slug(), List.copyOf(profileNames), properties);
+					if (log.isDebugEnabled()) {
+						log.debug("Successfully located configuration environment for '{}' service and {} profile: {}",
+								service.id(), profileName, source);
+					}
+
+					return source;
+				}).ifPresentOrElse(properties::add, () -> {
+					log.warn("Profile '{}' not found for service '{}'", profileName, service.id());
+
+					observation.event(ConfigurationEnvironmentObservation.missing(profileName));
+				});
+			}
+
+			return new ConfigurationEnvironment(service.slug(), List.copyOf(profileNames), properties);
+		});
 	}
 
 	private PropertySource createPropertySource(AuthenticatedPrincipal principal, Service service, Profile profile) {

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentObservation.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentObservation.java
@@ -21,11 +21,13 @@ final class ConfigurationEnvironmentObservation {
 	}
 
 	static Observation.Event located(String profile) {
-		return Observation.Event.of("konfigyr.vault.environment.located", profile);
+		return Observation.Event.of("konfigyr.vault.environment.located",
+				"located configuration environment for '%s' profile".formatted(profile));
 	}
 
 	static Observation.Event missing(String profile) {
-		return Observation.Event.of("konfigyr.vault.environment.missing", profile);
+		return Observation.Event.of("konfigyr.vault.environment.missing",
+				"configuration environment is missing for '%s' profile".formatted(profile));
 	}
 
 	static final class Context extends Observation.Context {

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentObservation.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentObservation.java
@@ -1,0 +1,68 @@
+package com.konfigyr.vault.environment;
+
+import com.konfigyr.namespace.Service;
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+final class ConfigurationEnvironmentObservation {
+
+	static final String OBSERVATION_NAME = "konfigyr.vault.environment.locator";
+
+	static Observation create(ObservationRegistry registry, Service service) {
+		return Observation.createNotStarted(Convention.INSTANCE, () -> new Context(service), registry);
+	}
+
+	static Observation.Event located(String profile) {
+		return Observation.Event.of("konfigyr.vault.environment.located", profile);
+	}
+
+	static Observation.Event missing(String profile) {
+		return Observation.Event.of("konfigyr.vault.environment.missing", profile);
+	}
+
+	static final class Context extends Observation.Context {
+		private final Service service;
+
+		Context(Service service) {
+			this.service = service;
+		}
+
+		String id() {
+			return service.id().serialize();
+		}
+
+		String name() {
+			return service.slug();
+		}
+	}
+
+	static final class Convention implements ObservationConvention<Context> {
+
+		static final ObservationConvention<Context> INSTANCE = new Convention();
+
+		@Override
+		public String getName() {
+			return OBSERVATION_NAME;
+		}
+
+		@Override
+		public String getContextualName(Context context) {
+			return "locating configuration environment for '" + context.name() + "' service";
+		}
+
+		@Override
+		public KeyValues getHighCardinalityKeyValues(Context context) {
+			return KeyValues.of("konfigyr.namespace.service", context.id());
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return context instanceof Context;
+		}
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentObservation.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/environment/ConfigurationEnvironmentObservation.java
@@ -12,6 +12,10 @@ final class ConfigurationEnvironmentObservation {
 
 	static final String OBSERVATION_NAME = "konfigyr.vault.environment.locator";
 
+	private ConfigurationEnvironmentObservation() {
+		// prevent instantiation
+	}
+
 	static Observation create(ObservationRegistry registry, Service service) {
 		return Observation.createNotStarted(Convention.INSTANCE, () -> new Context(service), registry);
 	}

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/extension/ObservedVaultExtension.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/extension/ObservedVaultExtension.java
@@ -1,0 +1,169 @@
+package com.konfigyr.vault.extension;
+
+import com.konfigyr.vault.*;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Map;
+
+/**
+ * {@link VaultExtension} that adds Micrometer-based observations around {@link Vault} operations.
+ * <p>
+ * This extension instruments the vault execution lifecycle and provides end-to-end operational
+ * visibility for configuration state access, cryptographic operations, repository mutations,
+ * and change workflows.
+ * <p>
+ * The extension decorates the target {@link Vault} with an observed variant that records timing,
+ * execution outcomes, and contextual metadata through the configured {@link ObservationRegistry}.
+ * <p>
+ * The observation boundary intentionally wraps the entire vault operation, including:
+ * <ul>
+ *     <li>Lock acquisition and contention time</li>
+ *     <li>Repository access and mutation operations</li>
+ *     <li>Encryption and decryption work</li>
+ *     <li>Event publication overhead</li>
+ *     <li>Internal validation and orchestration logic</li>
+ * </ul>
+ *
+ * This extension is therefore expected to be the outermost decorator in the {@link VaultExtension}
+ * chain. Placing observations outside the locking layer ensures that recorded durations
+ * accurately represent the total latency experienced by callers, including time spent waiting
+ * on profile-scoped locks.
+ *
+ * <p>
+ * <b>Important security consideration</b>, observations produced by this extension must never
+ * expose sensitive configuration data and should avoid recording:
+ * <ul>
+ *     <li>Unsealed property values</li>
+ *     <li>Property names containing sensitive information</li>
+ *     <li>Repository contents</li>
+ *     <li>Commit payloads or plaintext diffs</li>
+ * </ul>
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see Vault
+ * @see VaultExtension
+ * @see ObservationRegistry
+ */
+@NullMarked
+@RequiredArgsConstructor
+final class ObservedVaultExtension implements VaultExtension {
+
+	static final String OBSERVATION_NAME_PREFIX = "konfigyr.vault.";
+
+	private final ObservationRegistry registry;
+
+	@Override
+	public Vault extend(Vault vault) {
+		return new ObservedVault(vault, registry);
+	}
+
+	static final class ObservedVault extends AbstractDelegatingVault {
+
+		private final ObservationRegistry registry;
+
+		ObservedVault(Vault delegate, ObservationRegistry registry) {
+			super(delegate);
+			this.registry = registry;
+		}
+
+		@Override
+		public Properties state() {
+			return createObservation(ObservedOperation.STATE)
+					.observe(super::state);
+		}
+
+		@Override
+		public Map<String, String> unseal() {
+			return createObservation(ObservedOperation.UNSEAL)
+					.observe(() -> super.unseal());
+		}
+
+		@Override
+		public PropertyValue seal(PropertyValue property) {
+			return createObservation(ObservedOperation.SEAL_PROPERTY)
+					.observe(() -> super.seal(property));
+		}
+
+		@Override
+		public PropertyValue unseal(PropertyValue property) {
+			return createObservation(ObservedOperation.UNSEAL_PROPERTY)
+					.observe(() -> super.unseal(property));
+		}
+
+		@Override
+		public ApplyResult apply(PropertyChanges changes) {
+			return createObservation(ObservedOperation.APPLY)
+					.observe(() -> super.apply(changes));
+		}
+
+		@Override
+		public ChangeRequest submit(PropertyChanges changes) {
+			return createObservation(ObservedOperation.SUBMIT)
+					.observe(() -> super.submit(changes));
+		}
+
+		@Override
+		public ApplyResult merge(ChangeRequest changeRequest) {
+			return createObservation(ObservedOperation.MERGE)
+					.highCardinalityKeyValue("konfigyr.vault.change-request", changeRequest.id().serialize())
+					.observe(() -> super.merge(changeRequest));
+		}
+
+		@Override
+		public ChangeRequest discard(ChangeRequest changeRequest) {
+			return createObservation(ObservedOperation.DISCARD)
+					.highCardinalityKeyValue("konfigyr.vault.change-request", changeRequest.id().serialize())
+					.observe(() -> super.discard(changeRequest));
+		}
+
+		@Override
+		public void close() throws Exception {
+			createObservation(ObservedOperation.CLOSE)
+					.observeChecked(super::close);
+		}
+
+		private Observation createObservation(ObservedOperation operation) {
+			final String service = service().id().serialize();
+			final String profile = profile().id().serialize();
+
+			return Observation.createNotStarted(operation.observationName(), registry)
+					.contextualName(operation.contextualName(service, profile))
+					.highCardinalityKeyValue("konfigyr.namespace.service", service)
+					.highCardinalityKeyValue("konfigyr.vault.profile", profile);
+		}
+
+	}
+
+	enum ObservedOperation {
+		STATE("state", "reading state of vault profile '%s' for service '%s'"),
+		UNSEAL("unseal", "unsealing state of vault profile '%s' for service '%s'"),
+		SEAL_PROPERTY("seal-property", "sealing value of vault profile '%s' for service '%s'"),
+		UNSEAL_PROPERTY("unseal-property", "unsealing value of vault profile '%s' for service '%s'"),
+		APPLY("apply", "applying changes to vault profile '%s' for service '%s'"),
+		SUBMIT("submit", "submitting changes for review to vault profile '%s' for service '%s'"),
+		MERGE("merge", "merging proposed changes to vault profile '%s' for service '%s'"),
+		DISCARD("discard", "discarding proposed changes to vault profile '%s' for service '%s'"),
+		CLOSE("close", "closing vault profile '%s' for service '%s'");
+
+		private final String name;
+		private final String contextualNameTemplate;
+
+		ObservedOperation(String operation, String contextualNameTemplate) {
+			this.name = OBSERVATION_NAME_PREFIX + operation;
+			this.contextualNameTemplate = contextualNameTemplate;
+		}
+
+		String observationName() {
+			return name;
+		}
+
+		String contextualName(String service, String profile) {
+			return contextualNameTemplate.formatted(service, profile);
+		}
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/extension/VaultExtensionConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/extension/VaultExtensionConfiguration.java
@@ -1,23 +1,94 @@
 package com.konfigyr.vault.extension;
 
 import com.konfigyr.vault.VaultExtension;
+import io.micrometer.observation.ObservationRegistry;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 
+/**
+ * Configuration class for core {@link VaultExtension VaultExtensions}.
+ * <p>
+ * This configuration registers the default extension chain applied to every resolved
+ * {@link com.konfigyr.vault.Vault} instance. Extensions are ordered explicitly to ensure correct
+ * operational semantics, observability, concurrency guarantees, and event consistency.
+ * <p>
+ * The resulting invocation chain is:
+ * <pre>
+ * ObservedVaultExtension
+ *     → LockingVaultExtension
+ *         → PublishingVaultExtension
+ *             → Actual Vault
+ * </pre>
+ *
+ * <strong>1. Observation Layer</strong>
+ * <p>
+ * The {@link ObservedVaultExtension} is applied first (outermost layer) so that Micrometer
+ * observations encompass the entire lifecycle of a vault operation, including:
+ *
+ * <ul>
+ *     <li>Lock acquisition and contention time</li>
+ *     <li>Repository interactions</li>
+ *     <li>Event publication overhead</li>
+ *     <li>Internal processing latency</li>
+ * </ul>
+ *
+ * Placing observations outside the locking layer ensures that metrics reflect the real end-to-end
+ * duration experienced by callers rather than only the internal execution time after lock acquisition.
+ * <p>
+ * <strong>2. Locking Layer</strong>
+ * <p>
+ * The {@link LockingVaultExtension} is applied after observations and before event publication. This
+ * establishes the lock boundary as the authoritative consistency boundary for all state mutations.
+ * <p>
+ * The lock protects:
+ *
+ * <ul>
+ *     <li>Repository state transitions</li>
+ *     <li>Branch and revision updates</li>
+ *     <li>Change request lifecycle mutations</li>
+ *     <li>Event publication ordering</li>
+ * </ul>
+ *
+ * Keeping event publication inside the lock guarantees that emitted events remain causally ordered
+ * with the underlying repository mutations and prevents race conditions between concurrent apply,
+ * merge, or discard operations.
+ * <p>
+ * <strong>3. Event Publishing Layer</strong>
+ * <p>
+ * The {@link PublishingVaultExtension} is placed closest to the actual vault implementation so that
+ * events are only emitted after a successful mutation has completed.
+ * <p>
+ * This ensures:
+ *
+ * <ul>
+ *     <li>Only committed state transitions produce events</li>
+ *     <li>Failed operations do not emit misleading events</li>
+ *     <li>Published events reflect the final resulting state</li>
+ * </ul>
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see VaultExtension
+ */
 @Configuration(proxyBeanMethods = false)
 public class VaultExtensionConfiguration {
 
 	@Bean
-	@Order(Ordered.HIGHEST_PRECEDENCE)
+	@Order(1)
+	VaultExtension observedVaultExtension(ObservationRegistry observationRegistry) {
+		return new ObservedVaultExtension(observationRegistry);
+	}
+
+	@Bean
+	@Order(2)
 	VaultExtension lockingVaultExtension() {
 		return new LockingVaultExtension();
 	}
 
 	@Bean
-	@Order
+	@Order(3)
 	VaultExtension publishingVaultExtension(ApplicationEventPublisher eventPublisher) {
 		return new PublishingVaultExtension(eventPublisher);
 	}

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/gatekeeper/ChangeRequestGatekeeper.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/gatekeeper/ChangeRequestGatekeeper.java
@@ -2,6 +2,7 @@ package com.konfigyr.vault.gatekeeper;
 
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.vault.ChangeRequestMergeStatus;
+import io.micrometer.observation.ObservationRegistry;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.core.OrderComparator;
@@ -30,8 +31,10 @@ public final class ChangeRequestGatekeeper {
 
 	private final List<? extends Gate> gates;
 	private final GateContextFactory contextFactory;
+	private final ObservationRegistry observationRegistry;
 
-	ChangeRequestGatekeeper(GateContextFactory contextFactory, Iterable<? extends Gate> gates) {
+	ChangeRequestGatekeeper(ObservationRegistry observationRegistry, GateContextFactory contextFactory, Iterable<? extends Gate> gates) {
+		this.observationRegistry = observationRegistry;
 		this.contextFactory = contextFactory;
 		this.gates = StreamSupport.stream(gates.spliterator(), false)
 				.sorted(OrderComparator.INSTANCE)
@@ -48,28 +51,30 @@ public final class ChangeRequestGatekeeper {
 	 * @return the resulting {@link ChangeRequestMergeStatus}, never {@literal null}
 	 */
 	public ChangeRequestMergeStatus evaluate(EntityId changeRequestId) {
-		if (log.isDebugEnabled()) {
-			log.debug("Evaluating change request with {} against {} gate(s)", changeRequestId, gates.size());
-		}
-
-		final GateContext context = contextFactory.create(changeRequestId);
-
-		for (Gate gate : gates) {
-			final GateResult result = gate.evaluate(context);
-
+		return GatekeeperObservation.decorate(observationRegistry, changeRequestId, () -> {
 			if (log.isDebugEnabled()) {
-				log.debug("Gatekeeper obtained evaluation result: [gate={}, result={}, context={}]",
-						ClassUtils.getShortName(gate.getClass()), result, context);
+				log.debug("Evaluating change request with {} against {} gate(s)", changeRequestId, gates.size());
 			}
 
-			if (result instanceof GateResult.Block(ChangeRequestMergeStatus status, String reason)) {
-				log.info("Gatekeeper evaluated merge status of '{}' (reason: {}) using '{}' for change request: {}",
-						status, reason, ClassUtils.getShortName(gate.getClass()), context.changeRequestId());
-				return status;
-			}
-		}
+			final GateContext context = contextFactory.create(changeRequestId);
 
-		return ChangeRequestMergeStatus.MERGEABLE;
+			for (Gate gate : gates) {
+				final GateResult result = gate.evaluate(context);
+
+				if (log.isDebugEnabled()) {
+					log.debug("Gatekeeper obtained evaluation result: [gate={}, result={}, context={}]",
+							ClassUtils.getShortName(gate.getClass()), result, context);
+				}
+
+				if (result instanceof GateResult.Block(ChangeRequestMergeStatus status, String reason)) {
+					log.info("Gatekeeper evaluated merge status of '{}' (reason: {}) using '{}' for change request: {}",
+							status, reason, ClassUtils.getShortName(gate.getClass()), context.changeRequestId());
+					return status;
+				}
+			}
+
+			return ChangeRequestMergeStatus.MERGEABLE;
+		});
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/gatekeeper/ChangeRequestGatekeeperConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/gatekeeper/ChangeRequestGatekeeperConfiguration.java
@@ -3,6 +3,7 @@ package com.konfigyr.vault.gatekeeper;
 import com.konfigyr.namespace.Services;
 import com.konfigyr.vault.ProfileManager;
 import com.konfigyr.vault.state.StateRepositoryFactory;
+import io.micrometer.observation.ObservationRegistry;
 import org.jooq.DSLContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -23,8 +24,8 @@ public class ChangeRequestGatekeeperConfiguration {
 	}
 
 	@Bean
-	ChangeRequestGatekeeper changeRequestGatekeeper(GateContextFactory contextFactory) {
-		return new ChangeRequestGatekeeper(contextFactory, List.of(
+	ChangeRequestGatekeeper changeRequestGatekeeper(ObservationRegistry observationRegistry, GateContextFactory contextFactory) {
+		return new ChangeRequestGatekeeper(observationRegistry, contextFactory, List.of(
 				new LifecycleGate(),
 				new RepositoryStateGate(),
 				new ReviewStateGate()

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/gatekeeper/GatekeeperObservation.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/gatekeeper/GatekeeperObservation.java
@@ -1,0 +1,77 @@
+package com.konfigyr.vault.gatekeeper;
+
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.vault.ChangeRequestMergeStatus;
+import io.micrometer.common.KeyValues;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationConvention;
+import io.micrometer.observation.ObservationRegistry;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.util.function.Supplier;
+
+@NullMarked
+final class GatekeeperObservation {
+
+	static final String OBSERVATION_NAME = "konfigyr.vault.gatekeeper";
+
+	private GatekeeperObservation() {
+		// prevent instantiation
+	}
+
+	static ChangeRequestMergeStatus decorate(ObservationRegistry registry, EntityId id, Supplier<ChangeRequestMergeStatus> evaluator) {
+		final Observation observation = Observation.createNotStarted(Convention.INSTANCE, () -> new Context(id), registry);
+
+		return observation.observe(() -> {
+			final ChangeRequestMergeStatus status = evaluator.get();
+			final Context context = (Context) observation.getContext();
+			context.status(status);
+			return status;
+		});
+	}
+
+	static final class Context extends Observation.Context {
+		private final EntityId id;
+		private @Nullable ChangeRequestMergeStatus status;
+
+		Context(EntityId id) {
+			this.id = id;
+		}
+
+		void status(@Nullable ChangeRequestMergeStatus status) {
+			this.status = status;
+		}
+	}
+
+	static final class Convention implements ObservationConvention<Context> {
+
+		static final ObservationConvention<Context> INSTANCE = new Convention();
+
+		@Override
+		public String getName() {
+			return OBSERVATION_NAME;
+		}
+
+		@Override
+		public String getContextualName(Context context) {
+			return "evaluation of merge status for change request: " + context.id.serialize();
+		}
+
+		@Override
+		public KeyValues getHighCardinalityKeyValues(Context context) {
+			return KeyValues.of("konfigyr.vault.change-request", context.id.serialize());
+		}
+
+		@Override
+		public KeyValues getLowCardinalityKeyValues(Context context) {
+			return KeyValues.of("konfigyr.vault.change-request.merge-status",
+					context.status == null ? "n/a" : context.status.name());
+		}
+
+		@Override
+		public boolean supportsContext(Observation.Context context) {
+			return context instanceof Context;
+		}
+	}
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/state/VaultStateManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/state/VaultStateManager.java
@@ -11,6 +11,7 @@ import com.konfigyr.vault.Vault;
 import com.konfigyr.vault.VaultAccessor;
 import com.konfigyr.vault.VaultExtension;
 import com.konfigyr.vault.changes.ChangeRequestManager;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
@@ -38,6 +39,7 @@ public class VaultStateManager implements StateRepositoryFactory, VaultAccessor 
 	}
 
 	@Override
+	@Observed(name = "konfigyr.vault.open")
 	public Vault open(AuthenticatedPrincipal principal, Service service, Profile profile) {
 		final KeysetOperations keysetOperations = keysetOperationsFactory.create(
 				KeysetDefinition.of("vault/" + service.id().serialize(), TinkAlgorithm.AES256_GCM)

--- a/konfigyr-api/src/main/resources/application-local.example.yml
+++ b/konfigyr-api/src/main/resources/application-local.example.yml
@@ -43,3 +43,20 @@ konfigyr:
       # You can generate a new key here: http://konfigyr-web.app.dev.ebf.de/docs/development-guide/development
       value: RrdmFi8AmHSXzalSmdxIxnCYQlfdPzEytzLcvX3STKU=
 
+management:
+  endpoints:
+    web:
+      exposure:
+        # Exposes all endpoints on the management server
+        include: '*'
+
+  endpoint:
+    health:
+      # Alays show detailed health information for each individual health check
+      show-details: always
+
+  otlp:
+    metrics:
+      export:
+        # Disables the OTLP metrics exporter on your local machine
+        enabled: false

--- a/konfigyr-api/src/main/resources/application.yml
+++ b/konfigyr-api/src/main/resources/application.yml
@@ -37,3 +37,13 @@ spring:
   mvc:
     problemdetails:
       enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+
+  endpoint:
+    health:
+      show-details: when-authorized

--- a/konfigyr-api/src/main/resources/application.yml
+++ b/konfigyr-api/src/main/resources/application.yml
@@ -39,6 +39,12 @@ spring:
       enabled: true
 
 management:
+  info:
+    java:
+      enabled: true
+    build:
+      enabled: true
+
   endpoints:
     web:
       exposure:

--- a/konfigyr-api/src/main/resources/application.yml
+++ b/konfigyr-api/src/main/resources/application.yml
@@ -53,3 +53,7 @@ management:
   endpoint:
     health:
       show-details: when-authorized
+
+  observations:
+    annotations:
+      enabled: true

--- a/konfigyr-api/src/main/resources/application.yml
+++ b/konfigyr-api/src/main/resources/application.yml
@@ -50,10 +50,6 @@ management:
       exposure:
         include: health, info, metrics
 
-  endpoint:
-    health:
-      show-details: when-authorized
-
   observations:
     annotations:
       enabled: true

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/provenance/ProvenanceEvaluatorTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/provenance/ProvenanceEvaluatorTest.java
@@ -4,6 +4,7 @@ import com.konfigyr.artifactory.*;
 import com.konfigyr.io.ByteArray;
 import com.konfigyr.test.AbstractIntegrationTest;
 import com.konfigyr.version.Version;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -20,6 +21,9 @@ class ProvenanceEvaluatorTest extends AbstractIntegrationTest {
 
 	@Autowired
 	ProvenanceEvaluator evaluator;
+
+	@Autowired
+	TestObservationRegistry registry;
 
 	@Test
 	@DisplayName("should perform provenance evaluation on new property metadata for version")
@@ -119,6 +123,15 @@ class ProvenanceEvaluatorTest extends AbstractIntegrationTest {
 				.returns(coordinates.version(), Provenance::lastSeen)
 				.returns(1, Provenance::occurrences)
 				.returns(ByteArray.fromBase64String("cRJ8jlPpTPmTJEoZEZNDSjvdqafG05QkzNJplXyu9J0="), Provenance::checksum);
+
+		assertThat(registry)
+				.hasObservationWithNameEqualTo("konfigyr.artifactory.provenance-evaluation")
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.doesNotHaveError()
+				.hasHighCardinalityKeyValue("konfigyr.artifactory.artifact", "com.konfigyr:konfigyr-crypto-api:1.0.1")
+				.hasHighCardinalityKeyValue("konfigyr.artifactory.property", "spring.application.name");
 	}
 
 	static PropertyDescriptor metadata(String name, String typeName, String description, JsonSchema schema) {

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
@@ -17,6 +17,8 @@ import com.konfigyr.test.AbstractIntegrationTest;
 import com.konfigyr.test.TestAccounts;
 import com.konfigyr.test.TestPrincipals;
 import com.konfigyr.vault.*;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
@@ -648,12 +650,33 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 		final var repository = mock(AuditEventRepository.class);
 		doThrow(new RuntimeException("DB down")).when(repository).insert(any());
 
-		final var listener = new AuditEventListener(mock(), repository);
+		final var listener = new AuditEventListener(repository, mock(), ObservationRegistry.NOOP);
 
 		assertThatNoException()
 				.isThrownBy(() -> listener.on(new AccountEvent.Updated(EntityId.from(999))));
 
 		verify(repository).insert(any());
+	}
+
+	@Test
+	@DisplayName("should observe audit event listener")
+	void shouldObserveEventListener() {
+		final var registry = TestObservationRegistry.create();
+		final var listener = new AuditEventListener(repository, mock(), registry);
+
+		assertThatNoException()
+				.isThrownBy(() -> listener.on(new AccountEvent.Deleted(EntityId.from(1))));
+
+		assertThat(registry)
+				.hasObservationWithNameEqualTo(AuditObservation.OBSERVATION_NAME)
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.doesNotHaveError()
+				.hasHighCardinalityKeyValue("konfigyr.audit.event.id", EntityId.from(1).serialize())
+				.hasLowCardinalityKeyValue("konfigyr.audit.event.type", "accounts.deleted")
+				.hasContextualNameEqualTo("audit listener event with '%s' type and '%s' resource identifier"
+						.formatted("accounts.deleted", EntityId.from(1).serialize()));
 	}
 
 	private ObjectAssert<AuditRecord> assertAuditRecord(String entityType, EntityId entityId) {

--- a/konfigyr-api/src/test/java/com/konfigyr/queue/WorkerQueueAutoConfigurationTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/queue/WorkerQueueAutoConfigurationTest.java
@@ -1,5 +1,6 @@
 package com.konfigyr.queue;
 
+import io.micrometer.observation.ObservationRegistry;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,12 +23,16 @@ class WorkerQueueAutoConfigurationTest {
 	@Mock
 	DSLContext context;
 
+	@Mock
+	ObservationRegistry registry;
+
 	ApplicationContextRunner runner;
 
 	@BeforeEach
 	void setup() {
 		runner = new ApplicationContextRunner()
 				.withBean(DSLContext.class, () -> context)
+				.withBean(ObservationRegistry.class, () -> registry)
 				.withConfiguration(AutoConfigurations.of(WorkerQueueAutoConfiguration.class));
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/queue/WorkerQueueSchedulerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/queue/WorkerQueueSchedulerTest.java
@@ -3,6 +3,7 @@ package com.konfigyr.queue;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.konfigyr.entity.EntityId;
+import io.micrometer.observation.tck.TestObservationRegistry;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.AdditionalAnswers;
@@ -26,8 +27,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.await;
 import static org.mockito.Mockito.*;
 
@@ -43,6 +43,7 @@ class WorkerQueueSchedulerTest {
 	@Mock
 	QueueProcessor secondQueueProcessor;
 
+	TestObservationRegistry registry;
 	ExecutorService executor;
 
 	QueueRegistrar registrar;
@@ -53,6 +54,7 @@ class WorkerQueueSchedulerTest {
 		Logger logger = (Logger) LoggerFactory.getLogger(WorkerQueueScheduler.class);
 		logger.setLevel(Level.TRACE);
 
+		registry = TestObservationRegistry.create();
 		executor = Executors.newFixedThreadPool(3);
 		registrar = QueueRegistrar.of(
 				QueueProcessorRegistration.of("first-queue", firstQueueProcessor)
@@ -63,7 +65,7 @@ class WorkerQueueSchedulerTest {
 						.backoff(Duration.ofMillis(250))
 						.timeout(Duration.ofMillis(400))
 		);
-		scheduler = new WorkerQueueScheduler(logger, queue, registrar);
+		scheduler = new WorkerQueueScheduler(logger, queue, registrar, registry);
 		scheduler.afterPropertiesSet();
 	}
 
@@ -239,7 +241,7 @@ class WorkerQueueSchedulerTest {
 						.taskExecutor(secondTaskExecutor),
 				QueueProcessorRegistration.of("third-queue", secondQueueProcessor)
 						.taskExecutor(thirdTaskExecutor)
-		));
+		), registry);
 
 		assertThatNoException()
 				.as("Should not throw an exception when invoking lifecycle methods")
@@ -253,6 +255,37 @@ class WorkerQueueSchedulerTest {
 		verify((DisposableBean) firstTaskExecutor).destroy();
 		verify((AutoCloseable) secondTaskExecutor).close();
 		verifyNoInteractions(thirdTaskExecutor);
+	}
+
+	@Test
+	@DisplayName("should observe the the queue consume and task processing operations")
+	void observeQueueConsumeAndExecutorOperations() {
+		final var task = new QueuedTask(UUID.randomUUID(), "first-queue", EntityId.from(1));
+		doReturn(List.of(task)).when(queue).consume();
+
+		assertThatNoException().isThrownBy(scheduler::schedule);
+
+		verify(queue).consume();
+
+		await().untilAsserted(() -> {
+			verify(firstQueueProcessor).process(EntityId.from(1));
+			verify(queue).complete(eq(task));
+		});
+
+		assertThat(registry)
+				.hasObservationWithNameEqualTo(QueueObservation.CONSUME_OBSERVATION_NAME)
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.hasNoKeyValues();
+
+		assertThat(registry)
+				.hasObservationWithNameEqualTo(QueueObservation.PROCESS_OBSERVATION_NAME)
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.hasLowCardinalityKeyValue("konfigyr.queue.name", "first-queue")
+				.hasHighCardinalityKeyValue("konfigyr.queue.entity", EntityId.from(1).serialize());
 	}
 
 	static Stream<QueuedTask> generateTasks(String queueName, int count) {

--- a/konfigyr-api/src/test/java/com/konfigyr/security/AuthenticatedPrincipalContextFilterTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/security/AuthenticatedPrincipalContextFilterTest.java
@@ -1,0 +1,121 @@
+package com.konfigyr.security;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatException;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticatedPrincipalContextFilterTest {
+
+	@Mock
+	Authentication authentication;
+
+	@Mock
+	AuthenticatedPrincipal principal;
+
+	AuthenticatedPrincipalContextFilter filter;
+	MockHttpServletRequest request;
+	MockHttpServletResponse response;
+
+	@BeforeEach
+	void setup() {
+		filter = new AuthenticatedPrincipalContextFilter();
+		request = new MockHttpServletRequest();
+		response = new MockHttpServletResponse();
+	}
+
+	@AfterEach
+	void cleanup() {
+		SecurityContextHolder.clearContext();
+		MDC.clear();
+	}
+
+	@Test
+	@DisplayName("should populate MDC with actor and actor type when principal is present")
+	void shouldPopulateMdc() throws Exception {
+		doReturn("user-subject-id").when(principal).get();
+		doReturn(PrincipalType.USER_ACCOUNT).when(principal).getType();
+		doReturn(principal).when(authentication).getPrincipal();
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		filter.doFilter(request, response, (_, _) -> {
+			assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_KEY))
+					.isEqualTo("user-subject-id");
+
+			assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_TYPE_KEY))
+					.isEqualTo("USER_ACCOUNT");
+		});
+
+		assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_KEY))
+				.isNull();
+
+		assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_TYPE_KEY))
+				.isNull();
+	}
+
+	@Test
+	@DisplayName("should not populate MDC when no authentication is present")
+	void shouldNotPopulateMdcWhenUnauthenticated() throws Exception {
+		filter.doFilter(request, response, (_, _) -> {
+			assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_KEY))
+					.isNull();
+
+			assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_TYPE_KEY))
+					.isNull();
+		});
+	}
+
+	@Test
+	@DisplayName("should not populate MDC when principal is not an AuthenticatedPrincipal")
+	void shouldNotPopulateMdcForNonAuthenticatedPrincipal() throws Exception {
+		doReturn("plain-string-principal").when(authentication).getPrincipal();
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		filter.doFilter(request, response, (_, _) -> {
+			assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_KEY))
+					.isNull();
+
+			assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_TYPE_KEY))
+					.isNull();
+		});
+	}
+
+	@Test
+	@DisplayName("should clean up MDC even when filter chain throws an exception")
+	void shouldCleanUpMdcOnException() {
+		doReturn("user-subject-id").when(principal).get();
+		doReturn(PrincipalType.USER_ACCOUNT).when(principal).getType();
+		doReturn(principal).when(authentication).getPrincipal();
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		final var cause = new RuntimeException("filter chain failure");
+
+		assertThatException().isThrownBy(() ->
+				filter.doFilter(request, response, (_, _) -> {
+					assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_KEY))
+							.isEqualTo("user-subject-id");
+					throw cause;
+				})
+		).isEqualTo(cause);
+
+		assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_KEY))
+				.isNull();
+
+		assertThat(MDC.get(AuthenticatedPrincipalContextFilter.ACTOR_TYPE_KEY))
+				.isNull();
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/security/access/AccessControlRepositoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/security/access/AccessControlRepositoryTest.java
@@ -3,6 +3,8 @@ package com.konfigyr.security.access;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.NamespaceRole;
 import com.konfigyr.test.AbstractIntegrationTest;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -15,6 +17,9 @@ class AccessControlRepositoryTest extends AbstractIntegrationTest {
 	@Autowired
 	AccessControlRepository repository;
 
+	@Autowired
+	TestObservationRegistry observationRegistry;
+
 	@Test
 	@DisplayName("should fail to load access control for unknown object type")
 	void unknownObjectType() {
@@ -24,6 +29,13 @@ class AccessControlRepositoryTest extends AbstractIntegrationTest {
 				.isThrownBy(() -> repository.get(identity))
 				.returns(identity, ObjectIdentityNotFound::getObjectIdentity)
 				.withNoCause();
+
+		assertThatObservation()
+				.hasError()
+				.hasLowCardinalityKeyValue("konfigyr.identity.type", "unknown")
+				.hasHighCardinalityKeyValue("konfigyr.identity.id", "id")
+				.assertThatError()
+				.isInstanceOf(ObjectIdentityNotFound.class);
 	}
 
 	@Test
@@ -35,6 +47,13 @@ class AccessControlRepositoryTest extends AbstractIntegrationTest {
 				.isThrownBy(() -> repository.get(identity))
 				.returns(identity, ObjectIdentityNotFound::getObjectIdentity)
 				.withNoCause();
+
+		assertThatObservation()
+				.hasError()
+				.hasLowCardinalityKeyValue("konfigyr.identity.type", ObjectIdentity.NAMESPACE_TYPE)
+				.hasHighCardinalityKeyValue("konfigyr.identity.id", "unknown")
+				.assertThatError()
+				.isInstanceOf(ObjectIdentityNotFound.class);
 	}
 
 	@Test
@@ -50,6 +69,11 @@ class AccessControlRepositoryTest extends AbstractIntegrationTest {
 						AccessGrant.forNamespaceMember(EntityId.from(2), NamespaceRole.USER),
 						AccessGrant.forNamespaceApplication("kfg-A2c7mvoxEP1rb-_NQLvaZ5KJNTGR-oOp")
 				);
+
+		assertThatObservation()
+				.doesNotHaveError()
+				.hasLowCardinalityKeyValue("konfigyr.identity.type", ObjectIdentity.NAMESPACE_TYPE)
+				.hasHighCardinalityKeyValue("konfigyr.identity.id", "konfigyr");
 	}
 
 	@Test
@@ -65,6 +89,11 @@ class AccessControlRepositoryTest extends AbstractIntegrationTest {
 						AccessGrant.forNamespaceApplication("kfg-A2c7mvoxEP346BQCSuwnJ5ZNQIEsgCBG"),
 						AccessGrant.forNamespaceApplication("kfg-BAQp6u2ElYmuPyoa2Hj766ju0PPvL2Iq")
 				);
+
+		assertThatObservation()
+				.doesNotHaveError()
+				.hasLowCardinalityKeyValue("konfigyr.identity.type", ObjectIdentity.NAMESPACE_TYPE)
+				.hasHighCardinalityKeyValue("konfigyr.identity.id", EntityId.from(1L).serialize());
 	}
 
 	@Test
@@ -80,6 +109,19 @@ class AccessControlRepositoryTest extends AbstractIntegrationTest {
 						AccessGrant.forNamespaceApplication("kfg-A2c7mvoxEP346BQCSuwnJ5ZNQIEsgCBG"),
 						AccessGrant.forNamespaceApplication("kfg-BAQp6u2ElYmuPyoa2Hj766ju0PPvL2Iq")
 				);
+
+		assertThatObservation()
+				.doesNotHaveError()
+				.hasLowCardinalityKeyValue("konfigyr.identity.type", ObjectIdentity.NAMESPACE_TYPE)
+				.hasHighCardinalityKeyValue("konfigyr.identity.id", "1");
+	}
+
+	TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertThatObservation() {
+		return assertThat(observationRegistry)
+				.hasObservationWithNameEqualTo("konfigyr.security.access-control")
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped();
 	}
 
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/test/AbstractIntegrationTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/test/AbstractIntegrationTest.java
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.konfigyr.artifactory.store.MetadataStore;
 import com.konfigyr.feature.Features;
 import com.konfigyr.mail.Mailer;
+import com.konfigyr.test.observation.TestObservations;
 import com.konfigyr.test.smtp.TestSmtpServer;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,6 +26,7 @@ import org.wiremock.spring.InjectWireMock;
 @SpringBootTest
 @EnableWireMock
 @TestSmtpServer
+@TestObservations
 @ImportTestcontainers(TestContainers.class)
 @ExtendWith(PublishedEventsExtension.class)
 @ContextConfiguration(initializers = TemporaryDirectoryContextInitializer.class)

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/GitRepositoryHealthIndicatorTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/GitRepositoryHealthIndicatorTest.java
@@ -1,0 +1,94 @@
+package com.konfigyr.vault;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.boot.health.contributor.Health;
+import org.springframework.boot.health.contributor.Status;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class GitRepositoryHealthIndicatorTest {
+
+	@Test
+	@DisplayName("should report UP when repository directory exists and is readable")
+	void shouldReportUp(@TempDir Path directory) {
+		final var indicator = new GitRepositoryHealthIndicator(directory);
+		final var health = indicator.health(true);
+
+		assertThat(health)
+				.isNotNull()
+				.returns(Status.UP, Health::getStatus);
+
+		assertThat(health.getDetails())
+				.containsEntry("directory", directory.toString())
+				.containsKey("usableSpace")
+				.containsKey("totalSpace");
+	}
+
+	@Test
+	@DisplayName("should report DOWN when repository directory does not exist")
+	void shouldReportDownWhenDirectoryDoesNotExist(@TempDir Path directory) {
+		final var missing = directory.resolve("nonexistent");
+		final var indicator = new GitRepositoryHealthIndicator(missing);
+		final var health = indicator.health(true);
+
+		assertThat(health)
+				.isNotNull()
+				.returns(Status.DOWN, Health::getStatus);
+
+		assertThat(health.getDetails())
+				.containsEntry("directory", missing.toString())
+				.containsEntry("reason", "Repository directory does not exist");
+	}
+
+	@Test
+	@DisplayName("should report DOWN when repository directory is not readable")
+	void shouldReportDownWhenDirectoryIsNotReadable(@TempDir Path directory) throws Exception {
+		final var restricted = Files.createDirectory(directory.resolve("restricted"));
+
+		assertThat(restricted.toFile().setReadable(false))
+				.as("Failed to restrict repository directory access")
+				.isTrue();
+
+		try {
+			final var indicator = new GitRepositoryHealthIndicator(restricted);
+			final var health = indicator.health(true);
+
+			assertThat(health)
+					.isNotNull()
+					.returns(Status.DOWN, Health::getStatus);
+
+			assertThat(health.getDetails())
+					.containsEntry("directory", restricted.toString())
+					.containsEntry("reason", "Repository directory is not readable");
+		} finally {
+			assertThat(restricted.toFile().setReadable(true))
+					.as("Failed to restore repository directory access")
+					.isTrue();
+		}
+	}
+
+	@Test
+	@DisplayName("should format disk space in human-readable units")
+	void shouldFormatDiskSpace(@TempDir Path directory) {
+		final var indicator = new GitRepositoryHealthIndicator(directory);
+		final var health = indicator.health(true);
+
+		assertThat(health)
+				.isNotNull()
+				.returns(Status.UP, Health::getStatus);
+
+		assertThat(health.getDetails().get("usableSpace"))
+				.asString()
+				.matches("\\d+(\\.\\d+)? (B|KILOBYTES|MEGABYTES|GIGABYTES|TERABYTES)");
+
+		assertThat(health.getDetails().get("totalSpace"))
+				.asString()
+				.matches("\\d+(\\.\\d+)? (B|KILOBYTES|MEGABYTES|GIGABYTES|TERABYTES)");
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/environment/ConfigurationEnvironmentLocatorTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/environment/ConfigurationEnvironmentLocatorTest.java
@@ -90,7 +90,7 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 				.returns(Collections.emptyList(), ConfigurationEnvironment::propertySources);
 
 		assertObservation()
-				.hasEvent("konfigyr.vault.environment.missing", "unknown-profile");
+				.hasEvent("konfigyr.vault.environment.missing", "configuration environment is missing for 'unknown-profile' profile");
 	}
 
 	@Test
@@ -146,7 +146,7 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 				);
 
 		assertObservation()
-				.hasEvent("konfigyr.vault.environment.located", "development");
+				.hasEvent("konfigyr.vault.environment.located", "located configuration environment for 'development' profile");
 	}
 
 	@Test
@@ -169,8 +169,8 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 				);
 
 		assertObservation()
-				.hasEvent("konfigyr.vault.environment.located", "development")
-				.hasEvent("konfigyr.vault.environment.located", "staging");
+				.hasEvent("konfigyr.vault.environment.located", "located configuration environment for 'development' profile")
+				.hasEvent("konfigyr.vault.environment.located", "located configuration environment for 'staging' profile");
 	}
 
 	Profile setupBranchForProfile(String profileName) {

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/environment/ConfigurationEnvironmentLocatorTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/environment/ConfigurationEnvironmentLocatorTest.java
@@ -10,6 +10,8 @@ import com.konfigyr.vault.*;
 import com.konfigyr.vault.state.RepositoryStateException;
 import com.konfigyr.vault.state.StateRepository;
 import com.konfigyr.vault.state.StateRepositoryFactory;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -51,6 +53,9 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 	@Autowired
 	ConfigurationEnvironmentLocator locator;
 
+	@Autowired
+	TestObservationRegistry observationRegistry;
+
 	@BeforeEach
 	void setup() {
 		service = services.get(EntityId.from(2)).orElseThrow();
@@ -59,7 +64,6 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 
 	@AfterEach
 	void cleanup() throws Exception {
-		System.out.println("Destroying repository");
 		repository.destroy();
 		repository.close();
 	}
@@ -84,6 +88,9 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 				.returns("konfigyr-id", ConfigurationEnvironment::name)
 				.returns(List.of("unknown-profile"), ConfigurationEnvironment::profiles)
 				.returns(Collections.emptyList(), ConfigurationEnvironment::propertySources);
+
+		assertObservation()
+				.hasEvent("konfigyr.vault.environment.missing", "unknown-profile");
 	}
 
 	@Test
@@ -94,6 +101,15 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 		assertThatExceptionOfType(RepositoryStateException.class)
 				.isThrownBy(() -> locator.locate(principal, service, "staging"))
 				.returns(RepositoryStateException.ErrorCode.UNKNOWN_REPOSITORY, RepositoryStateException::getErrorCode);
+
+		assertThat(observationRegistry)
+				.hasObservationWithNameEqualTo(ConfigurationEnvironmentObservation.OBSERVATION_NAME)
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.hasError()
+				.assertThatError()
+				.isInstanceOf(RepositoryStateException.class);
 	}
 
 	@Test
@@ -102,6 +118,15 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 		assertThatExceptionOfType(RepositoryStateException.class)
 				.isThrownBy(() -> locator.locate(principal, service, "production"))
 				.returns(RepositoryStateException.ErrorCode.UNKNOWN_PROFILE, RepositoryStateException::getErrorCode);
+
+		assertThat(observationRegistry)
+				.hasObservationWithNameEqualTo(ConfigurationEnvironmentObservation.OBSERVATION_NAME)
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.hasError()
+				.assertThatError()
+				.isInstanceOf(RepositoryStateException.class);
 	}
 
 	@Test
@@ -119,6 +144,9 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 				.satisfiesExactly(
 						assertPropertySource(service, profile, Map.of("spring.profiles.active", "development"))
 				);
+
+		assertObservation()
+				.hasEvent("konfigyr.vault.environment.located", "development");
 	}
 
 	@Test
@@ -139,6 +167,10 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 						assertPropertySource(service, staging, Map.of()),
 						assertPropertySource(service, development, Map.of("spring.profiles.active", "development"))
 				);
+
+		assertObservation()
+				.hasEvent("konfigyr.vault.environment.located", "development")
+				.hasEvent("konfigyr.vault.environment.located", "staging");
 	}
 
 	Profile setupBranchForProfile(String profileName) {
@@ -165,6 +197,17 @@ class ConfigurationEnvironmentLocatorTest extends AbstractIntegrationTest {
 			);
 		}
 		return profile;
+	}
+
+	TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertObservation() {
+		return assertThat(observationRegistry)
+				.hasObservationWithNameEqualTo(ConfigurationEnvironmentObservation.OBSERVATION_NAME)
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.doesNotHaveError()
+				.hasContextualNameEqualTo("locating configuration environment for '%s' service".formatted(service.slug()))
+				.hasHighCardinalityKeyValue("konfigyr.namespace.service", service.id().serialize());
 	}
 
 	static Consumer<PropertySource> assertPropertySource(Service service, Profile profile, Map<String, String> source) {

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/extension/ObservedVaultExtensionTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/extension/ObservedVaultExtensionTest.java
@@ -1,0 +1,226 @@
+package com.konfigyr.vault.extension;
+
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.io.ByteArray;
+import com.konfigyr.namespace.Service;
+import com.konfigyr.vault.*;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ObservedVaultExtensionTest {
+
+	@Mock
+	Vault vault;
+
+	@Mock
+	Service service;
+
+	@Mock
+	Profile profile;
+
+	TestObservationRegistry observationRegistry;
+
+	ObservedVaultExtension extension;
+
+	@BeforeEach
+	void setup() {
+		doReturn(EntityId.from(1000)).when(service).id();
+		doReturn(EntityId.from(2000)).when(profile).id();
+		doReturn(service).when(vault).service();
+		doReturn(profile).when(vault).profile();
+
+		observationRegistry = TestObservationRegistry.create();
+		extension = new ObservedVaultExtension(observationRegistry);
+	}
+
+	@Test
+	@DisplayName("should observe retrieving current configuration state")
+	void shouldObserveStateOperation() {
+		final var properties = Properties.builder().build();
+		doReturn(properties).when(vault).state();
+
+		final var extended = extension.extend(vault);
+
+		assertThat(extended.state())
+				.isSameAs(properties);
+
+		verify(vault).state();
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.STATE)
+				.doesNotHaveError();
+	}
+
+	@Test
+	@DisplayName("should observe unsealing vault configuration state")
+	void shouldObserveUnsealOperation() {
+		final var properties = Map.of("spring.application.name", "konfigyr");
+		doReturn(properties).when(vault).unseal();
+
+		final var extended = extension.extend(vault);
+
+		assertThat(extended.unseal())
+				.isSameAs(properties);
+
+		verify(vault).unseal();
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.UNSEAL)
+				.doesNotHaveError();
+	}
+
+	@Test
+	@DisplayName("should observe sealing a property value using the vault encryption keyset")
+	void shouldObserveSealPropertyOperation() {
+		final var sealed = PropertyValue.sealed(ByteArray.fromString("sealed"), ByteArray.fromString("checksum"));
+		final var unsealed = PropertyValue.unsealed(ByteArray.fromString("unsealed"), ByteArray.fromString("checksum"));
+		doReturn(sealed).when(vault).seal(unsealed);
+
+		final var extended = extension.extend(vault);
+
+		assertThat(extended.seal(unsealed))
+				.isSameAs(sealed);
+
+		verify(vault).seal(unsealed);
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.SEAL_PROPERTY)
+				.doesNotHaveError();
+	}
+
+	@Test
+	@DisplayName("should observe unsealing a property value using the vault encryption keyset")
+	void shouldObserveUnsealPropertyOperation() {
+		final var sealed = PropertyValue.sealed(ByteArray.fromString("sealed"), ByteArray.fromString("checksum"));
+		final var unsealed = PropertyValue.unsealed(ByteArray.fromString("unsealed"), ByteArray.fromString("checksum"));
+		doReturn(unsealed).when(vault).unseal(sealed);
+
+		final var extended = extension.extend(vault);
+
+		assertThat(extended.unseal(sealed))
+				.isSameAs(unsealed);
+
+		verify(vault).unseal(sealed);
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.UNSEAL_PROPERTY)
+				.doesNotHaveError();
+	}
+
+	@Test
+	@DisplayName("should observe applying changes to the vault profile")
+	void shouldObserveApplyOperation() {
+		final var changes = mock(PropertyChanges.class);
+		final var result = mock(ApplyResult.class);
+		doReturn(result).when(vault).apply(changes);
+
+		final var extended = extension.extend(vault);
+
+		assertThat(extended.apply(changes))
+				.isSameAs(result);
+
+		verify(vault).apply(changes);
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.APPLY)
+				.doesNotHaveError();
+	}
+
+	@Test
+	@DisplayName("should observe submitting changes to the vault profile")
+	void shouldObserveSubmitOperation() {
+		final var changes = mock(PropertyChanges.class);
+		final var request = mock(ChangeRequest.class);
+		doReturn(request).when(vault).submit(changes);
+
+		final var extended = extension.extend(vault);
+
+		assertThat(extended.submit(changes))
+				.isSameAs(request);
+
+		verify(vault).submit(changes);
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.SUBMIT)
+				.doesNotHaveError();
+	}
+
+	@Test
+	@DisplayName("should observe merging proposed changes to the vault profile")
+	void shouldObserveMergeOperation() {
+		final var request = mock(ChangeRequest.class);
+		final var result = mock(ApplyResult.class);
+		doReturn(EntityId.from(4000)).when(request).id();
+		doReturn(result).when(vault).merge(request);
+
+		final var extended = extension.extend(vault);
+
+		assertThat(extended.merge(request))
+				.isSameAs(result);
+
+		verify(vault).merge(request);
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.MERGE)
+				.hasHighCardinalityKeyValue("konfigyr.vault.change-request", EntityId.from(4000).serialize())
+				.doesNotHaveError();
+	}
+
+	@Test
+	@DisplayName("should observe discarding proposed changes")
+	void shouldObserveDiscardOperation() {
+		final var request = mock(ChangeRequest.class);
+		final var discarded = mock(ChangeRequest.class);
+		doReturn(EntityId.from(5000)).when(request).id();
+		doReturn(discarded).when(vault).discard(request);
+
+		final var extended = extension.extend(vault);
+
+		assertThat(extended.discard(request))
+				.isSameAs(discarded);
+
+		verify(vault).discard(request);
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.DISCARD)
+				.hasHighCardinalityKeyValue("konfigyr.vault.change-request", EntityId.from(5000).serialize())
+				.doesNotHaveError();
+	}
+
+	@Test
+	@DisplayName("should propagate exceptions from the delegate vault and record them in the observation")
+	void shouldPropagateExceptions() throws Exception {
+		final var cause = new IllegalStateException("boom");
+		doThrow(cause).when(vault).close();
+
+		final var extended = extension.extend(vault);
+
+		assertThatIllegalStateException()
+				.isThrownBy(extended::close)
+				.isEqualTo(cause);
+
+		verify(vault).close();
+
+		assertObservation(ObservedVaultExtension.ObservedOperation.CLOSE)
+				.hasError(cause);
+	}
+
+	TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertObservation(
+			ObservedVaultExtension.ObservedOperation operation
+	) {
+		return assertThat(observationRegistry)
+				.hasObservationWithNameEqualTo(operation.observationName())
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.hasContextualNameEqualTo(operation.contextualName(EntityId.from(1000).serialize(), EntityId.from(2000).serialize()))
+				.hasHighCardinalityKeyValue("konfigyr.namespace.service", EntityId.from(1000).serialize())
+				.hasHighCardinalityKeyValue("konfigyr.vault.profile", EntityId.from(2000).serialize());
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/extension/VaultExtensionConfigurationTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/extension/VaultExtensionConfigurationTest.java
@@ -1,0 +1,44 @@
+package com.konfigyr.vault.extension;
+
+import com.konfigyr.vault.VaultExtension;
+import io.micrometer.observation.ObservationRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class VaultExtensionConfigurationTest {
+
+	@Mock
+	ApplicationEventPublisher applicationEventPublisher;
+
+	ObservationRegistry observationRegistry = ObservationRegistry.NOOP;
+
+	@Test
+	@DisplayName("should declare vault extension beans in correct order")
+	void extensionSanityTest() {
+		new ApplicationContextRunner()
+				.withBean(ApplicationEventPublisher.class, () -> applicationEventPublisher)
+				.withBean(ObservationRegistry.class, () -> observationRegistry)
+				.withUserConfiguration(VaultExtensionConfiguration.class)
+				.run(context -> {
+					assertThat(context)
+							.hasNotFailed();
+
+					assertThat(context.getBeanProvider(VaultExtension.class).orderedStream())
+							.map(Object::getClass)
+							.map(Class.class::cast)
+							.containsExactly(
+									ObservedVaultExtension.class,
+									LockingVaultExtension.class,
+									PublishingVaultExtension.class
+							);
+				});
+	}
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/gatekeeper/ChangeRequestGatekeeperTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/gatekeeper/ChangeRequestGatekeeperTest.java
@@ -2,6 +2,10 @@ package com.konfigyr.vault.gatekeeper;
 
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.vault.ChangeRequestMergeStatus;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import org.jspecify.annotations.Nullable;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,11 +27,18 @@ class ChangeRequestGatekeeperTest {
 	@Mock
 	GateContext context;
 
+	TestObservationRegistry observationRegistry;
+
+	@BeforeEach
+	void setup() {
+		observationRegistry = TestObservationRegistry.create();
+	}
+
 	@Test
 	@DisplayName("should fail to create a gatekeeper instance with no rules")
 	void createGatekeeperWithoutRules() {
 		assertThatIllegalArgumentException()
-				.isThrownBy(() -> new ChangeRequestGatekeeper(contextFactory, List.of()))
+				.isThrownBy(() -> new ChangeRequestGatekeeper(observationRegistry, contextFactory, List.of()))
 				.withMessage("At least one gate must be configured");
 	}
 
@@ -35,7 +46,7 @@ class ChangeRequestGatekeeperTest {
 	@DisplayName("should fail to evaluate due to context factory error")
 	void contextFactoryFailure() {
 		final var gate = mock(Gate.class);
-		final var gatekeeper = new ChangeRequestGatekeeper(contextFactory, List.of(gate));
+		final var gatekeeper = new ChangeRequestGatekeeper(observationRegistry, contextFactory, List.of(gate));
 
 		final var cause = new RuntimeException("context factory failure");
 		doThrow(cause).when(contextFactory).create(EntityId.from(1246525));
@@ -46,13 +57,16 @@ class ChangeRequestGatekeeperTest {
 
 		verify(contextFactory).create(EntityId.from(1246525));
 		verifyNoInteractions(gate);
+
+		assertObservation(1246525, null)
+				.hasError(cause);
 	}
 
 	@Test
 	@DisplayName("should fail to evaluate due to gate processing error")
 	void gateProcessingFailure() {
 		final var gate = mock(Gate.class);
-		final var gatekeeper = new ChangeRequestGatekeeper(contextFactory, List.of(gate));
+		final var gatekeeper = new ChangeRequestGatekeeper(observationRegistry, contextFactory, List.of(gate));
 
 		final var cause = new RuntimeException("context factory failure");
 		doThrow(cause).when(gate).evaluate(context);
@@ -64,6 +78,9 @@ class ChangeRequestGatekeeperTest {
 
 		verify(contextFactory).create(EntityId.from(1246525));
 		verify(gate).evaluate(context);
+
+		assertObservation(1246525, null)
+				.hasError(cause);
 	}
 
 	@Test
@@ -73,7 +90,7 @@ class ChangeRequestGatekeeperTest {
 		final var second = gateFor(2, GateResult.block(ChangeRequestMergeStatus.NOT_OPEN, "It's closed, duh!"));
 		final var third = gateFor(3, GateResult.pass());
 
-		final var gatekeeper = new ChangeRequestGatekeeper(contextFactory, List.of(first, second, third));
+		final var gatekeeper = new ChangeRequestGatekeeper(observationRegistry, contextFactory, List.of(first, second, third));
 
 		doReturn(context).when(contextFactory).create(EntityId.from(96736));
 
@@ -84,6 +101,9 @@ class ChangeRequestGatekeeperTest {
 		verify(first).evaluate(context);
 		verify(second).evaluate(context);
 		verify(third, never()).evaluate(context);
+
+		assertObservation(96736, ChangeRequestMergeStatus.NOT_OPEN)
+				.doesNotHaveError();
 	}
 
 	@Test
@@ -93,7 +113,7 @@ class ChangeRequestGatekeeperTest {
 		final var second = gateFor(2, GateResult.pass());
 		final var third = gateFor(3, GateResult.pass());
 
-		final var gatekeeper = new ChangeRequestGatekeeper(contextFactory, List.of(first, second, third));
+		final var gatekeeper = new ChangeRequestGatekeeper(observationRegistry, contextFactory, List.of(first, second, third));
 
 		doReturn(context).when(contextFactory).create(EntityId.from(586152));
 
@@ -104,6 +124,22 @@ class ChangeRequestGatekeeperTest {
 		verify(first).evaluate(context);
 		verify(second).evaluate(context);
 		verify(third).evaluate(context);
+
+		assertObservation(586152, ChangeRequestMergeStatus.MERGEABLE)
+				.doesNotHaveError();
+	}
+
+	TestObservationRegistryAssert.TestObservationRegistryAssertReturningObservationContextAssert assertObservation(
+			long id,
+			@Nullable ChangeRequestMergeStatus status
+	) {
+		return assertThat(observationRegistry)
+				.hasObservationWithNameEqualTo(GatekeeperObservation.OBSERVATION_NAME)
+				.that()
+				.hasBeenStarted()
+				.hasBeenStopped()
+				.hasHighCardinalityKeyValue("konfigyr.vault.change-request", EntityId.from(id).serialize())
+				.hasLowCardinalityKeyValue("konfigyr.vault.change-request.merge-status", status == null ? "n/a" : status.name());
 	}
 
 	static Gate gateFor(int order, GateResult result) {

--- a/konfigyr-core/src/main/java/com/konfigyr/observation/KonfigyrValueExpressionResolver.java
+++ b/konfigyr-core/src/main/java/com/konfigyr/observation/KonfigyrValueExpressionResolver.java
@@ -1,0 +1,46 @@
+package com.konfigyr.observation;
+
+import io.micrometer.common.annotation.ValueExpressionResolver;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.expression.EvaluationContext;
+import org.springframework.expression.Expression;
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.SimpleEvaluationContext;
+import org.springframework.util.Assert;
+
+@NullMarked
+final class KonfigyrValueExpressionResolver implements ValueExpressionResolver {
+
+	private final ExpressionParser expressionParser;
+	private final EvaluationContext evaluationContext;
+
+	public KonfigyrValueExpressionResolver(ConversionService conversionService) {
+		this(new SpelExpressionParser(), conversionService);
+	}
+
+	public KonfigyrValueExpressionResolver(ExpressionParser expressionParser, ConversionService conversionService) {
+		this.expressionParser = expressionParser;
+		this.evaluationContext = SimpleEvaluationContext
+				.forReadOnlyDataBinding()
+				.withConversionService(conversionService)
+				.build();
+	}
+
+	@Override
+	public String resolve(String expression, @Nullable Object parameter) {
+		final String value;
+
+		try {
+			final Expression expressionToEvaluate = expressionParser.parseExpression(expression);
+			value = expressionToEvaluate.getValue(evaluationContext, parameter, String.class);
+		} catch (Exception ex) {
+			throw new IllegalStateException("Unable to evaluate SpEL expression '%s'".formatted(expression), ex);
+		}
+
+		Assert.state(value != null, () -> "Value from '%s' expression must not be null".formatted(expression));
+		return value;
+	}
+}

--- a/konfigyr-core/src/main/java/com/konfigyr/observation/KonfigyrValueExpressionResolver.java
+++ b/konfigyr-core/src/main/java/com/konfigyr/observation/KonfigyrValueExpressionResolver.java
@@ -17,11 +17,11 @@ final class KonfigyrValueExpressionResolver implements ValueExpressionResolver {
 	private final ExpressionParser expressionParser;
 	private final EvaluationContext evaluationContext;
 
-	public KonfigyrValueExpressionResolver(ConversionService conversionService) {
+	KonfigyrValueExpressionResolver(ConversionService conversionService) {
 		this(new SpelExpressionParser(), conversionService);
 	}
 
-	public KonfigyrValueExpressionResolver(ExpressionParser expressionParser, ConversionService conversionService) {
+	KonfigyrValueExpressionResolver(ExpressionParser expressionParser, ConversionService conversionService) {
 		this.expressionParser = expressionParser;
 		this.evaluationContext = SimpleEvaluationContext
 				.forReadOnlyDataBinding()

--- a/konfigyr-core/src/main/java/com/konfigyr/observation/ObservationAutoConfiguration.java
+++ b/konfigyr-core/src/main/java/com/konfigyr/observation/ObservationAutoConfiguration.java
@@ -1,0 +1,19 @@
+package com.konfigyr.observation;
+
+import io.micrometer.common.annotation.ValueExpressionResolver;
+import io.micrometer.observation.ObservationRegistry;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.core.convert.ConversionService;
+
+@AutoConfiguration
+@ConditionalOnClass(ObservationRegistry.class)
+public class ObservationAutoConfiguration {
+
+	@Bean
+	ValueExpressionResolver spelValueExpressionResolver(ConversionService conversionService) {
+		return new KonfigyrValueExpressionResolver(conversionService);
+	}
+
+}

--- a/konfigyr-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/konfigyr-core/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,2 +1,3 @@
 com.konfigyr.crypto.CryptographyAutoConfiguration
+com.konfigyr.observation.ObservationAutoConfiguration
 com.konfigyr.web.WebAutoConfiguration

--- a/konfigyr-core/src/test/java/com/konfigyr/observation/KonfigyrValueExpressionResolverTest.java
+++ b/konfigyr-core/src/test/java/com/konfigyr/observation/KonfigyrValueExpressionResolverTest.java
@@ -1,0 +1,84 @@
+package com.konfigyr.observation;
+
+import io.micrometer.common.annotation.ValueExpressionResolver;
+import org.apache.commons.lang3.tuple.Pair;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.convert.ApplicationConversionService;
+import org.springframework.expression.spel.SpelEvaluationException;
+import org.springframework.expression.spel.SpelMessage;
+import org.springframework.format.support.FormattingConversionService;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+class KonfigyrValueExpressionResolverTest {
+
+	FormattingConversionService conversions;
+	ValueExpressionResolver resolver;
+
+	@BeforeEach
+	void setup() {
+		conversions = new FormattingConversionService();
+		ApplicationConversionService.configure(conversions);
+
+		resolver = new KonfigyrValueExpressionResolver(conversions);
+	}
+
+	@Test
+	@DisplayName("should evaluate valid expression to string")
+	void checkValidExpression() {
+		var value = Map.of("foo", Pair.of(1, 2));
+
+		assertThat(resolver.resolve("['foo'].left", value))
+				.isEqualTo("1");
+	}
+
+	@Test
+	@DisplayName("should evaluate expression to string using conversion service")
+	void checkConvertedExpression() {
+		var value = Pair.of(1, 2);
+
+		conversions.addConverter(Pair.class, String.class, (source) -> "Pair(%s,%s)".formatted(source.getLeft(), source.getRight()));
+
+		assertThat(resolver.resolve("#this", value))
+				.isEqualTo("Pair(1,2)");
+	}
+
+	@Test
+	@DisplayName("should fail to evaluate invalid expression")
+	void checkInvalidExpression() {
+		var value = Map.of("foo", Pair.of(1, 2));
+		assertThatIllegalStateException()
+				.isThrownBy(() -> resolver.resolve("['bar'].right", value))
+				.withCauseInstanceOf(SpelEvaluationException.class);
+	}
+
+	@Test
+	@DisplayName("should fail to evaluate null expressions")
+	void checkNullExpressions() {
+		var value = Pair.of(null, null);
+
+		assertThatIllegalStateException()
+				.isThrownBy(() -> resolver.resolve("#this.right", value))
+				.withMessageContaining("Value from '%s' expression must not be null", "#this.right")
+				.withNoCause();
+	}
+
+	@Test
+	@DisplayName("should fail to invoke methods via expression")
+	void checkExpressionMethodAccess() {
+		var value = Pair.of(1, 2);
+
+		assertThatIllegalStateException()
+				.isThrownBy(() -> resolver.resolve("toString()", value))
+				.withCauseInstanceOf(SpelEvaluationException.class)
+				.extracting(Throwable::getCause, InstanceOfAssertFactories.throwable(SpelEvaluationException.class))
+				.returns(SpelMessage.METHOD_NOT_FOUND, SpelEvaluationException::getMessageCode);
+	}
+
+}

--- a/konfigyr-identity/build.gradle
+++ b/konfigyr-identity/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation project(':konfigyr-mail')
 
     /* Spring Boot starter */
+    implementation 'org.springframework.boot:spring-boot-starter-aspectj'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.boot:spring-boot-starter-restclient'
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
@@ -22,6 +23,7 @@ dependencies {
 
     /* Tracing and observability */
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-opentelemetry'
     implementation 'io.micrometer:micrometer-observation'
 
     /* Spring Common libraries */
@@ -51,6 +53,10 @@ dependencies {
     testImplementation project(':konfigyr-test')
     testImplementation 'org.seleniumhq.selenium:htmlunit3-driver'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+}
+
+springBoot {
+    buildInfo()
 }
 
 node {

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/DefaultAccountIdentityService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/DefaultAccountIdentityService.java
@@ -2,6 +2,7 @@ package com.konfigyr.identity.authentication;
 
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.identity.authentication.idenitity.AccountIdentityRepository;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NonNull;
@@ -53,6 +54,7 @@ class DefaultAccountIdentityService implements AccountIdentityService {
 
 	@NonNull
 	@Override
+	@Observed(name = "konfigyr.identity.account.lookup", lowCardinalityKeyValues = { "lookup.type", "username" })
 	public AccountIdentity get(@NonNull String username) throws UsernameNotFoundException {
 		final EntityId id;
 
@@ -69,6 +71,7 @@ class DefaultAccountIdentityService implements AccountIdentityService {
 
 	@NonNull
 	@Override
+	@Observed(name = "konfigyr.identity.account.lookup", lowCardinalityKeyValues = { "lookup.type", "identifier" })
 	public AccountIdentity get(@NonNull EntityId id) throws UsernameNotFoundException {
 		AccountIdentity user = lookupFromCache(id.serialize());
 
@@ -87,6 +90,7 @@ class DefaultAccountIdentityService implements AccountIdentityService {
 
 	@NonNull
 	@Override
+	@Observed(name = "konfigyr.identity.account.authenticate")
 	public <R extends OAuth2UserRequest, U extends OAuth2User> AccountIdentityUser get(
 			@NonNull OAuth2UserService<R, U> service,
 			@NonNull R request

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/oauth/AuthorizedClientService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/oauth/AuthorizedClientService.java
@@ -7,6 +7,7 @@ import com.konfigyr.entity.EntityId;
 import com.konfigyr.identity.KonfigyrIdentityKeysets;
 import com.konfigyr.identity.authentication.AccountIdentityUser;
 import com.konfigyr.io.ByteArray;
+import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.Converter;
@@ -83,6 +84,7 @@ public class AuthorizedClientService implements OAuth2AuthorizedClientService {
 
 	@Override
 	@SuppressWarnings("unchecked")
+	@Observed(name = "konfigyr.identity.access-tokens.lookup")
 	@Transactional(readOnly = true, label = "oauth-client-service-load")
 	public <T extends OAuth2AuthorizedClient> T loadAuthorizedClient(String clientRegistrationId, String principalName) {
 		final EntityId account;
@@ -123,6 +125,7 @@ public class AuthorizedClientService implements OAuth2AuthorizedClientService {
 
 	@Override
 	@Transactional(label = "oauth-client-service-save")
+	@Observed(name = "konfigyr.identity.access-tokens.store")
 	public void saveAuthorizedClient(OAuth2AuthorizedClient authorizedClient, Authentication principal) {
 		final EntityId account = lookupUserIdentifierForAuthentication(principal);
 
@@ -146,6 +149,7 @@ public class AuthorizedClientService implements OAuth2AuthorizedClientService {
 
 	@Override
 	@Transactional(label = "oauth-client-service-remove")
+	@Observed(name = "konfigyr.identity.access-tokens.remove")
 	public void removeAuthorizedClient(String clientRegistrationId, String principalName) {
 		final EntityId account = EntityId.from(principalName);
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
@@ -6,6 +6,7 @@ import com.konfigyr.data.converter.EncryptionConverter;
 import com.konfigyr.data.converter.JsonConverter;
 import com.konfigyr.data.converter.MessageDigestConverter;
 import com.konfigyr.io.ByteArray;
+import io.micrometer.observation.annotation.Observed;
 import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.jmolecules.event.annotation.DomainEventHandler;
@@ -106,6 +107,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	}
 
 	@Override
+	@Observed(name = "konfigyr.identity.authorization.store")
 	@Transactional(label = "authorization-service.save-authorization")
 	public void save(OAuth2Authorization authorization) {
 		Assert.notNull(authorization, "OAuth2 Authorization cannot be null");
@@ -149,6 +151,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	}
 
 	@Override
+	@Observed(name = "konfigyr.identity.consent.store")
 	@Transactional(label = "authorization-service.save-consent")
 	public void save(OAuth2AuthorizationConsent consent) {
 		Assert.notNull(consent, "OAuth2 Authorization consent cannot be null");
@@ -184,6 +187,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
 	@Override
 	@Transactional(readOnly = true, label = "authorization-service.find-authorization-by-id")
+	@Observed(name = "konfigyr.identity.authorization.lookup", lowCardinalityKeyValues = { "lookup.type", "identifier" })
 	public OAuth2Authorization findById(String id) {
 		Assert.hasText(id, "OAuth2 Authorization identifier cannot be empty");
 
@@ -194,6 +198,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
 	@Override
 	@Transactional(readOnly = true, label = "authorization-service.find-authorization-by-token")
+	@Observed(name = "konfigyr.identity.authorization.lookup", lowCardinalityKeyValues = { "lookup.type", "token" })
 	public OAuth2Authorization findByToken(String token, @Nullable OAuth2TokenType type) {
 		Assert.hasText(token, "OAuth2 Authorization token value cannot be empty");
 
@@ -229,6 +234,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	}
 
 	@Override
+	@Observed(name = "konfigyr.identity.consent.lookup")
 	@Transactional(readOnly = true, label = "authorization-service.find-consent-by-id")
 	public OAuth2AuthorizationConsent findById(String registeredClientId, String principalName) {
 		Assert.hasText(registeredClientId, "Registered client identifier cannot be empty");
@@ -251,6 +257,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	}
 
 	@Override
+	@Observed(name = "konfigyr.identity.authorization.remove")
 	@Transactional(label = "authorization-service.remove-authorization")
 	public void remove(OAuth2Authorization authorization) {
 		Assert.notNull(authorization, "OAuth2 Authorization cannot be null");
@@ -280,6 +287,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	}
 
 	@Override
+	@Observed(name = "konfigyr.identity.consent.remove")
 	@Transactional(label = "authorization-service.remove-consent")
 	public void remove(OAuth2AuthorizationConsent consent) {
 		Assert.notNull(consent, "OAuth2 Authorization consent cannot be null");
@@ -309,6 +317,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 		}
 	}
 
+	@Observed(name = "konfigyr.identity.authorization.cleanup")
 	@Scheduled(cron = "${konfigyr.authorization.cleanup.cron:0 * * * * *}")
 	@Transactional(label = "authorization-service.cleanup-expired-authorizations")
 	void cleanup() {

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/DelegatingRegisteredClientRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/DelegatingRegisteredClientRepository.java
@@ -1,6 +1,5 @@
 package com.konfigyr.identity.authorization.client;
 
-import io.micrometer.observation.annotation.Observed;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
@@ -37,13 +36,11 @@ public final class DelegatingRegisteredClientRepository implements RegisteredCli
 	}
 
 	@Override
-	@Observed(name = "konfigyr.identity.client.repository.lookup", lowCardinalityKeyValues = { "lookup.type", "client-registration" })
 	public RegisteredClient findById(String id) {
 		return lookup(RegisteredClientRepository::findById, id);
 	}
 
 	@Override
-	@Observed(name = "konfigyr.identity.client.repository.lookup", lowCardinalityKeyValues = { "lookup.type", "client-id" })
 	public RegisteredClient findByClientId(String clientId) {
 		return lookup(RegisteredClientRepository::findByClientId, clientId);
 	}

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/DelegatingRegisteredClientRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/DelegatingRegisteredClientRepository.java
@@ -1,5 +1,6 @@
 package com.konfigyr.identity.authorization.client;
 
+import io.micrometer.observation.annotation.Observed;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
@@ -36,11 +37,13 @@ public final class DelegatingRegisteredClientRepository implements RegisteredCli
 	}
 
 	@Override
+	@Observed(name = "konfigyr.identity.client.repository.lookup", lowCardinalityKeyValues = { "lookup.type", "client-registration" })
 	public RegisteredClient findById(String id) {
 		return lookup(RegisteredClientRepository::findById, id);
 	}
 
 	@Override
+	@Observed(name = "konfigyr.identity.client.repository.lookup", lowCardinalityKeyValues = { "lookup.type", "client-id" })
 	public RegisteredClient findByClientId(String clientId) {
 		return lookup(RegisteredClientRepository::findByClientId, clientId);
 	}

--- a/konfigyr-identity/src/main/resources/application.yml
+++ b/konfigyr-identity/src/main/resources/application.yml
@@ -40,6 +40,26 @@ konfigyr:
         access-token-time-to-live: 15m
         refresh-token-time-to-live: 7d
 
+management:
+  info:
+    java:
+      enabled: true
+    build:
+      enabled: true
+
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics
+
+  endpoint:
+    health:
+      show-details: when-authorized
+
+  observations:
+    annotations:
+      enabled: true
+
 logging:
   pattern:
     console: '%clr(%d{HH:mm:ss.SSS}){faint} %clr([%-20thread]) %clr(%-5level) [%mdc] %clr(%-40.40logger{39}){cyan} %clr(:){faint} %marker %m%n'

--- a/konfigyr-identity/src/main/resources/application.yml
+++ b/konfigyr-identity/src/main/resources/application.yml
@@ -1,4 +1,7 @@
 spring:
+  application:
+    name: konfigyr-identity
+
   cache:
     cache-names: crypto-keysets, user-cache
     caffeine:

--- a/konfigyr-test/build.gradle
+++ b/konfigyr-test/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     /* Spring WebMvc support */
     compileOnly 'org.springframework.boot:spring-boot-starter-webmvc-test'
 
+    /* Spring Micrometer Test support */
+    compileOnly 'org.springframework.boot:spring-boot-starter-micrometer-metrics-test'
+
     /* Spring Validator support */
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
@@ -37,7 +40,7 @@ dependencies {
     testImplementation 'com.konfigyr:konfigyr-mail-api'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation 'org.springframework.security:spring-security-oauth2-core'
-
+    testImplementation 'org.springframework.boot:spring-boot-starter-micrometer-metrics-test'
 }
 
 /* Disable any Javadoc task, this library should not be published */

--- a/konfigyr-test/src/main/java/com/konfigyr/test/observation/TestObservationConfiguration.java
+++ b/konfigyr-test/src/main/java/com/konfigyr/test/observation/TestObservationConfiguration.java
@@ -1,0 +1,40 @@
+package com.konfigyr.test.observation;
+
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.event.BeforeTestExecutionEvent;
+
+/**
+ * Internal configuration class used to provide a {@link TestObservationRegistry} to the
+ * Spring {@link org.springframework.context.ApplicationContext}.
+ * <p>
+ * It also registers the {@link ApplicationListener} bean that would liste for the
+ * {@link BeforeTestExecutionEvent} to reset the registry state after each test method.
+ * <p>
+ * This prevents {@code Cross-Test Contamination} where observations recorded in one test
+ * could incorrectly influence the assertions of a subsequent test within the same Spring
+ * {@link org.springframework.context.ApplicationContext}.
+ * <p>
+ * This is marked as a {@link TestConfiguration} to prevent it from being picked up by component
+ * scanning in the main application.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see TestObservationRegistry
+ */
+@TestConfiguration
+class TestObservationConfiguration {
+
+	@Bean
+	TestObservationRegistry testObservationRegistry() {
+		return TestObservationRegistry.create();
+	}
+
+	@Bean
+	ApplicationListener<BeforeTestExecutionEvent> testObservationRegistryListener(TestObservationRegistry observationRegistry) {
+		return ignore -> observationRegistry.clear();
+	}
+
+}

--- a/konfigyr-test/src/main/java/com/konfigyr/test/observation/TestObservations.java
+++ b/konfigyr-test/src/main/java/com/konfigyr/test/observation/TestObservations.java
@@ -1,0 +1,40 @@
+package com.konfigyr.test.observation;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.*;
+
+/**
+ * Annotation that enables comprehensive testing support for Spring Observations.
+ * <p>
+ * This annotation performs two primary functions:
+ * <ul>
+ *     <li>
+ *         Imports the {@link TestObservationConfiguration} to provide a
+ *         {@link io.micrometer.observation.tck.TestObservationRegistry} Spring Bean.
+ *     </li>
+ *     <li>
+ *         Registers the {@link org.springframework.context.ApplicationListener} for
+ *         {@link org.springframework.test.context.event.BeforeTestExecutionEvent} to ensure
+ *         the registry is automatically cleared between test methods, preventing state leakage.
+ *    </li>
+ * </ul>
+ *
+ * Use this on any {@code @SpringBootTest} or {@code @ContextConfiguration} test class
+ * where you need to assert metrics, traces, or metadata via the Observation API like so:
+ * <pre>
+ * &#64;SpringBootTest
+ * &#64;TestObservations
+ * class MyObservationTest { ... }
+ * </pre>
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@Documented
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Import(TestObservationConfiguration.class)
+public @interface TestObservations {
+
+}

--- a/konfigyr-test/src/test/java/com/konfigyr/test/observation/TestObservationConfigurationTest.java
+++ b/konfigyr-test/src/test/java/com/konfigyr/test/observation/TestObservationConfigurationTest.java
@@ -1,0 +1,51 @@
+package com.konfigyr.test.observation;
+
+import com.konfigyr.test.smtp.TestSmtpServer;
+import io.micrometer.observation.Observation;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatObject;
+
+@TestSmtpServer
+@TestObservations
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+@SpringBootTest(classes = TestObservationConfigurationTest.class)
+class TestObservationConfigurationTest {
+
+	@Autowired
+	ObservationRegistry registry;
+
+	@Test
+	@DisplayName("should register a test implementation of the Observation registry")
+	void registeredTestInstance() {
+		assertThatObject(registry)
+				.isNotNull()
+				.isInstanceOf(TestObservationRegistry.class);
+	}
+
+	@Test
+	@Order(1)
+	@DisplayName("should record first observation in the test Observation registry")
+	void shouldRecordFirstObservation() {
+		Observation.start("first.observation", registry).stop();
+
+		assertThat((TestObservationRegistry) registry)
+				.hasObservationWithNameEqualTo("first.observation")
+				.that()
+				.hasBeenStopped();
+	}
+
+	@Test
+	@Order(2)
+	@DisplayName("should verify that the first observation has been removed from test Observation registry")
+	void shouldResetObservationRegistry() {
+		assertThat((TestObservationRegistry) registry)
+				.doesNotHaveAnyObservation();
+	}
+
+}


### PR DESCRIPTION
Add observability improvements: health indicator, MDC filter, and metrics                                                                                                                                                                                                            

- Add `GitRepositoryHealthIndicator` to report vault git repository status                                                                                                                                                                                                             
- Add `AuthenticatedPrincipalContextFilter` to populate MDC with principal context                                                                                                                                                                                                     
- Add `@Observed` annotations to services that should be closely monitored during the first phase
- Add `AuditObservation` to monitor audit event listener
- Add `ConfigurationEnvironmentObservation` to observe lookup of configuration environment
- Add `QueueObservation` to monitor queued task execution
- Configure actuator endpoints for health, info, and metrics