### PR TITLE
Add JWT audience validation to the OAuth2 resource server

### DIFF
--- a/konfigyr-api/src/main/resources/application.yml
+++ b/konfigyr-api/src/main/resources/application.yml
@@ -32,6 +32,8 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: http://localhost:8081
+          audiences:
+            - konfigyr-api
 
 
   mvc:

--- a/konfigyr-api/src/test/java/com/konfigyr/security/SecurityIntegrationTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/security/SecurityIntegrationTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.assertj.MvcTestResultAssert;
 
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.function.Consumer;
 
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
@@ -30,6 +31,7 @@ public class SecurityIntegrationTest extends AbstractControllerTest {
 	void validateMember() {
 		final String token = generateAccessToken(claims -> claims
 				.issuer(wiremock.baseUrl())
+				.audience(List.of("konfigyr-api"))
 				.subject(TestPrincipals.john().getName())
 				.claim("scp", OAuthScope.NAMESPACES.getAuthority())
 		);
@@ -50,6 +52,7 @@ public class SecurityIntegrationTest extends AbstractControllerTest {
 	void validateApplication() {
 		final String token = generateAccessToken(claims -> claims
 				.issuer(wiremock.baseUrl())
+				.audience(List.of("konfigyr-api"))
 				.subject("kfg-A2c7mvoxEP1rb-_NQLvaZ5KJNTGR-oOp")
 				.claim(StandardClaimNames.NAME, "OAuth application")
 				.claim("scp", OAuthScopes.of(OAuthScope.NAMESPACES, OAuthScope.PROFILES).toString())
@@ -86,6 +89,7 @@ public class SecurityIntegrationTest extends AbstractControllerTest {
 
 		final String token = generateAccessToken(claims -> claims
 				.issuer(wiremock.baseUrl())
+				.audience(List.of("konfigyr-api"))
 				.subject(TestPrincipals.from(account).getName())
 				.claim(StandardClaimNames.EMAIL, account.email())
 				.claim(StandardClaimNames.NAME, account.displayName())
@@ -107,6 +111,7 @@ public class SecurityIntegrationTest extends AbstractControllerTest {
 	void invalidSubject() {
 		final String token = generateAccessToken(claims -> claims
 				.issuer(wiremock.baseUrl())
+				.audience(List.of("konfigyr-api"))
 				.subject("some subject")
 				.claim("scp", OAuthScope.NAMESPACES.getAuthority())
 		);
@@ -139,6 +144,35 @@ public class SecurityIntegrationTest extends AbstractControllerTest {
 				.subject(TestPrincipals.john().getName())
 				.expirationTime(Date.from(timestamp.minusSeconds(600)))
 				.notBeforeTime(Date.from(timestamp.minusSeconds(1200)))
+		);
+
+		assertThatRequest(token)
+				.hasStatus(HttpStatus.UNAUTHORIZED)
+				.matches(SecurityMockMvcResultMatchers.unauthenticated());
+	}
+
+	@Test
+	@DisplayName("should fail to validate the OAuth Access token when audience is missing")
+	void missingAudience() {
+		final String token = generateAccessToken(claims -> claims
+				.issuer(wiremock.baseUrl())
+				.subject(TestPrincipals.john().getName())
+				.claim("scp", OAuthScope.NAMESPACES.getAuthority())
+		);
+
+		assertThatRequest(token)
+				.hasStatus(HttpStatus.UNAUTHORIZED)
+				.matches(SecurityMockMvcResultMatchers.unauthenticated());
+	}
+
+	@Test
+	@DisplayName("should fail to validate the OAuth Access token when audience does not match")
+	void invalidAudience() {
+		final String token = generateAccessToken(claims -> claims
+				.issuer(wiremock.baseUrl())
+				.audience(List.of("wrong-audience"))
+				.subject(TestPrincipals.john().getName())
+				.claim("scp", OAuthScope.NAMESPACES.getAuthority())
 		);
 
 		assertThatRequest(token)

--- a/konfigyr-api/src/test/java/com/konfigyr/test/AbstractControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/test/AbstractControllerTest.java
@@ -36,6 +36,7 @@ import tools.jackson.databind.json.JsonMapper;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.function.Consumer;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -375,7 +376,8 @@ public abstract class AbstractControllerTest extends AbstractIntegrationTest {
 					.jwtID(String.valueOf(instant.toEpochMilli()))
 					.notBeforeTime(Date.from(instant))
 					.issueTime(Date.from(instant))
-					.issuer(wiremock.baseUrl());
+					.issuer(wiremock.baseUrl())
+					.audience(List.of("konfigyr-api"));
 
 			customizer.accept(claims);
 

--- a/konfigyr-api/src/test/resources/application-test.yml
+++ b/konfigyr-api/src/test/resources/application-test.yml
@@ -14,6 +14,8 @@ spring:
       resourceserver:
         jwt:
           issuer-uri: http://localhost:${wiremock.server.port:8888}
+          audiences:
+            - konfigyr-api
 
 konfigyr:
   account:

--- a/konfigyr-data/src/main/java/com/konfigyr/data/converter/JsonConverter.java
+++ b/konfigyr-data/src/main/java/com/konfigyr/data/converter/JsonConverter.java
@@ -6,6 +6,7 @@ import org.jooq.impl.AbstractConverter;
 import org.jspecify.annotations.NonNull;
 import org.springframework.util.Assert;
 import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JavaType;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 
@@ -20,6 +21,7 @@ import tools.jackson.databind.json.JsonMapper;
 public final class JsonConverter<T> extends AbstractConverter<String, T> {
 
 	private final ObjectMapper mapper;
+	private final JavaType javaType;
 
 	/**
 	 * Creates a new {@link JsonConverter} with the default {@link ObjectMapper} that would convert
@@ -33,7 +35,7 @@ public final class JsonConverter<T> extends AbstractConverter<String, T> {
 	public static <T> Converter<String, T> create(Class<T> type) {
 		Assert.notNull(type, "Target converter type must not be null");
 
-		return new JsonConverter<>(JsonMapper.builder().build(), type);
+		return create(JsonMapper.builder().build(), type);
 	}
 
 	/**
@@ -50,12 +52,31 @@ public final class JsonConverter<T> extends AbstractConverter<String, T> {
 		Assert.notNull(mapper, "Object mapper must not be null");
 		Assert.notNull(type, "Target converter type must not be null");
 
+		return new JsonConverter<>(mapper, mapper.constructType(type));
+	}
+
+	/**
+	 * Creates a new {@link JsonConverter} with an already customized {@link JsonMapper} that would
+	 * convert values to or from desired type.
+	 *
+	 * @param mapper object mapper instance to be used, can't be {@literal null}
+	 * @param type target type, can't be {@literal null}
+	 * @param <T> generic converter target type
+	 * @return JSON converter, never {@literal null}
+	 */
+	@NonNull
+	public static <T> Converter<String, T> create(ObjectMapper mapper, JavaType type) {
+		Assert.notNull(mapper, "Object mapper must not be null");
+		Assert.notNull(type, "Target converter type must not be null");
+
 		return new JsonConverter<>(mapper, type);
 	}
 
-	JsonConverter(@NonNull ObjectMapper mapper, @NonNull Class<T> type) {
-		super(String.class, type);
+	@SuppressWarnings("unchecked")
+	JsonConverter(@NonNull ObjectMapper mapper, @NonNull JavaType type) {
+		super(String.class, (Class<T>) type.getRawClass());
 		this.mapper = mapper;
+		this.javaType = type;
 	}
 
 	@Override
@@ -65,7 +86,7 @@ public final class JsonConverter<T> extends AbstractConverter<String, T> {
 		}
 
 		try {
-			return mapper.readValue(value, toType());
+			return mapper.readValue(value, javaType);
 		} catch (JacksonException e) {
 			throw new DataTypeException("Error when converting JSON to " + toType(), e);
 		}

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationConfiguration.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.security.oauth2.server.authorization.settings.Authori
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import tools.jackson.databind.ObjectMapper;
 import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
@@ -97,7 +98,12 @@ public class AuthorizationConfiguration implements InitializingBean {
 
 	@Bean
 	OAuth2TokenCustomizer<JwtEncodingContext> tokenCustomizer() {
-		return new TokenCustomizer();
+		return new TokenCustomizer(
+				properties.getAudiences()
+						.stream()
+						.filter(StringUtils::hasText)
+						.toList()
+		);
 	}
 
 	@NonNull

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationProperties.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationProperties.java
@@ -40,6 +40,15 @@ public class AuthorizationProperties {
 	private String clientName = "Konfigyr OAuth Client";
 
 	/**
+	 * Audience(s) to include in access tokens issued by this authorization server.
+	 * <p>
+	 * Resource servers that accept these tokens must validate that the {@code aud} claim contains at least
+	 * one of these values before granting access.
+	 */
+	@NotEmpty
+	private Set<String> audiences = new HashSet<>();
+
+	/**
 	 * Redirect URI(s) that the built-in Konfigyr OAuth client may use to redirect the user-agent when using
 	 * the {@code authorization_code} grant type.
 	 */

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
@@ -39,10 +39,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
@@ -100,7 +97,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	) {
 		this.context = context;
 		this.publisher = publisher;
-		this.attributeConverter = JsonConverter.create(mapper, Map.class);
+		this.attributeConverter = JsonConverter.create(mapper, mapper.constructType(Map.class));
 		this.hashingConverter = MessageDigestConverter.create("BLAKE2s-256", BouncyCastleProvider.PROVIDER_NAME);
 		this.encryptionConverter = EncryptionConverter.create(operations);
 		this.registeredClientConverter = Converter.fromNullable(String.class, RegisteredClient.class, repository::findByClientId);

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/TokenCustomizer.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/TokenCustomizer.java
@@ -4,6 +4,7 @@ import com.konfigyr.identity.authentication.AccountIdentity;
 import com.konfigyr.identity.authentication.AccountIdentityUser;
 import org.jspecify.annotations.NonNull;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
 import org.springframework.security.oauth2.jwt.JwtClaimsSet;
@@ -12,6 +13,8 @@ import org.springframework.security.oauth2.server.authorization.authentication.O
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
+
+import java.util.Set;
 
 import java.util.Collections;
 import java.util.List;
@@ -32,13 +35,14 @@ final class TokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingContext>
 			context.getClaims().audience(audiences);
 
 			final Authentication authentication = context.getPrincipal();
+			final Set<String> authorizedScopes = context.getAuthorizedScopes();
 
 			if (authentication.getPrincipal() instanceof AccountIdentityUser user) {
-				customizeAccessToken(user.getAccountIdentity(), context.getClaims());
+				customizeAccessToken(user.getAccountIdentity(), authorizedScopes, context.getClaims());
 			}
 
 			if (authentication.getPrincipal() instanceof AccountIdentity identity) {
-				customizeAccessToken(identity, context.getClaims());
+				customizeAccessToken(identity, authorizedScopes, context.getClaims());
 			}
 
 			if (authentication instanceof OAuth2ClientAuthenticationToken client && client.getRegisteredClient() != null) {
@@ -59,9 +63,15 @@ final class TokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingContext>
 		}
 	}
 
-	private void customizeAccessToken(@NonNull AccountIdentity identity, JwtClaimsSet.Builder claims) {
-		claims.claim(StandardClaimNames.EMAIL, identity.getEmail())
-				.claim(StandardClaimNames.NAME, identity.getDisplayName());
+	private void customizeAccessToken(@NonNull AccountIdentity identity, Set<String> authorizedScopes, JwtClaimsSet.Builder claims) {
+		if (authorizedScopes.contains(OidcScopes.OPENID)) {
+			claims.claim(StandardClaimNames.EMAIL, identity.getEmail())
+					.claim(StandardClaimNames.NAME, identity.getDisplayName());
+		}
+
+		if (authorizedScopes.contains(OidcScopes.EMAIL)) {
+			claims.claim(StandardClaimNames.EMAIL, identity.getEmail());
+		}
 	}
 
 	private void customizeAccessToken(@NonNull RegisteredClient registeredClient, JwtClaimsSet.Builder claims) {

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/TokenCustomizer.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/TokenCustomizer.java
@@ -13,13 +13,24 @@ import org.springframework.security.oauth2.server.authorization.client.Registere
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenCustomizer;
 
+import java.util.Collections;
+import java.util.List;
+
 final class TokenCustomizer implements OAuth2TokenCustomizer<JwtEncodingContext> {
 
 	static final OAuth2TokenType ID_TOKEN_TOKEN_TYPE = new OAuth2TokenType(OidcParameterNames.ID_TOKEN);
 
+	private final List<String> audiences;
+
+	TokenCustomizer(List<String> audiences) {
+		this.audiences = Collections.unmodifiableList(audiences);
+	}
+
 	@Override
 	public void customize(@NonNull JwtEncodingContext context) {
 		if (OAuth2TokenType.ACCESS_TOKEN.equals(context.getTokenType())) {
+			context.getClaims().audience(audiences);
+
 			final Authentication authentication = context.getPrincipal();
 
 			if (authentication.getPrincipal() instanceof AccountIdentityUser user) {

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepository.java
@@ -19,7 +19,7 @@ import static com.konfigyr.data.tables.OauthApplications.OAUTH_APPLICATIONS;
 public class RegisteredNamespaceClientRepository extends AbstractRegisteredClientRepository {
 
 	private static final Set<AuthorizationGrantType> SUPPORTED_GRANT_TYPES = Set.of(
-			AuthorizationGrantType.CLIENT_CREDENTIALS, AuthorizationGrantType.REFRESH_TOKEN
+			AuthorizationGrantType.CLIENT_CREDENTIALS
 	);
 
 	private final DSLContext context;

--- a/konfigyr-identity/src/main/resources/application.yml
+++ b/konfigyr-identity/src/main/resources/application.yml
@@ -34,6 +34,8 @@ konfigyr:
   identity:
     authorization:
       client-id: konfigyr
+      audiences:
+        - konfigyr-api
       redirect-uris:
         - "http://127.0.0.1:8080/login/oauth2/code/konfigyr"
         - "https://oauth.pstmn.io/v1/callback"

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/TokenCustomizerTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/TokenCustomizerTest.java
@@ -15,6 +15,9 @@ import org.springframework.security.oauth2.server.authorization.OAuth2TokenType;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2ClientAuthenticationToken;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.token.JwtEncodingContext;
+import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenClaimNames;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -25,7 +28,7 @@ class TokenCustomizerTest {
 
 	final AccountIdentity identity = AccountIdentities.john().build();
 
-	final TokenCustomizer customizer = new TokenCustomizer();
+	final TokenCustomizer customizer = new TokenCustomizer(List.of("konfigyr-api", "konfigyr-identity"));
 
 	@Test
 	@DisplayName("should not customize ID token when account identity is not present in Authentication")
@@ -47,8 +50,9 @@ class TokenCustomizerTest {
 		assertThatNoException().isThrownBy(() -> customizer.customize(context));
 
 		assertThat(context.getClaims().build().getClaims())
-				.hasSize(1)
-				.containsEntry(StandardClaimNames.SUB, "test-subject");
+				.hasSize(2)
+				.containsEntry(StandardClaimNames.SUB, "test-subject")
+				.containsEntry(OAuth2TokenClaimNames.AUD, List.of("konfigyr-api", "konfigyr-identity"));
 	}
 
 	@Test
@@ -60,8 +64,9 @@ class TokenCustomizerTest {
 		assertThatNoException().isThrownBy(() -> customizer.customize(context));
 
 		assertThat(context.getClaims().build().getClaims())
-				.hasSize(1)
-				.containsEntry(StandardClaimNames.SUB, "test-subject");
+				.hasSize(2)
+				.containsEntry(StandardClaimNames.SUB, "test-subject")
+				.containsEntry(OAuth2TokenClaimNames.AUD, List.of("konfigyr-api", "konfigyr-identity"));
 	}
 
 	@Test
@@ -77,9 +82,10 @@ class TokenCustomizerTest {
 		assertThatNoException().isThrownBy(() -> customizer.customize(context));
 
 		assertThat(context.getClaims().build().getClaims())
-				.hasSize(2)
+				.hasSize(3)
 				.containsEntry(StandardClaimNames.SUB, "test-subject")
-				.containsEntry(StandardClaimNames.NAME, "Test client name");
+				.containsEntry(StandardClaimNames.NAME, "Test client name")
+				.containsEntry(OAuth2TokenClaimNames.AUD, List.of("konfigyr-api", "konfigyr-identity"));
 	}
 
 	@Test
@@ -90,10 +96,11 @@ class TokenCustomizerTest {
 		assertThatNoException().isThrownBy(() -> customizer.customize(context));
 
 		assertThat(context.getClaims().build().getClaims())
-				.hasSize(3)
+				.hasSize(4)
 				.containsEntry(StandardClaimNames.SUB, "test-subject")
 				.containsEntry(StandardClaimNames.NAME, identity.getDisplayName())
-				.containsEntry(StandardClaimNames.EMAIL, identity.getEmail());
+				.containsEntry(StandardClaimNames.EMAIL, identity.getEmail())
+				.containsEntry(OAuth2TokenClaimNames.AUD, List.of("konfigyr-api", "konfigyr-identity"));
 	}
 
 	@Test
@@ -105,10 +112,11 @@ class TokenCustomizerTest {
 		assertThatNoException().isThrownBy(() -> customizer.customize(context));
 
 		assertThat(context.getClaims().build().getClaims())
-				.hasSize(3)
+				.hasSize(4)
 				.containsEntry(StandardClaimNames.SUB, "test-subject")
 				.containsEntry(StandardClaimNames.EMAIL, identity.getEmail())
-				.containsEntry(StandardClaimNames.NAME, identity.getDisplayName());
+				.containsEntry(StandardClaimNames.NAME, identity.getDisplayName())
+				.containsEntry(OAuth2TokenClaimNames.AUD, List.of("konfigyr-api", "konfigyr-identity"));
 	}
 
 	@Test

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/TokenCustomizerTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/TokenCustomizerTest.java
@@ -6,6 +6,7 @@ import com.konfigyr.identity.authentication.OAuthAccountIdentityUser;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.OidcScopes;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm;
@@ -18,6 +19,7 @@ import org.springframework.security.oauth2.server.authorization.token.JwtEncodin
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenClaimNames;
 
 import java.util.List;
+import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -89,9 +91,24 @@ class TokenCustomizerTest {
 	}
 
 	@Test
+	@DisplayName("should not include personal information in OAuth Access token when no scopes are authorized")
+	void customizeAccessTokenForIdentityWithoutScopes() {
+		final var context = createContextFor(OAuth2TokenType.ACCESS_TOKEN, identity);
+
+		assertThatNoException().isThrownBy(() -> customizer.customize(context));
+
+		assertThat(context.getClaims().build().getClaims())
+				.hasSize(2)
+				.containsEntry(StandardClaimNames.SUB, "test-subject")
+				.containsEntry(OAuth2TokenClaimNames.AUD, List.of("konfigyr-api", "konfigyr-identity"))
+				.doesNotContainKey(StandardClaimNames.NAME)
+				.doesNotContainKey(StandardClaimNames.EMAIL);
+	}
+
+	@Test
 	@DisplayName("should customize OAuth Access token when account identity is present in Authentication")
 	void customizeAccessTokenForIdentity() {
-		final var context = createContextFor(OAuth2TokenType.ACCESS_TOKEN, identity);
+		final var context = createContextFor(OAuth2TokenType.ACCESS_TOKEN, identity, OidcScopes.OPENID);
 
 		assertThatNoException().isThrownBy(() -> customizer.customize(context));
 
@@ -104,10 +121,25 @@ class TokenCustomizerTest {
 	}
 
 	@Test
+	@DisplayName("should only include email in OAuth Access token when only email scope is authorized")
+	void customizeAccessTokenForIdentityWithEmailScope() {
+		final var context = createContextFor(OAuth2TokenType.ACCESS_TOKEN, identity, OidcScopes.EMAIL);
+
+		assertThatNoException().isThrownBy(() -> customizer.customize(context));
+
+		assertThat(context.getClaims().build().getClaims())
+				.hasSize(3)
+				.containsEntry(StandardClaimNames.SUB, "test-subject")
+				.containsEntry(StandardClaimNames.EMAIL, identity.getEmail())
+				.containsEntry(OAuth2TokenClaimNames.AUD, List.of("konfigyr-api", "konfigyr-identity"))
+				.doesNotContainKey(StandardClaimNames.NAME);
+	}
+
+	@Test
 	@DisplayName("should customize OAuth Access token when account identity user is present in Authentication")
 	void customizeAccessTokenForUser() {
 		final var user = new OAuthAccountIdentityUser(identity, mock(OAuth2User.class));
-		final var context = createContextFor(OAuth2TokenType.ACCESS_TOKEN, user);
+		final var context = createContextFor(OAuth2TokenType.ACCESS_TOKEN, user, OidcScopes.OPENID);
 
 		assertThatNoException().isThrownBy(() -> customizer.customize(context));
 
@@ -152,19 +184,20 @@ class TokenCustomizerTest {
 				.containsEntry(StandardClaimNames.PICTURE, identity.getAvatar().get());
 	}
 
-	static JwtEncodingContext createContextFor(OAuth2TokenType type, Object principal) {
+	static JwtEncodingContext createContextFor(OAuth2TokenType type, Object principal, String... scopes) {
 		final var authentication = mock(Authentication.class);
 		doReturn(principal).when(authentication).getPrincipal();
 
-		return createContextFor(type, authentication);
+		return createContextFor(type, authentication, scopes);
 	}
 
-	static JwtEncodingContext createContextFor(OAuth2TokenType type, Authentication authentication) {
+	static JwtEncodingContext createContextFor(OAuth2TokenType type, Authentication authentication, String... scopes) {
 		final var claims = JwtClaimsSet.builder().subject("test-subject");
 
 		return JwtEncodingContext.with(JwsHeader.with(SignatureAlgorithm.RS256), claims)
 				.principal(authentication)
 				.tokenType(type)
+				.authorizedScopes(Set.of(scopes))
 				.build();
 	}
 

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepositoryTest.java
@@ -76,10 +76,7 @@ class RegisteredNamespaceClientRepositoryTest extends AbstractClientRepositoryTe
 						"namespaces:invite",
 						"namespaces"
 				))
-				.satisfies(assertAuthorizationGrantTypes(
-						AuthorizationGrantType.CLIENT_CREDENTIALS,
-						AuthorizationGrantType.REFRESH_TOKEN
-				))
+				.satisfies(assertAuthorizationGrantTypes(AuthorizationGrantType.CLIENT_CREDENTIALS))
 				.satisfies(assertClientAuthenticationMethods())
 				.satisfies(assertTokenSettings())
 				.satisfies(assertClientSettings())
@@ -102,10 +99,7 @@ class RegisteredNamespaceClientRepositoryTest extends AbstractClientRepositoryTe
 						"namespaces:invite",
 						"namespaces"
 				))
-				.satisfies(assertAuthorizationGrantTypes(
-						AuthorizationGrantType.CLIENT_CREDENTIALS,
-						AuthorizationGrantType.REFRESH_TOKEN
-				))
+				.satisfies(assertAuthorizationGrantTypes(AuthorizationGrantType.CLIENT_CREDENTIALS))
 				.satisfies(assertClientAuthenticationMethods())
 				.satisfies(assertTokenSettings())
 				.satisfies(assertClientSettings())


### PR DESCRIPTION
- Introduce JWT `aud` claim validation
- Remove the `refresh_token` grant type from namespace apps, a new token should be issued
- email and name scopes should be gated behind `openid` or `email` scopes