### PR TITLE
Import configuration properties from YAML, JSON or properties files

### DIFF
--- a/konfigyr-frontend/package-lock.json
+++ b/konfigyr-frontend/package-lock.json
@@ -38,7 +38,8 @@
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
-        "use-debounce": "^10.1.1"
+        "use-debounce": "^10.1.1",
+        "yaml": "^2.8.4"
       },
       "devDependencies": {
         "@stylistic/eslint-plugin": "^5.10.0",
@@ -10028,6 +10029,20 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/konfigyr-frontend/package.json
+++ b/konfigyr-frontend/package.json
@@ -46,7 +46,8 @@
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
-    "use-debounce": "^10.1.1"
+    "use-debounce": "^10.1.1",
+    "yaml": "^2.8.4"
   },
   "devDependencies": {
     "@stylistic/eslint-plugin": "^5.10.0",

--- a/konfigyr-frontend/src/components/vault/changeset/editor.tsx
+++ b/konfigyr-frontend/src/components/vault/changeset/editor.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from 'react';
 import {
   useAddProperty,
+  useImportProperties,
   useModifyProperty,
   useRemoveProperty,
   useRestoreProperty,
@@ -13,7 +14,7 @@ import { SearchInputGroup } from '@konfigyr/components/vault/properties/search-i
 import { PropertyHistorySidebar } from '@konfigyr/components/vault/properties/history-sidebar';
 import { PropertyStatusFilters, StatusFilter } from '@konfigyr/components/vault/properties/status-filters';
 import { PropertiesTable } from '@konfigyr/components/vault/properties/table';
-
+import { PropertiesImportDialog } from '@konfigyr/components/vault/properties/properties-import-dialog';
 import type {
   ChangesetState,
   ConfigurationProperty,
@@ -65,6 +66,7 @@ export function ChangesetEditor({ catalog, changeset, ...props }: { catalog: Ser
   const { mutateAsync: onUpdateProperty } = useModifyProperty(changeset);
   const { mutateAsync: onDeleteProperty } = useRemoveProperty(changeset);
   const { mutateAsync: onRestoreProperty } = useRestoreProperty(changeset);
+  const { mutateAsync: onImportProperties } = useImportProperties(changeset);
 
   const properties = useFilteredProperties(
     changeset,
@@ -91,6 +93,10 @@ export function ChangesetEditor({ catalog, changeset, ...props }: { catalog: Ser
 
   const onRestore = async (property: ConfigurationProperty<any>) => {
     await onRestoreProperty({ property });
+  };
+
+  const onImport = async (newProperties: Array<ConfigurationProperty<any>>) => {
+    await onImportProperties(newProperties);
   };
 
   return (
@@ -121,6 +127,8 @@ export function ChangesetEditor({ catalog, changeset, ...props }: { catalog: Ser
             changeset={changeset}
             onAdd={onAdd}
           />
+
+          <PropertiesImportDialog onImport={onImport} />
         </div>
 
         <PropertyStatusFilters

--- a/konfigyr-frontend/src/components/vault/changeset/editor.tsx
+++ b/konfigyr-frontend/src/components/vault/changeset/editor.tsx
@@ -128,7 +128,7 @@ export function ChangesetEditor({ catalog, changeset, ...props }: { catalog: Ser
             onAdd={onAdd}
           />
 
-          <PropertiesImportDialog onImport={onImport} />
+          <PropertiesImportDialog onImport={onImport} profile={changeset.profile} />
         </div>
 
         <PropertyStatusFilters

--- a/konfigyr-frontend/src/components/vault/properties/messages.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/messages.tsx
@@ -21,6 +21,13 @@ export const AddPropertyLabel = () => (
   />
 );
 
+export const ImportPropertiesLabel = () => (
+  <FormattedMessage
+    defaultMessage="Import"
+    description="Label used in action links or buttons that would add a configuration properties from an external file (e.g., JSON, YAML)."
+  />
+);
+
 export const RestorePropertyLabel = () => (
   <FormattedMessage
     defaultMessage="Restore property"

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -14,7 +14,7 @@ import { Field, FieldDescription, FieldLabel } from '@konfigyr/components/ui/fie
 import { Input } from '@konfigyr/components/ui/input';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
 import { ImportPropertiesLabel } from './messages';
-import type { ConfigurationProperty } from '@konfigyr/hooks/types';
+import type { ConfigurationProperty, Profile } from '@konfigyr/hooks/types';
 
 type ConfigurationImporterStatusProps = {
   isParsing: boolean;
@@ -58,10 +58,10 @@ export function ConfigurationImporter ({ onChange }: {
   );
 }
 
-export function PropertiesImportDialog ({ onImport }: {
+export function PropertiesImportDialog ({ profile, onImport }: {
   onImport: (properties: Array<ConfigurationProperty<any>>) => void | Promise<unknown>
+  profile: Profile
 }) {
-
   const [open, setOpen] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const { properties, reset, error, parseFile, isParsing, isError } = useConfigFileParser();
@@ -85,7 +85,7 @@ export function PropertiesImportDialog ({ onImport }: {
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger
         render={
-          <Button variant="outline">
+          <Button variant="outline" disabled={profile.policy === 'IMMUTABLE'}>
             <ImportIcon/>
             <ImportPropertiesLabel/>
           </Button>

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -20,7 +20,7 @@ import type { ConfigurationProperty } from '@konfigyr/hooks/types';
 export function ConfigurationImporter ({ onChange }: {
   onChange: (file: File ) => void,
 }) {
-  const inputId = 'configuration-importer-input';
+  const inputId = React.useId();
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -37,7 +37,7 @@ export function ConfigurationImporter ({ onChange }: {
           description="Label for the dialog that allows importing new configuration properties from a file"
         />
       </FieldLabel>
-      <Input id={inputId} data-testid={inputId} type="file" accept=".json,application/json,.properties,.yaml,.yml" onChange={handleChange}/>
+      <Input id={inputId} type="file" accept=".json,application/json,.properties,.yaml,.yml" onChange={handleChange}/>
       <FieldDescription>
         <FormattedMessage
           defaultMessage="Supported formats: <b>.json</b>, <b>.yaml</b>, <b>.yml</b> or <b>.properties</b>."

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -1,0 +1,164 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { CurlyBracesIcon, FileCog, ImportIcon } from 'lucide-react';
+import { FormattedMessage } from 'react-intl';
+import { Button } from '@konfigyr/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@konfigyr/components/ui/dialog';
+import { Field, FieldDescription, FieldLabel } from '@konfigyr/components/ui/field';
+import { Input } from '@konfigyr/components/ui/input';
+import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import { ImportPropertiesLabel } from './messages';
+import type { ConfigurationProperty } from '@konfigyr/hooks/types';
+
+export function ConfigurationImporter ({ error, onChange }: {
+  error?: string
+  onChange: (file: File ) => void,
+}) {
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) {
+      onChange(file);
+    }
+  }
+
+  return (
+    <Field>
+      <FieldLabel htmlFor="json">
+        <FormattedMessage
+          defaultMessage="Select existing configuration file"
+          description="Label for the dialog that allows importing new configuration properties from a file"
+        />
+      </FieldLabel>
+      <Input id="json" type="file" accept=".json,application/json,.properties,.yaml,.yml" onChange={handleChange}/>
+      <FieldDescription>
+        {error
+          ?
+          <span className="text-destructive">{error}</span>
+          :
+          <FormattedMessage
+            defaultMessage="Supported formats: <b>.json</b>, <b>.yaml</b>, <b>.yml</b> or <b>.properties</b>."
+            description="Label describing the supported file formats for importing configuration properties."
+            values={{
+              b: (chunks) => <strong> {chunks}</strong>,
+            }}
+          />
+        }
+      </FieldDescription>
+    </Field>
+  );
+}
+
+export function PropertiesImportDialog ({ onImport }: {
+  onImport: (properties: Array<ConfigurationProperty<any>>) => void | Promise<unknown>
+}) {
+  const [open, setOpen] = useState(false);
+  const { properties, error, parseFile, reset } = useConfigFileParser();
+
+  const onOpenChange = useCallback((state: boolean) => {
+    setOpen(state);
+    reset();
+  }, [properties]);
+
+  const handleSubmit = useCallback(() => {
+    onImport(properties);
+    setOpen(false);
+  }, [properties]);
+
+  const amount = useMemo(() => properties.length, [properties]);
+
+  const isImportDisabled = useMemo(() => properties.length === 0, [properties]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger
+        render={
+          <Button variant="outline">
+            <ImportIcon/>
+            <ImportPropertiesLabel/>
+          </Button>
+        }
+      />
+      <DialogContent className="sm:max-w-140">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-lg">
+            <FileCog size="1rem"/>
+            <FormattedMessage
+              defaultMessage="Import configuration properties"
+              description="Label for the dialog that allows importing new configuration properties from a file (e.g., JSON, YAML)"
+            />
+          </DialogTitle>
+        </DialogHeader>
+
+        <ConfigurationImporter error={error} onChange={parseFile}/>
+
+        {isImportDisabled
+          ? <ConfigurationPropertiesEmpty />
+          : <ConfigurationPropertiesReadyForImport amount={amount} />
+        }
+
+        <DialogFooter showCloseButton={true}>
+          <Button disabled={isImportDisabled} onClick={handleSubmit}>
+            <ImportIcon/>
+            <ImportPropertiesLabel/>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function ConfigurationPropertiesEmpty () {
+  return (
+    <EmptyState
+      icon={
+        <CurlyBracesIcon/>
+      }
+      title={
+        <FormattedMessage
+          defaultMessage="No configuration properties for import."
+          description="Empty state title used when no configuration propertis are found."
+        />
+      }
+      description={
+        <FormattedMessage
+          defaultMessage="Import new properties from existing configuration file. It will create new configuration properties or overwrite existing values. Files in unsupported formats will be rejected."
+          values={{
+            b: (chunks) => <strong> {chunks}</strong>,
+          }}
+          description="Label prompting an user to import configuration properties from a file."
+        />
+      }
+    />
+  );
+}
+
+function ConfigurationPropertiesReadyForImport ({ amount }: { amount: number }) {
+  return (
+    <EmptyState
+      icon={
+        <CurlyBracesIcon/>
+      }
+      title={
+        <FormattedMessage
+          defaultMessage="Ready for import"
+          description="Empty state title used when no configuration propertis are found."
+        />
+      }
+      description={
+        <FormattedMessage
+          defaultMessage="There are {amount} new configuration properties ready for import. The import will create new properties or overwrite existing values."
+          values={{ amount: <strong>{amount}</strong> }}
+          description="Label prompting an user to import configuration properties from a file."
+        />
+      }
+    />
+  );
+}

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -17,10 +17,10 @@ import { EmptyState } from '@konfigyr/components/ui/empty';
 import { ImportPropertiesLabel } from './messages';
 import type { ConfigurationProperty } from '@konfigyr/hooks/types';
 
-export function ConfigurationImporter ({ error, onChange }: {
-  error?: string
+export function ConfigurationImporter ({ onChange }: {
   onChange: (file: File ) => void,
 }) {
+  const inputId = 'configuration-importer-input';
 
   function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
@@ -31,26 +31,21 @@ export function ConfigurationImporter ({ error, onChange }: {
 
   return (
     <Field>
-      <FieldLabel htmlFor="json">
+      <FieldLabel htmlFor={inputId}>
         <FormattedMessage
           defaultMessage="Select existing configuration file"
           description="Label for the dialog that allows importing new configuration properties from a file"
         />
       </FieldLabel>
-      <Input id="json" type="file" accept=".json,application/json,.properties,.yaml,.yml" onChange={handleChange}/>
+      <Input id={inputId} data-testid={inputId} type="file" accept=".json,application/json,.properties,.yaml,.yml" onChange={handleChange}/>
       <FieldDescription>
-        {error
-          ?
-          <span className="text-destructive">{error}</span>
-          :
-          <FormattedMessage
-            defaultMessage="Supported formats: <b>.json</b>, <b>.yaml</b>, <b>.yml</b> or <b>.properties</b>."
-            description="Label describing the supported file formats for importing configuration properties."
-            values={{
-              b: (chunks) => <strong> {chunks}</strong>,
-            }}
-          />
-        }
+        <FormattedMessage
+          defaultMessage="Supported formats: <b>.json</b>, <b>.yaml</b>, <b>.yml</b> or <b>.properties</b>."
+          description="Label describing the supported file formats for importing configuration properties."
+          values={{
+            b: (chunks) => <strong> {chunks}</strong>,
+          }}
+        />
       </FieldDescription>
     </Field>
   );
@@ -60,21 +55,41 @@ export function PropertiesImportDialog ({ onImport }: {
   onImport: (properties: Array<ConfigurationProperty<any>>) => void | Promise<unknown>
 }) {
   const [open, setOpen] = useState(false);
-  const { properties, error, parseFile, reset } = useConfigFileParser();
+  const [isImporting, setIsImporting] = useState(false);
+  const [error, setError] = useState<string>();
+  const { properties, parseFile, reset } = useConfigFileParser();
 
   const onOpenChange = useCallback((state: boolean) => {
     setOpen(state);
+    setError(undefined);
     reset();
-  }, [properties]);
+  }, [reset]);
 
-  const handleSubmit = useCallback(() => {
-    onImport(properties);
-    setOpen(false);
-  }, [properties]);
+  const handleFileChange = useCallback(async (file: File) => {
+    setError(undefined);
+    try {
+      await parseFile(file);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Parse error');
+    }
+  }, [parseFile]);
+
+  const handleSubmit = useCallback(async () => {
+    setIsImporting(true);
+    setError(undefined);
+    try {
+      await onImport(properties);
+      setOpen(false);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Import failed');
+    } finally {
+      setIsImporting(false);
+    }
+  }, [onImport, properties]);
 
   const amount = useMemo(() => properties.length, [properties]);
 
-  const isImportDisabled = useMemo(() => properties.length === 0, [properties]);
+  const isImportDisabled = useMemo(() => properties.length === 0 || isImporting, [isImporting, properties]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -97,7 +112,12 @@ export function PropertiesImportDialog ({ onImport }: {
           </DialogTitle>
         </DialogHeader>
 
-        <ConfigurationImporter error={error} onChange={parseFile}/>
+        <ConfigurationImporter onChange={handleFileChange}/>
+        {error && (
+          <p className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
 
         {isImportDisabled
           ? <ConfigurationPropertiesEmpty />
@@ -155,7 +175,7 @@ function ConfigurationPropertiesReadyForImport ({ amount }: { amount: number }) 
       description={
         <FormattedMessage
           defaultMessage="There are {amount} new configuration properties ready for import. The import will create new properties or overwrite existing values."
-          values={{ amount: <strong>{amount}</strong> }}
+          values={{ amount }}
           description="Label prompting an user to import configuration properties from a file."
         />
       }

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { CurlyBracesIcon, FileCog, ImportIcon } from 'lucide-react';
 import { FormattedMessage } from 'react-intl';
 import { Button } from '@konfigyr/components/ui/button';
@@ -87,9 +87,7 @@ export function PropertiesImportDialog ({ onImport }: {
     }
   }, [onImport, properties]);
 
-  const amount = useMemo(() => properties.length, [properties]);
-
-  const isImportDisabled = useMemo(() => properties.length === 0 || isImporting, [isImporting, properties]);
+  const isImportDisabled = properties.length === 0 || isImporting;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -121,7 +119,7 @@ export function PropertiesImportDialog ({ onImport }: {
 
         {isImportDisabled
           ? <ConfigurationPropertiesEmpty />
-          : <ConfigurationPropertiesReadyForImport amount={amount} />
+          : <ConfigurationPropertiesReadyForImport amount={properties.length} />
         }
 
         <DialogFooter showCloseButton={true}>

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
-import { CurlyBracesIcon, FileCog, ImportIcon } from 'lucide-react';
-import { FormattedMessage } from 'react-intl';
+import { FileCog, ImportIcon } from 'lucide-react';
+import { FormattedMessage, useIntl } from 'react-intl';
 import { Button } from '@konfigyr/components/ui/button';
 import {
   Dialog,
@@ -13,16 +13,23 @@ import {
 import { Field, FieldDescription, FieldLabel } from '@konfigyr/components/ui/field';
 import { Input } from '@konfigyr/components/ui/input';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
-import { EmptyState } from '@konfigyr/components/ui/empty';
 import { ImportPropertiesLabel } from './messages';
 import type { ConfigurationProperty } from '@konfigyr/hooks/types';
 
+type ConfigurationImporterStatusProps = {
+  isParsing: boolean;
+  isError: boolean;
+  error?: Error;
+  hasProperties: boolean;
+  amount: number;
+};
+
 export function ConfigurationImporter ({ onChange }: {
-  onChange: (file: File ) => void,
+  onChange: (file: File) => void,
 }) {
   const inputId = React.useId();
 
-  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleChange (e: React.ChangeEvent<HTMLInputElement>) {
     const file = e.target.files?.[0];
     if (file) {
       onChange(file);
@@ -54,40 +61,25 @@ export function ConfigurationImporter ({ onChange }: {
 export function PropertiesImportDialog ({ onImport }: {
   onImport: (properties: Array<ConfigurationProperty<any>>) => void | Promise<unknown>
 }) {
+
   const [open, setOpen] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
-  const [error, setError] = useState<string>();
-  const { properties, parseFile, reset } = useConfigFileParser();
+  const { properties, reset, error, parseFile, isParsing, isError } = useConfigFileParser();
 
   const onOpenChange = useCallback((state: boolean) => {
     setOpen(state);
-    setError(undefined);
     reset();
   }, [reset]);
 
-  const handleFileChange = useCallback(async (file: File) => {
-    setError(undefined);
-    try {
-      await parseFile(file);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Parse error');
-    }
-  }, [parseFile]);
-
   const handleSubmit = useCallback(async () => {
     setIsImporting(true);
-    setError(undefined);
-    try {
-      await onImport(properties);
-      setOpen(false);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Import failed');
-    } finally {
-      setIsImporting(false);
-    }
+    await onImport(properties);
+    setOpen(false);
+    setIsImporting(false);
   }, [onImport, properties]);
 
   const isImportDisabled = properties.length === 0 || isImporting;
+
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -110,17 +102,15 @@ export function PropertiesImportDialog ({ onImport }: {
           </DialogTitle>
         </DialogHeader>
 
-        <ConfigurationImporter onChange={handleFileChange}/>
-        {error && (
-          <p className="text-sm text-destructive">
-            {error}
-          </p>
-        )}
+        <ConfigurationImporter onChange={parseFile}/>
 
-        {isImportDisabled
-          ? <ConfigurationPropertiesEmpty />
-          : <ConfigurationPropertiesReadyForImport amount={properties.length} />
-        }
+        <ConfigurationImporterStatus
+          isParsing={isParsing}
+          hasProperties={properties.length > 0}
+          amount={properties.length}
+          isError={isError}
+          error={error}
+        />
 
         <DialogFooter showCloseButton={true}>
           <Button disabled={isImportDisabled} onClick={handleSubmit}>
@@ -133,50 +123,86 @@ export function PropertiesImportDialog ({ onImport }: {
   );
 }
 
-function ConfigurationPropertiesEmpty () {
+function ConfigurationImporterStatus ({ hasProperties, amount, isParsing, isError, error }: ConfigurationImporterStatusProps ) {
+  const intl = useIntl();
+
+  const noPropertiesTitle = intl.formatMessage({
+    defaultMessage: 'No configuration properties for import',
+    description: 'Empty state description shown when parsed configuration has no properties.',
+  });
+
   return (
-    <EmptyState
-      icon={
-        <CurlyBracesIcon/>
-      }
-      title={
-        <FormattedMessage
-          defaultMessage="No configuration properties for import."
-          description="Empty state title used when no configuration propertis are found."
+    <>
+      {isParsing && (
+        <ParseStatus
+          title={
+            intl.formatMessage({
+              defaultMessage: 'Reading configuration',
+              description: 'Status title shown while configuration file is being parsed.',
+            })
+          }
+          description={
+            intl.formatMessage({
+              defaultMessage: 'Reading your configuration',
+              description: 'Status description shown while configuration file is being parsed',
+            })
+          }
         />
-      }
-      description={
-        <FormattedMessage
-          defaultMessage="Import new properties from existing configuration file. It will create new configuration properties or overwrite existing values. Files in unsupported formats will be rejected."
-          values={{
-            b: (chunks) => <strong> {chunks}</strong>,
-          }}
-          description="Label prompting an user to import configuration properties from a file."
+      )}
+
+      {isError && (
+        <ParseStatus
+          title={noPropertiesTitle}
+          description={
+            intl.formatMessage({
+              defaultMessage: 'Could not read your configuration: {error}',
+              description: 'Error message shown when configuration parsing fails',
+            }, {
+              error: error?.message,
+            })
+          }
         />
-      }
-    />
+      )}
+
+      {!hasProperties && !isError && (
+        <ParseStatus
+          title={noPropertiesTitle}
+          description={
+            intl.formatMessage({
+              defaultMessage: 'Your configuration is empty',
+              description: 'Empty state title shown when parsed configuration has no properties',
+            })
+          }
+        />
+      )}
+
+      {hasProperties && !isError && (
+        <ParseStatus
+          title={
+            intl.formatMessage({
+              defaultMessage: 'Ready for import',
+              description: 'State title shown when parsed configuration properties are ready',
+            })
+          }
+          description={
+            intl.formatMessage({
+              defaultMessage: 'Your configuration was parsed. There are {amount} new configuration properties ready for import.',
+              description: 'State description shown when parsed configuration properties are ready',
+            }, {
+              amount: amount,
+            })
+          }
+        />
+      )}
+    </>
   );
 }
 
-function ConfigurationPropertiesReadyForImport ({ amount }: { amount: number }) {
+function ParseStatus ({ title, description }: { title: string, description: string }) {
   return (
-    <EmptyState
-      icon={
-        <CurlyBracesIcon/>
-      }
-      title={
-        <FormattedMessage
-          defaultMessage="Ready for import"
-          description="Empty state title used when no configuration propertis are found."
-        />
-      }
-      description={
-        <FormattedMessage
-          defaultMessage="There are {amount} new configuration properties ready for import. The import will create new properties or overwrite existing values."
-          values={{ amount }}
-          description="Label prompting an user to import configuration properties from a file."
-        />
-      }
-    />
+    <div className="mx-auto flex max-w-sm flex-col items-center gap-2 text-center">
+      <div className="text-lg font-medium">{title}</div>
+      <div className="text-sm/relaxed">{description}</div>
+    </div>
   );
 }

--- a/konfigyr-frontend/src/hooks/vault/changeset.ts
+++ b/konfigyr-frontend/src/hooks/vault/changeset.ts
@@ -240,6 +240,47 @@ export const useAddProperty = generatePropertyOperationMutation(
   },
 );
 
+export const useImportProperties = (changeset: ChangesetState) => {
+  const client = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (properties: Array<ConfigurationProperty<any>>): Promise<ChangesetState>=> {
+      const result: Array<ConfigurationProperty<any>> = [];
+
+      properties.forEach(( property: ConfigurationProperty<any>) => {
+        const existing = changeset.properties.find(p => p.name === property.name);
+        if (existing) {
+          result.push(
+            {
+              ...existing,
+              value: property.value,
+              state: existing.state === ConfigurationPropertyState.ADDED ? ConfigurationPropertyState.ADDED : ConfigurationPropertyState.UPDATED,
+            },
+          );
+        } else {
+          result.push(
+            {
+              ...property,
+              state: ConfigurationPropertyState.ADDED,
+            },
+          );
+        }
+      });
+
+      return Promise.resolve({
+        ...changeset,
+        properties: result,
+        deleted: result.filter(p => p.state === ConfigurationPropertyState.REMOVED).length,
+        modified: result.filter(p => p.state === ConfigurationPropertyState.UPDATED).length,
+        added: result.filter(p => p.state === ConfigurationPropertyState.ADDED).length,
+      });
+    },
+    onSuccess(result: ChangesetState) {
+      client.setQueryData(vaultKeys.getChangeset(result.profile), result);
+    },
+  });
+};
+
 export const useRestoreProperty = generatePropertyOperationMutation(
   (state, property) => {
     const properties: Array<ConfigurationProperty<any>> = state.properties.map(it => {

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { PropertyTransitionType } from '@konfigyr/hooks/vault/types';
 import { parse } from 'yaml';
 import type { ConfigurationProperty } from '@konfigyr/hooks/vault/types';
@@ -23,6 +23,22 @@ const decodeEscapes = (value: string) => {
     .replace(/\\\\/g, '\\');
 };
 
+const hasOddTrailingBackslashes = (value: string) => {
+  let count = 0;
+  for (let i = value.length - 1; i >= 0 && value[i] === '\\'; i--) {
+    count++;
+  }
+  return count % 2 === 1;
+};
+
+const isEscaped = (value: string, index: number) => {
+  let backslashes = 0;
+  for (let i = index - 1; i >= 0 && value[i] === '\\'; i--) {
+    backslashes++;
+  }
+  return backslashes % 2 === 1;
+};
+
 /**
  * Parses Java-style `.properties` file content into an array of `Property` objects.
  *
@@ -37,7 +53,7 @@ const parseProperties = (text: string): Array<Property> => {
   const lines: Array<string> = [];
   for (let i = 0; i < rawLines.length; i++) {
     let line = rawLines[i] ?? '';
-    while (/\\$/.test(line) && !/\\\\$/.test(line)) {
+    while (hasOddTrailingBackslashes(line)) {
       line = line.slice(0, -1) + (rawLines[++i] ?? '');
     }
     lines.push(line);
@@ -51,8 +67,7 @@ const parseProperties = (text: string): Array<Property> => {
     let sep = -1;
     for (let i = 0; i < line.length; i++) {
       const ch = line[i];
-      const prevBackslash = i > 0 && line[i - 1] === '\\';
-      if (prevBackslash) continue;
+      if (isEscaped(line, i)) continue;
       if (ch === '=' || ch === ':' || /\s/.test(ch)) {
         sep = i;
         break;
@@ -88,10 +103,17 @@ const parseProperties = (text: string): Array<Property> => {
  * @param prefix - A prefix used for nested keys. Used internally during recursion.
  */
 function jsonToProperties (obj: any, prefix = ''): string {
+  if (obj === null || obj === undefined) {
+    return prefix ? `${prefix}=` : '';
+  }
+
+  if (typeof obj !== 'object') {
+    return prefix ? `${prefix}=${obj}` : '';
+  }
+
   const lines: Array<string> = [];
 
-  for (const key in obj) {
-    const value = obj[key];
+  for (const [key, value] of Object.entries(obj)) {
     const newKey = prefix ? `${prefix}.${key}` : key;
 
     if (Array.isArray(value)) {
@@ -157,12 +179,11 @@ const parseJson = (text?: string): Array<Property> => {
  */
 export function useConfigFileParser () {
   const [properties, setProperties] = useState<Array<ConfigurationProperty<any>>>([]);
-  const [error, setError] = useState<string>();
+  const parseSequenceRef = useRef(0);
 
   async function parseFile (file: File) {
+    const currentSequence = ++parseSequenceRef.current;
     try {
-      setError(undefined);
-
       const text = await file.text();
       const name = file.name.toLowerCase();
 
@@ -184,7 +205,7 @@ export function useConfigFileParser () {
           state: PropertyTransitionType.ADDED,
           value: {
             encoded: p.value,
-            decoded: 'string',
+            decoded: p.value,
           },
           typeName: 'string',
           schema: {
@@ -192,17 +213,23 @@ export function useConfigFileParser () {
           },
         };
       });
+      if (parseSequenceRef.current !== currentSequence) {
+        return;
+      }
       setProperties(configurationProperties);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Parse error');
+      if (parseSequenceRef.current !== currentSequence) {
+        return;
+      }
       setProperties([]);
+      throw e;
     }
   }
 
   const reset = () => {
+    parseSequenceRef.current++;
     setProperties([]);
-    setError(undefined);
   };
 
-  return { properties, error, parseFile, reset };
+  return { properties, parseFile, reset };
 }

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -8,6 +8,9 @@ type Property = {
   value: string;
 };
 
+const buildProperty = (name: string, value: string): Property => {
+  return { name, value };
+};
 /**
  * Decodes escaped sequences in a string (commonly found in `.properties` files).
  *
@@ -46,7 +49,7 @@ const isEscaped = (value: string, index: number) => {
  *
  * @param text - Raw `.properties` file content.
  */
-const parseProperties = (text: string): Array<Property> => {
+const parsePropertiesFile = (text: string): Array<Property> => {
   const out: Array<Property> = [];
 
   const rawLines = text.replace(/\r\n?/g, '\n').split('\n');
@@ -91,7 +94,9 @@ const parseProperties = (text: string): Array<Property> => {
     value = decodeEscapes(value.trim());
 
     if (key) {
-      out.push({ name: key, value });
+      out.push(
+        buildProperty(key, value),
+      );
     }
   }
 
@@ -115,47 +120,54 @@ const isScalar = (value: unknown) => {
 };
 
 /**
- * Converts a JSON object into a flat string of Java-style `.properties` entries.
+ * Converts a JSON-compatible object into flat `Property` entries.
  *
  * @param obj - The input object to convert. Can contain nested objects and arrays.
- * @param prefix - A prefix used for nested keys. Used internally during recursion.
  */
-function jsonToProperties (obj: any, prefix = ''): string {
-  if (obj === null || obj === undefined) {
-    return prefix ? `${prefix}=` : '';
-  }
+function jsonToProperties (obj: unknown): Array<Property> {
+  const properties: Array<Property> = [];
 
-  if (typeof obj !== 'object') {
-    return prefix ? `${prefix}=${obj}` : '';
-  }
-
-  const lines: Array<string> = [];
-
-  for (const [key, value] of Object.entries(obj)) {
-    const newKey = prefix ? `${prefix}.${key}` : key;
+  const append = (value: unknown, prefix: string) => {
+    if (!prefix) {
+      return;
+    }
 
     if (Array.isArray(value)) {
-      // If the array only contains scalar values, serialize it as a single comma-separated value.
-      // This matches common `.properties` conventions like: key=a,b,c
       if (value.every(isScalar)) {
-        lines.push(`${newKey}=${value.map(v => String(v)).join(',')}`);
-      } else {
-        value.forEach((v, i) => {
-          if (typeof v === 'object') {
-            lines.push(jsonToProperties(v, `${newKey}[${i}]`));
-          } else {
-            lines.push(`${newKey}[${i}]=${v}`);
-          }
-        });
+        properties.push(
+          buildProperty(prefix, value.map(v => String(v)).join(',')),
+        );
+        return;
       }
-    } else if (typeof value === 'object' && value !== null) {
-      lines.push(jsonToProperties(value, newKey));
-    } else {
-      lines.push(`${newKey}=${value}`);
+
+      value.forEach((item, index) => {
+        append(item, `${prefix}[${index}]`);
+      });
+      return;
     }
+
+    if (value !== null && typeof value === 'object') {
+      Object.entries(value).forEach(([key, nestedValue]) => {
+        const nestedKey = `${prefix}.${key}`;
+        append(nestedValue, nestedKey);
+      });
+      return;
+    }
+
+    properties.push(
+      buildProperty(prefix, String(value)),
+    );
+  };
+
+  if (obj === null || obj === undefined || typeof obj !== 'object') {
+    return [];
   }
 
-  return lines.join('\n');
+  Object.entries(obj).forEach(([key, value]) => {
+    append(value, key);
+  });
+
+  return properties;
 }
 
 /**
@@ -163,13 +175,12 @@ function jsonToProperties (obj: any, prefix = ''): string {
  *
  * @param yamlText - Raw YAML content to parse.
  */
-const parseYaml = (yamlText?: string): Array<Property> => {
+const parseYamlFile = (yamlText?: string): Array<Property> => {
   if (!yamlText) {
     return [];
   }
   const parsedYamlObject = parse(yamlText);
-  const propertiesString = jsonToProperties(parsedYamlObject);
-  return parseProperties(propertiesString);
+  return jsonToProperties(parsedYamlObject);
 };
 
 /**
@@ -177,13 +188,12 @@ const parseYaml = (yamlText?: string): Array<Property> => {
  *
  * @param text - Raw JSON string to parse.
  */
-const parseJson = (text?: string): Array<Property> => {
+const parseJsonFile = (text?: string): Array<Property> => {
   if (!text) {
     return [];
   }
   const parsedJsonObject = JSON.parse(text);
-  const propertiesText = jsonToProperties(parsedJsonObject);
-  return parseProperties(propertiesText);
+  return jsonToProperties(parsedJsonObject);
 };
 
 /**
@@ -219,11 +229,11 @@ export function useConfigFileParser () {
       let parsedProperties: Array<Property> = [];
 
       if (name.endsWith('.json')) {
-        parsedProperties = parseJson(text);
+        parsedProperties = parseJsonFile(text);
       } else if (name.endsWith('.properties')) {
-        parsedProperties = parseProperties(text);
+        parsedProperties = parsePropertiesFile(text);
       } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
-        parsedProperties = parseYaml(text);
+        parsedProperties = parseYamlFile(text);
       } else {
         throw new Error('Unsupported file type');
       }

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -3,13 +3,25 @@ import { PropertyTransitionType } from '@konfigyr/hooks/vault/types';
 import { parse } from 'yaml';
 import type { ConfigurationProperty } from '@konfigyr/hooks/vault/types';
 
-type Property = {
-  name: string;
-  value: string;
-};
-
-const buildProperty = (name: string, value: string): Property => {
-  return { name, value };
+/**
+ * Builds a configuration property object from a name/value pair.
+ *
+ * @param name - property key.
+ * @param value - property value
+ */
+const buildConfigurationProperty = (name: string, value: string): ConfigurationProperty<string> => {
+  return {
+    name: name,
+    state: PropertyTransitionType.ADDED,
+    value: {
+      encoded: value,
+      decoded: value,
+    },
+    typeName: 'string',
+    schema: {
+      type: 'string',
+    },
+  };
 };
 /**
  * Decodes escaped sequences in a string (commonly found in `.properties` files).
@@ -49,8 +61,8 @@ const isEscaped = (value: string, index: number) => {
  *
  * @param text - Raw `.properties` file content.
  */
-const parsePropertiesFile = (text: string): Array<Property> => {
-  const out: Array<Property> = [];
+const parsePropertiesFile = (text: string): Array<ConfigurationProperty<string>> => {
+  const out: Array<ConfigurationProperty<string>> = [];
 
   const rawLines = text.replace(/\r\n?/g, '\n').split('\n');
 
@@ -95,14 +107,13 @@ const parsePropertiesFile = (text: string): Array<Property> => {
 
     if (key) {
       out.push(
-        buildProperty(key, value),
+        buildConfigurationProperty(key, value),
       );
     }
   }
 
   return out;
 };
-
 /**
  * Checks whether a value is a scalar primitive.
  *
@@ -118,14 +129,13 @@ const isScalar = (value: unknown) => {
     typeof value === 'bigint'
   );
 };
-
 /**
  * Converts a JSON-compatible object into flat `Property` entries.
  *
  * @param obj - The input object to convert. Can contain nested objects and arrays.
  */
-function jsonToProperties (obj: unknown): Array<Property> {
-  const properties: Array<Property> = [];
+function jsonToProperties (obj: unknown): Array<ConfigurationProperty<string>> {
+  const properties: Array<ConfigurationProperty<string>> = [];
 
   const append = (value: unknown, prefix: string) => {
     if (!prefix) {
@@ -135,7 +145,7 @@ function jsonToProperties (obj: unknown): Array<Property> {
     if (Array.isArray(value)) {
       if (value.every(isScalar)) {
         properties.push(
-          buildProperty(prefix, value.map(v => String(v)).join(',')),
+          buildConfigurationProperty(prefix, value.map(v => String(v)).join(',')),
         );
         return;
       }
@@ -155,7 +165,7 @@ function jsonToProperties (obj: unknown): Array<Property> {
     }
 
     properties.push(
-      buildProperty(prefix, String(value)),
+      buildConfigurationProperty(prefix, String(value)),
     );
   };
 
@@ -169,26 +179,24 @@ function jsonToProperties (obj: unknown): Array<Property> {
 
   return properties;
 }
-
 /**
  * Parses YAML text and converts it into an array of `Property` objects.
  *
  * @param yamlText - Raw YAML content to parse.
  */
-const parseYamlFile = (yamlText?: string): Array<Property> => {
+const parseYamlFile = (yamlText?: string): Array<ConfigurationProperty<string>> => {
   if (!yamlText) {
     return [];
   }
   const parsedYamlObject = parse(yamlText);
   return jsonToProperties(parsedYamlObject);
 };
-
 /**
  * Parses JSON text and converts it into an array of `Property` objects.
  *
  * @param text - Raw JSON string to parse.
  */
-const parseJsonFile = (text?: string): Array<Property> => {
+const parseJsonFile = (text?: string): Array<ConfigurationProperty<string>> => {
   if (!text) {
     return [];
   }
@@ -208,8 +216,11 @@ const parseJsonFile = (text?: string): Array<Property> => {
  * @returns An object containing:
  * - `properties` - The parsed configuration properties.
  * - `error` - An error message if parsing fails.
- * - `parse` - Async function to parse a given `File`.
+ * - `parseFile` - Async function to parse a given `File`.
  * - `reset` - Function to clear parsed data and errors.
+ * - `isParsing` - Indicates whether a parse operation is currently in progress.
+ * - `isError` - Indicates whether the latest parse operation failed.
+ * - `isReady` - Indicates parser idle state (not parsing and no error).
  */
 export function useConfigFileParser () {
   const [properties, setProperties] = useState<Array<ConfigurationProperty<any>>>([]);
@@ -226,7 +237,7 @@ export function useConfigFileParser () {
       const text = await file.text();
       const name = file.name.toLowerCase();
 
-      let parsedProperties: Array<Property> = [];
+      let parsedProperties: Array<ConfigurationProperty<string>> = [];
 
       if (name.endsWith('.json')) {
         parsedProperties = parseJsonFile(text);
@@ -238,24 +249,10 @@ export function useConfigFileParser () {
         throw new Error('Unsupported file type');
       }
 
-      const configurationProperties: Array<ConfigurationProperty<any>> = parsedProperties.map((p: Property) => {
-        return {
-          name: p.name,
-          state: PropertyTransitionType.ADDED,
-          value: {
-            encoded: p.value,
-            decoded: p.value,
-          },
-          typeName: 'string',
-          schema: {
-            type: 'string',
-          },
-        };
-      });
       if (parseSequenceRef.current !== currentSequence) {
         return;
       }
-      setProperties(configurationProperties);
+      setProperties(parsedProperties);
       setIsParsing(false);
       setError(undefined);
     } catch (e) {

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -20,6 +20,8 @@ const decodeEscapes = (value: string) => {
     .replace(/\\r/g, '\r')
     .replace(/\\n/g, '\n')
     .replace(/\\f/g, '\f')
+    // Java .properties allows escaping separators and special key chars.
+    .replace(/\\([:=#!\s])/g, '$1')
     .replace(/\\\\/g, '\\');
 };
 
@@ -201,10 +203,15 @@ const parseJson = (text?: string): Array<Property> => {
  */
 export function useConfigFileParser () {
   const [properties, setProperties] = useState<Array<ConfigurationProperty<any>>>([]);
+  const [error, setError] = useState<Error>();
+  const [isParsing, setIsParsing] = useState(false);
   const parseSequenceRef = useRef(0);
 
   async function parseFile (file: File) {
     const currentSequence = ++parseSequenceRef.current;
+    setIsParsing(true);
+    setError(undefined);
+
     try {
       const text = await file.text();
       const name = file.name.toLowerCase();
@@ -239,19 +246,32 @@ export function useConfigFileParser () {
         return;
       }
       setProperties(configurationProperties);
+      setIsParsing(false);
+      setError(undefined);
     } catch (e) {
       if (parseSequenceRef.current !== currentSequence) {
         return;
       }
       setProperties([]);
-      throw e;
+      setIsParsing(false);
+      setError(e instanceof Error ? e : new Error('Parse error'));
     }
   }
 
   const reset = () => {
     parseSequenceRef.current++;
     setProperties([]);
+    setError(undefined);
+    setIsParsing(false);
   };
 
-  return { properties, parseFile, reset };
+  return {
+    properties,
+    error,
+    parseFile,
+    reset,
+    isParsing,
+    isError: !!error,
+    isReady: !isParsing && !error,
+  };
 }

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -1,0 +1,208 @@
+import { useState } from 'react';
+import { PropertyTransitionType } from '@konfigyr/hooks/vault/types';
+import { parse } from 'yaml';
+import type { ConfigurationProperty } from '@konfigyr/hooks/vault/types';
+
+type Property = {
+  name: string;
+  value: string;
+};
+
+/**
+ * Decodes escaped sequences in a string (commonly found in `.properties` files).
+ *
+ * @param value - The input string containing escape sequences.
+ */
+const decodeEscapes = (value: string) => {
+  return value
+    .replace(/\\u([0-9a-fA-F]{4})/g, (_, hex) => String.fromCharCode(parseInt(hex, 16)))
+    .replace(/\\t/g, '\t')
+    .replace(/\\r/g, '\r')
+    .replace(/\\n/g, '\n')
+    .replace(/\\f/g, '\f')
+    .replace(/\\\\/g, '\\');
+};
+
+/**
+ * Parses Java-style `.properties` file content into an array of `Property` objects.
+ *
+ * @param text - Raw `.properties` file content.
+ */
+const parseProperties = (text: string): Array<Property> => {
+  const out: Array<Property> = [];
+
+  const rawLines = text.replace(/\r\n?/g, '\n').split('\n');
+
+  // Handle line continuations ending with an odd number of backslashes
+  const lines: Array<string> = [];
+  for (let i = 0; i < rawLines.length; i++) {
+    let line = rawLines[i] ?? '';
+    while (/\\$/.test(line) && !/\\\\$/.test(line)) {
+      line = line.slice(0, -1) + (rawLines[++i] ?? '');
+    }
+    lines.push(line);
+  }
+
+  for (const original of lines) {
+    const line = original.trim();
+    if (!line || line.startsWith('#') || line.startsWith('!')) continue;
+
+    // Find first unescaped separator: =, :, or whitespace
+    let sep = -1;
+    for (let i = 0; i < line.length; i++) {
+      const ch = line[i];
+      const prevBackslash = i > 0 && line[i - 1] === '\\';
+      if (prevBackslash) continue;
+      if (ch === '=' || ch === ':' || /\s/.test(ch)) {
+        sep = i;
+        break;
+      }
+    }
+
+    let [key, value] = ['', ''];
+    if (sep === -1) {
+      [key, value] = [line, ''];
+    } else {
+      key = line.slice(0, sep).trimEnd();
+      value = line.slice(sep);
+
+      // If separator was whitespace, value may start immediately; if =/:, skip them
+      value = value.replace(/^[\s:=]+/, '');
+    }
+
+    key = decodeEscapes(key.trim());
+    value = decodeEscapes(value.trim());
+
+    if (key) {
+      out.push({ name: key, value });
+    }
+  }
+
+  return out;
+};
+
+/**
+ * Converts a JSON object into a flat string of Java-style `.properties` entries.
+ *
+ * @param obj - The input object to convert. Can contain nested objects and arrays.
+ * @param prefix - A prefix used for nested keys. Used internally during recursion.
+ */
+function jsonToProperties (obj: any, prefix = ''): string {
+  const lines: Array<string> = [];
+
+  for (const key in obj) {
+    const value = obj[key];
+    const newKey = prefix ? `${prefix}.${key}` : key;
+
+    if (Array.isArray(value)) {
+      value.forEach((v, i) => {
+        if (typeof v === 'object') {
+          lines.push(jsonToProperties(v, `${newKey}[${i}]`));
+        } else {
+          lines.push(`${newKey}[${i}]=${v}`);
+        }
+      });
+    } else if (typeof value === 'object' && value !== null) {
+      lines.push(jsonToProperties(value, newKey));
+    } else {
+      lines.push(`${newKey}=${value}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Parses YAML text and converts it into an array of `Property` objects.
+ *
+ * @param yamlText - Raw YAML content to parse.
+ */
+const parseYaml = (yamlText?: string): Array<Property> => {
+  if (!yamlText) {
+    return [];
+  }
+  const parsedYamlObject = parse(yamlText);
+  const propertiesString = jsonToProperties(parsedYamlObject);
+  return parseProperties(propertiesString);
+};
+
+/**
+ * Parses JSON text and converts it into an array of `Property` objects.
+ *
+ * @param text - Raw JSON string to parse.
+ */
+const parseJson = (text?: string): Array<Property> => {
+  if (!text) {
+    return [];
+  }
+  const parsedJsonObject = JSON.parse(text);
+  const propertiesText = jsonToProperties(parsedJsonObject);
+  return parseProperties(propertiesText);
+};
+
+/**
+ * React hook for parsing configuration files into structured properties.
+ *
+ * Supports the following file formats:
+ * - `.json`
+ * - `.properties`
+ * - `.yaml`
+ * - `.yml`
+ *
+ * @returns An object containing:
+ * - `properties` - The parsed configuration properties.
+ * - `error` - An error message if parsing fails.
+ * - `parse` - Async function to parse a given `File`.
+ * - `reset` - Function to clear parsed data and errors.
+ */
+export function useConfigFileParser () {
+  const [properties, setProperties] = useState<Array<ConfigurationProperty<any>>>([]);
+  const [error, setError] = useState<string>();
+
+  async function parseFile (file: File) {
+    try {
+      setError(undefined);
+
+      const text = await file.text();
+      const name = file.name.toLowerCase();
+
+      let parsedProperties: Array<Property> = [];
+
+      if (name.endsWith('.json')) {
+        parsedProperties = parseJson(text);
+      } else if (name.endsWith('.properties')) {
+        parsedProperties = parseProperties(text);
+      } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
+        parsedProperties = parseYaml(text);
+      } else {
+        throw new Error('Unsupported file type');
+      }
+
+      const configurationProperties: Array<ConfigurationProperty<any>> = parsedProperties.map((p: Property) => {
+        return {
+          name: p.name,
+          state: PropertyTransitionType.ADDED,
+          value: {
+            encoded: p.value,
+            decoded: 'string',
+          },
+          typeName: 'string',
+          schema: {
+            type: 'string',
+          },
+        };
+      });
+      setProperties(configurationProperties);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Parse error');
+      setProperties([]);
+    }
+  }
+
+  const reset = () => {
+    setProperties([]);
+    setError(undefined);
+  };
+
+  return { properties, error, parseFile, reset };
+}

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -97,6 +97,22 @@ const parseProperties = (text: string): Array<Property> => {
 };
 
 /**
+ * Checks whether a value is a scalar primitive.
+ *
+ * @param value - the value to evaluate.
+ */
+const isScalar = (value: unknown) => {
+  return (
+    value === null ||
+    value === undefined ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+  );
+};
+
+/**
  * Converts a JSON object into a flat string of Java-style `.properties` entries.
  *
  * @param obj - The input object to convert. Can contain nested objects and arrays.
@@ -117,13 +133,19 @@ function jsonToProperties (obj: any, prefix = ''): string {
     const newKey = prefix ? `${prefix}.${key}` : key;
 
     if (Array.isArray(value)) {
-      value.forEach((v, i) => {
-        if (typeof v === 'object') {
-          lines.push(jsonToProperties(v, `${newKey}[${i}]`));
-        } else {
-          lines.push(`${newKey}[${i}]=${v}`);
-        }
-      });
+      // If the array only contains scalar values, serialize it as a single comma-separated value.
+      // This matches common `.properties` conventions like: key=a,b,c
+      if (value.every(isScalar)) {
+        lines.push(`${newKey}=${value.map(v => String(v)).join(',')}`);
+      } else {
+        value.forEach((v, i) => {
+          if (typeof v === 'object') {
+            lines.push(jsonToProperties(v, `${newKey}[${i}]`));
+          } else {
+            lines.push(`${newKey}[${i}]=${v}`);
+          }
+        });
+      }
     } else if (typeof value === 'object' && value !== null) {
       lines.push(jsonToProperties(value, newKey));
     } else {

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, waitFor, within } from '@testing-library/react';
 import { renderWithMessageProvider } from '@konfigyr/test/helpers/messages';
 import { PropertiesImportDialog } from '@konfigyr/components/vault/properties/properties-import-dialog';
 import userEvent from '@testing-library/user-event';
+import { profiles } from '@konfigyr/test/helpers/mocks';
 import React from 'react';
 
 const PROPERTIES_FILE = 'server.port=8080';
@@ -15,11 +16,21 @@ const YAML_FILE = `
 describe('components | vault | properties | <PropertiesImportDialog/>', () => {
   afterEach(() => cleanup());
 
+  test('should render disabled Import button for the immutable profile', () => {
+    const user = userEvent.setup();
+    const onImport = vi.fn().mockResolvedValue(undefined);
+    const result = renderWithMessageProvider(
+      <PropertiesImportDialog onImport={onImport} profile={profiles.deprecated} />,
+    );
+
+    expect(result.getByRole('button', { name: 'Import' })).toBeDisabled();
+  });
+
   test('should show empty state by default when dialog is open', async () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport}/>,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development} />,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));
@@ -34,7 +45,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport}/>,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development} />,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));
@@ -78,7 +89,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport}/>,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development} />,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));
@@ -120,7 +131,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport}/>,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development} />,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -15,6 +15,21 @@ const YAML_FILE = `
 describe('components | vault | properties | <PropertiesImportDialog/>', () => {
   afterEach(() => cleanup());
 
+  test('should show empty state by default when dialog is open', async () => {
+    const user = userEvent.setup();
+    const onImport = vi.fn().mockResolvedValue(undefined);
+    const result = renderWithMessageProvider(
+      <PropertiesImportDialog onImport={onImport}/>,
+    );
+
+    await user.click(result.getByRole('button', { name: 'Import' }));
+    await waitFor(() => expect(result.getByRole('dialog')).toBeInTheDocument());
+
+    expect(result.getByText('No configuration properties for import')).toBeInTheDocument();
+    expect(result.getByText('Your configuration is empty')).toBeInTheDocument();
+    expect(within(result.getByRole('dialog')).getByRole('button', { name: 'Import' })).toBeDisabled();
+  });
+
   test('should import properties and close dialog on successful submit', async () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
@@ -101,26 +116,29 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     await waitFor(() => expect(result.queryByRole('dialog')).toBeNull());
   });
 
-  test('should keep dialog open and show import error when submit fails', async () => {
+  test('should show parsing error for invalid JSON file', async () => {
     const user = userEvent.setup();
-    const onImport = vi.fn().mockRejectedValue(new Error('Import request failed'));
+    const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
       <PropertiesImportDialog onImport={onImport}/>,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));
-    const input = await result.findByLabelText('Select existing configuration file');
-    const file = new File([PROPERTIES_FILE], 'application.properties', { type: 'text/plain' });
+    await waitFor(() => expect(result.getByRole('dialog')).toBeInTheDocument());
+
+    const input = result.getByLabelText('Select existing configuration file');
+    const file = new File(['{invalid'], 'application.json', { type: 'application/json' });
     await user.upload(input, file);
 
-    await waitFor(() => expect(result.getByText('Ready for import')).toBeInTheDocument());
-    const dialog = result.getByRole('dialog');
-    const importButton = within(dialog).getByRole('button', { name: 'Import' });
-    await user.click(importButton);
-
-    await waitFor(() => expect(result.getByText('Import request failed')).toBeInTheDocument());
-    expect(result.getByRole('dialog')).toBeInTheDocument();
-    expect(within(result.getByRole('dialog')).getByRole('button', { name: 'Import' })).not.toBeDisabled();
+    await waitFor(() => {
+      expect(result.getByText('No configuration properties for import')).toBeInTheDocument();
+      expect(result.getByText('Could not read your configuration: Expected property name or \'}\' in JSON at position 1 (line 1 column 2)')).toBeInTheDocument();
+    });
+    expect(
+      within(
+        result.getByRole('dialog')).getByRole('button', { name: 'Import' }),
+    ).toBeDisabled();
+    expect(onImport).not.toHaveBeenCalled();
   });
 
 });

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -38,8 +38,24 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const importButton = within(dialog).getByRole('button', { name: 'Import' });
     await user.click(importButton);
 
-    await waitFor(() => expect(onImport).toHaveBeenCalledOnce());
-    expect(onImport.mock.calls[0][0]).toMatchObject([{ name: 'server.port' }]);
+    await waitFor(() => {
+      expect(onImport).toHaveBeenCalledExactlyOnceWith(
+        [
+          {
+            name: 'server.port',
+            schema: {
+              type: 'string',
+            },
+            state: 'ADDED',
+            typeName: 'string',
+            value: {
+              decoded: '8080',
+              encoded: '8080',
+            },
+          },
+
+        ]);
+    });
     await waitFor(() => expect(result.queryByRole('dialog')).toBeNull());
   });
 
@@ -66,8 +82,22 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const importButton = within(dialog).getByRole('button', { name: 'Import' });
     await user.click(importButton);
 
-    await waitFor(() => expect(onImport).toHaveBeenCalledOnce());
-    expect(onImport.mock.calls[0][0]).toMatchObject([{ name: 'server.port' }]);
+    await waitFor(() => {
+      expect(onImport).toHaveBeenCalledExactlyOnceWith( [
+        {
+          name: 'server.port',
+          schema: {
+            type: 'string',
+          },
+          state: 'ADDED',
+          typeName: 'string',
+          value: {
+            decoded: '8080',
+            encoded: '8080',
+          },
+        },
+      ]);
+    });
     await waitFor(() => expect(result.queryByRole('dialog')).toBeNull());
   });
 

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, waitFor, within } from '@testing-library/react';
+import { renderWithMessageProvider } from '@konfigyr/test/helpers/messages';
+import { PropertiesImportDialog } from '@konfigyr/components/vault/properties/properties-import-dialog';
+import userEvents from '@testing-library/user-event';
+import React from 'react';
+
+const PROPERTIES_FILE = 'server.port=8080';
+
+const YAML_FILE = `
+  server:
+    port: 8080
+`;
+
+describe('components | vault | properties | <PropertiesImportDialog/>', () => {
+  afterEach(() => cleanup());
+
+  test('should import properties and close dialog on successful submit', async () => {
+    const onImport = vi.fn().mockResolvedValue(undefined);
+    const result = renderWithMessageProvider(
+      <PropertiesImportDialog onImport={onImport}/>,
+    );
+
+    await userEvents.click(result.getByRole('button', { name: 'Import' }));
+    await waitFor(() => expect(result.getByRole('dialog')).toBeInTheDocument());
+
+    const input = result.getByTestId('configuration-importer-input');
+    const file = new File([PROPERTIES_FILE], 'application.properties', { type: 'text/plain' });
+    await userEvents.upload(input, file);
+
+    await waitFor(() => {
+      expect(result.getByText('Ready for import')).toBeInTheDocument();
+      expect(result.getByText(/there are 1 new configuration properties ready for import/i)).toBeInTheDocument();
+    });
+
+    const dialog = result.getByRole('dialog');
+    const importButton = within(dialog).getByRole('button', { name: 'Import' });
+    await userEvents.click(importButton);
+
+    await waitFor(() => expect(onImport).toHaveBeenCalledOnce());
+    expect(onImport.mock.calls[0][0]).toMatchObject([{ name: 'server.port' }]);
+    await waitFor(() => expect(result.queryByRole('dialog')).toBeNull());
+  });
+
+  test('should import yaml and close dialog on successful submit', async () => {
+    const onImport = vi.fn().mockResolvedValue(undefined);
+    const result = renderWithMessageProvider(
+      <PropertiesImportDialog onImport={onImport}/>,
+    );
+
+    await userEvents.click(result.getByRole('button', { name: 'Import' }));
+    await waitFor(() => expect(result.getByRole('dialog')).toBeInTheDocument());
+
+    const input = result.getByTestId('configuration-importer-input');
+    const file = new File([YAML_FILE], 'application.yaml', { type: 'text/plain' });
+    await userEvents.upload(input, file);
+
+    await waitFor(() => {
+      expect(result.getByText('Ready for import')).toBeInTheDocument();
+      expect(result.getByText(/there are 1 new configuration properties ready for import/i)).toBeInTheDocument();
+    });
+
+    const dialog = result.getByRole('dialog');
+    const importButton = within(dialog).getByRole('button', { name: 'Import' });
+    await userEvents.click(importButton);
+
+    await waitFor(() => expect(onImport).toHaveBeenCalledOnce());
+    expect(onImport.mock.calls[0][0]).toMatchObject([{ name: 'server.port' }]);
+    await waitFor(() => expect(result.queryByRole('dialog')).toBeNull());
+  });
+
+  test('should keep dialog open and show import error when submit fails', async () => {
+    const onImport = vi.fn().mockRejectedValue(new Error('Import request failed'));
+    const result = renderWithMessageProvider(
+      <PropertiesImportDialog onImport={onImport}/>,
+    );
+
+    await userEvents.click(result.getByRole('button', { name: 'Import' }));
+    const input = await result.findByTestId('configuration-importer-input');
+    const file = new File([PROPERTIES_FILE], 'application.properties', { type: 'text/plain' });
+    await userEvents.upload(input, file);
+
+    await waitFor(() => expect(result.getByText('Ready for import')).toBeInTheDocument());
+    const dialog = result.getByRole('dialog');
+    const importButton = within(dialog).getByRole('button', { name: 'Import' });
+    await userEvents.click(importButton);
+
+    await waitFor(() => expect(result.getByText('Import request failed')).toBeInTheDocument());
+    expect(result.getByRole('dialog')).toBeInTheDocument();
+    expect(within(result.getByRole('dialog')).getByRole('button', { name: 'Import' })).not.toBeDisabled();
+  });
+
+});

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 import { cleanup, waitFor, within } from '@testing-library/react';
 import { renderWithMessageProvider } from '@konfigyr/test/helpers/messages';
 import { PropertiesImportDialog } from '@konfigyr/components/vault/properties/properties-import-dialog';
-import userEvents from '@testing-library/user-event';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 const PROPERTIES_FILE = 'server.port=8080';
@@ -16,17 +16,18 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
   afterEach(() => cleanup());
 
   test('should import properties and close dialog on successful submit', async () => {
+    const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
       <PropertiesImportDialog onImport={onImport}/>,
     );
 
-    await userEvents.click(result.getByRole('button', { name: 'Import' }));
+    await user.click(result.getByRole('button', { name: 'Import' }));
     await waitFor(() => expect(result.getByRole('dialog')).toBeInTheDocument());
 
-    const input = result.getByTestId('configuration-importer-input');
+    const input = result.getByLabelText('Select existing configuration file');
     const file = new File([PROPERTIES_FILE], 'application.properties', { type: 'text/plain' });
-    await userEvents.upload(input, file);
+    await user.upload(input, file);
 
     await waitFor(() => {
       expect(result.getByText('Ready for import')).toBeInTheDocument();
@@ -35,7 +36,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
 
     const dialog = result.getByRole('dialog');
     const importButton = within(dialog).getByRole('button', { name: 'Import' });
-    await userEvents.click(importButton);
+    await user.click(importButton);
 
     await waitFor(() => expect(onImport).toHaveBeenCalledOnce());
     expect(onImport.mock.calls[0][0]).toMatchObject([{ name: 'server.port' }]);
@@ -43,17 +44,18 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
   });
 
   test('should import yaml and close dialog on successful submit', async () => {
+    const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
       <PropertiesImportDialog onImport={onImport}/>,
     );
 
-    await userEvents.click(result.getByRole('button', { name: 'Import' }));
+    await user.click(result.getByRole('button', { name: 'Import' }));
     await waitFor(() => expect(result.getByRole('dialog')).toBeInTheDocument());
 
-    const input = result.getByTestId('configuration-importer-input');
+    const input = result.getByLabelText('Select existing configuration file');
     const file = new File([YAML_FILE], 'application.yaml', { type: 'text/plain' });
-    await userEvents.upload(input, file);
+    await user.upload(input, file);
 
     await waitFor(() => {
       expect(result.getByText('Ready for import')).toBeInTheDocument();
@@ -62,7 +64,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
 
     const dialog = result.getByRole('dialog');
     const importButton = within(dialog).getByRole('button', { name: 'Import' });
-    await userEvents.click(importButton);
+    await user.click(importButton);
 
     await waitFor(() => expect(onImport).toHaveBeenCalledOnce());
     expect(onImport.mock.calls[0][0]).toMatchObject([{ name: 'server.port' }]);
@@ -70,20 +72,21 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
   });
 
   test('should keep dialog open and show import error when submit fails', async () => {
+    const user = userEvent.setup();
     const onImport = vi.fn().mockRejectedValue(new Error('Import request failed'));
     const result = renderWithMessageProvider(
       <PropertiesImportDialog onImport={onImport}/>,
     );
 
-    await userEvents.click(result.getByRole('button', { name: 'Import' }));
-    const input = await result.findByTestId('configuration-importer-input');
+    await user.click(result.getByRole('button', { name: 'Import' }));
+    const input = await result.findByLabelText('Select existing configuration file');
     const file = new File([PROPERTIES_FILE], 'application.properties', { type: 'text/plain' });
-    await userEvents.upload(input, file);
+    await user.upload(input, file);
 
     await waitFor(() => expect(result.getByText('Ready for import')).toBeInTheDocument());
     const dialog = result.getByRole('dialog');
     const importButton = within(dialog).getByRole('button', { name: 'Import' });
-    await userEvents.click(importButton);
+    await user.click(importButton);
 
     await waitFor(() => expect(result.getByText('Import request failed')).toBeInTheDocument());
     expect(result.getByRole('dialog')).toBeInTheDocument();

--- a/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
+++ b/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
@@ -2,7 +2,7 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { describe, expect, test } from 'vitest';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
 
-const deferred = <T,>() => {
+function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
   const promise = new Promise<T>((res, rej) => {
@@ -10,7 +10,7 @@ const deferred = <T,>() => {
     reject = rej;
   });
   return { promise, resolve, reject };
-};
+}
 
 const mockFile = (name: string, text: string | Promise<string>): File => {
   return {

--- a/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
+++ b/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
@@ -1,0 +1,103 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, test } from 'vitest';
+import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
+
+const deferred = <T,>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+const mockFile = (name: string, text: string | Promise<string>): File => {
+  return {
+    name,
+    text: () => typeof text === 'string' ? Promise.resolve(text) : text,
+  } as File;
+};
+
+describe('hooks | vault | useConfigFileParser', () => {
+  test('should parse escaped property keys and odd-backslash continuations', async () => {
+    const { result } = renderHook(() => useConfigFileParser());
+    const file = mockFile(
+      'application.properties',
+      [
+        'db\\:host=localhost',
+        'my\\\\\\ key=escaped-space',
+        'message=hello\\',
+        'world',
+      ].join('\n'),
+    );
+
+    await act(async () => {
+      await result.current.parseFile(file);
+    });
+
+    expect(result.current.properties).toMatchObject([
+      { name: 'db:host', value: { encoded: 'localhost', decoded: 'localhost' } },
+      { name: 'my\\ key', value: { encoded: 'escaped-space', decoded: 'escaped-space' } },
+      { name: 'message', value: { encoded: 'helloworld', decoded: 'helloworld' } },
+    ]);
+  });
+
+  test('should not fail on scalar JSON/YAML roots', async () => {
+    const { result } = renderHook(() => useConfigFileParser());
+
+    await act(async () => {
+      await result.current.parseFile(mockFile('application.json', 'null'));
+    });
+    expect(result.current.properties).toStrictEqual([]);
+
+    await act(async () => {
+      await result.current.parseFile(mockFile('application.yaml', '42'));
+    });
+    expect(result.current.properties).toStrictEqual([]);
+  });
+
+  test('should throw and clear properties on parse error', async () => {
+    const { result } = renderHook(() => useConfigFileParser());
+
+    await act(async () => {
+      await result.current.parseFile(mockFile('application.properties', 'ok=1'));
+    });
+    expect(result.current.properties).toMatchObject([{ name: 'ok' }]);
+
+    await expect(
+      act(async () => {
+        await result.current.parseFile(mockFile('application.json', '{invalid'));
+      }),
+    ).rejects.toBeDefined();
+
+    expect(result.current.properties).toStrictEqual([]);
+  });
+
+  test('should ignore stale parse results from previous file selection', async () => {
+    const { result } = renderHook(() => useConfigFileParser());
+    const slowText = deferred<string>();
+
+    const slowFile = mockFile('slow.properties', slowText.promise);
+    const fastFile = mockFile('fast.properties', 'current.value=2');
+
+    act(() => {
+      void result.current.parseFile(slowFile);
+      void result.current.parseFile(fastFile);
+    });
+
+    await waitFor(() => {
+      expect(result.current.properties).toMatchObject([{ name: 'current.value' }]);
+    });
+
+    await act(async () => {
+      slowText.resolve('stale.value=1');
+      await slowText.promise;
+    });
+
+    await waitFor(() => {
+      expect(result.current.properties).toMatchObject([{ name: 'current.value' }]);
+      expect(result.current.properties).not.toMatchObject([{ name: 'stale.value' }]);
+    });
+  });
+});

--- a/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
+++ b/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
@@ -20,6 +20,16 @@ const mockFile = (name: string, text: string | Promise<string>): File => {
 };
 
 describe('hooks | vault | useConfigFileParser', () => {
+  test('should expose ready state by default', () => {
+    const { result } = renderHook(() => useConfigFileParser());
+
+    expect(result.current.properties).toStrictEqual([]);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
+  });
+
   test('should parse escaped property keys and odd-backslash continuations', async () => {
     const { result } = renderHook(() => useConfigFileParser());
     const file = mockFile(
@@ -41,6 +51,10 @@ describe('hooks | vault | useConfigFileParser', () => {
       { name: 'my\\ key', value: { encoded: 'escaped-space', decoded: 'escaped-space' } },
       { name: 'message', value: { encoded: 'helloworld', decoded: 'helloworld' } },
     ]);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
   });
 
   test('should not fail on scalar JSON/YAML roots', async () => {
@@ -50,11 +64,17 @@ describe('hooks | vault | useConfigFileParser', () => {
       await result.current.parseFile(mockFile('application.json', 'null'));
     });
     expect(result.current.properties).toStrictEqual([]);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
 
     await act(async () => {
       await result.current.parseFile(mockFile('application.yaml', '42'));
     });
     expect(result.current.properties).toStrictEqual([]);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
   });
 
   test('should serialize scalar arrays as comma-separated values for JSON and YAML', async () => {
@@ -81,6 +101,9 @@ describe('hooks | vault | useConfigFileParser', () => {
       { name: 'items[0].a', value: { encoded: '1', decoded: '1' } },
       { name: 'items[1].a', value: { encoded: '2', decoded: '2' } },
     ]);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
 
     await act(async () => {
       await result.current.parseFile(
@@ -107,9 +130,12 @@ describe('hooks | vault | useConfigFileParser', () => {
       { name: 'items[0].a', value: { encoded: '1', decoded: '1' } },
       { name: 'items[1].a', value: { encoded: '2', decoded: '2' } },
     ]);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
   });
 
-  test('should throw and clear properties on parse error', async () => {
+  test('should expose error state on parse error', async () => {
     const { result } = renderHook(() => useConfigFileParser());
 
     await act(async () => {
@@ -117,13 +143,17 @@ describe('hooks | vault | useConfigFileParser', () => {
     });
     expect(result.current.properties).toMatchObject([{ name: 'ok' }]);
 
-    await expect(
-      act(async () => {
-        await result.current.parseFile(mockFile('application.json', '{invalid'));
-      }),
-    ).rejects.toBeDefined();
+    await act(async () => {
+      await result.current.parseFile(mockFile('application.json', '{invalid'));
+    });
 
     expect(result.current.properties).toStrictEqual([]);
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect(result.current.error?.message).toBeTruthy();
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isReady).toBe(false);
   });
 
   test('should ignore stale parse results from previous file selection', async () => {
@@ -138,9 +168,17 @@ describe('hooks | vault | useConfigFileParser', () => {
       void result.current.parseFile(fastFile);
     });
 
+    expect(result.current.isParsing).toBe(true);
+    expect(result.current.isReady).toBe(false);
+
     await waitFor(() => {
       expect(result.current.properties).toMatchObject([{ name: 'current.value' }]);
     });
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
 
     await act(async () => {
       slowText.resolve('stale.value=1');
@@ -151,5 +189,28 @@ describe('hooks | vault | useConfigFileParser', () => {
       expect(result.current.properties).toMatchObject([{ name: 'current.value' }]);
       expect(result.current.properties).not.toMatchObject([{ name: 'stale.value' }]);
     });
+
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
+  });
+
+  test('should reset data and status', async () => {
+    const { result } = renderHook(() => useConfigFileParser());
+
+    await act(async () => {
+      await result.current.parseFile(mockFile('application.properties', 'ok=1'));
+    });
+
+    act(() => {
+      result.current.reset();
+    });
+
+    expect(result.current.properties).toStrictEqual([]);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
   });
 });

--- a/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
+++ b/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
@@ -57,6 +57,58 @@ describe('hooks | vault | useConfigFileParser', () => {
     expect(result.current.properties).toStrictEqual([]);
   });
 
+  test('should serialize scalar arrays as comma-separated values for JSON and YAML', async () => {
+    const { result } = renderHook(() => useConfigFileParser());
+
+    await act(async () => {
+      await result.current.parseFile(
+        mockFile(
+          'application.json',
+          JSON.stringify({
+            tags: ['a', 'b'],
+            nums: [1, 2],
+            mix: ['x', 2, true],
+            items: [{ a: 1 }, { a: 2 }],
+          }),
+        ),
+      );
+    });
+
+    expect(result.current.properties).toMatchObject([
+      { name: 'tags', value: { encoded: 'a,b', decoded: 'a,b' } },
+      { name: 'nums', value: { encoded: '1,2', decoded: '1,2' } },
+      { name: 'mix', value: { encoded: 'x,2,true', decoded: 'x,2,true' } },
+      { name: 'items[0].a', value: { encoded: '1', decoded: '1' } },
+      { name: 'items[1].a', value: { encoded: '2', decoded: '2' } },
+    ]);
+
+    await act(async () => {
+      await result.current.parseFile(
+        mockFile(
+          'application.yaml',
+          [
+            'tags:',
+            '  - a',
+            '  - b',
+            'nums: [1, 2]',
+            'mix: [x, 2, true]',
+            'items:',
+            '  - a: 1',
+            '  - a: 2',
+          ].join('\n'),
+        ),
+      );
+    });
+
+    expect(result.current.properties).toMatchObject([
+      { name: 'tags', value: { encoded: 'a,b', decoded: 'a,b' } },
+      { name: 'nums', value: { encoded: '1,2', decoded: '1,2' } },
+      { name: 'mix', value: { encoded: 'x,2,true', decoded: 'x,2,true' } },
+      { name: 'items[0].a', value: { encoded: '1', decoded: '1' } },
+      { name: 'items[1].a', value: { encoded: '2', decoded: '2' } },
+    ]);
+  });
+
   test('should throw and clear properties on parse error', async () => {
     const { result } = renderHook(() => useConfigFileParser());
 


### PR DESCRIPTION
- Added an **Import** button to the **Configuration Overview** page.
<img width="1788" height="525" alt="Screenshot 2026-05-13 at 10 25 31" src="https://github.com/user-attachments/assets/5da8340b-1ccb-4848-9e03-11a26b6d6604" />

- Clicking the **Import** button opens the **Import Configuration Properties** dialog
- Users can import configuration properties from:
  - YAML files
  - JSON files
  - .properties files
- Existing configuration entries are automatically updated with values from the imported file if matching properties already exist

<img width="1789" height="599" alt="Screenshot 2026-05-13 at 10 25 50" src="https://github.com/user-attachments/assets/a01c73c2-e03d-4305-82cc-9da8ab78fc49" />


