### PR TITLE
Cache registered namespace client lookups in SAS

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/NamespaceController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/NamespaceController.java
@@ -156,7 +156,6 @@ class NamespaceController {
 			);
 
 			return NamespaceDefinition.builder()
-					.owner(1L)
 					.slug(slug)
 					.name(name)
 					.description(description)

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationConfiguration.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationConfiguration.java
@@ -6,9 +6,13 @@ import com.konfigyr.crypto.jose.JoseAutoConfiguration;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.identity.KonfigyrIdentityKeysets;
 import com.konfigyr.identity.authentication.AccountIdentity;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.konfigyr.identity.authorization.client.CachingRegisteredClientRepository;
 import com.konfigyr.identity.authorization.client.DelegatingRegisteredClientRepository;
 import com.konfigyr.identity.authorization.client.KonfigyrRegisteredClientRepository;
 import com.konfigyr.identity.authorization.client.RegisteredNamespaceClientRepository;
+import org.springframework.boot.cache.metrics.CacheMetricsRegistrar;
+import org.springframework.cache.caffeine.CaffeineCache;
 import com.konfigyr.identity.authorization.jwk.KeysetSource;
 import com.konfigyr.identity.authorization.jwk.SigningJwkSelector;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -64,10 +68,19 @@ public class AuthorizationConfiguration implements InitializingBean {
 	}
 
 	@Bean
-	RegisteredClientRepository registeredClientRepository(DSLContext context) {
+	RegisteredClientRepository registeredClientRepository(DSLContext context, CacheMetricsRegistrar registrar) {
+		Assert.notNull(properties.getCache().getSpec(), "Cache specification must not be null");
+
+		final CaffeineCache cache = new CaffeineCache(
+				"identity.registered-clients",
+				Caffeine.from(properties.getCache().getSpec()).recordStats().build()
+		);
+
+		registrar.bindCacheToRegistry(cache);
+
 		return new DelegatingRegisteredClientRepository(List.of(
 				new KonfigyrRegisteredClientRepository(properties),
-				new RegisteredNamespaceClientRepository(properties, context)
+				new CachingRegisteredClientRepository(cache, new RegisteredNamespaceClientRepository(properties, context))
 		));
 	}
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationProperties.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationProperties.java
@@ -3,6 +3,7 @@ package com.konfigyr.identity.authorization;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.boot.cache.autoconfigure.CacheProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.boot.security.oauth2.server.authorization.autoconfigure.servlet.OAuth2AuthorizationServerProperties;
@@ -67,5 +68,14 @@ public class AuthorizationProperties {
 	 */
 	@NestedConfigurationProperty
 	OAuth2AuthorizationServerProperties.Token token = new OAuth2AuthorizationServerProperties.Token();
+
+	/**
+	 * Customize how the Authorization Server caches registered OAuth clients.
+	 * <p>
+	 * It is recommended that entries should be kept in the cache for no longer than 5 minutes,
+	 * and therefore we recommend using the following specification: {@code expireAfterWrite=5m}.
+	 */
+	@NestedConfigurationProperty
+	CacheProperties.Caffeine cache = new CacheProperties.Caffeine();
 
 }

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
@@ -100,7 +100,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 		this.attributeConverter = JsonConverter.create(mapper, mapper.constructType(Map.class));
 		this.hashingConverter = MessageDigestConverter.create("BLAKE2s-256", BouncyCastleProvider.PROVIDER_NAME);
 		this.encryptionConverter = EncryptionConverter.create(operations);
-		this.registeredClientConverter = Converter.fromNullable(String.class, RegisteredClient.class, repository::findByClientId);
+		this.registeredClientConverter = Converter.fromNullable(String.class, RegisteredClient.class, repository::findById);
 	}
 
 	@Override

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/CachingRegisteredClientRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/CachingRegisteredClientRepository.java
@@ -1,0 +1,72 @@
+package com.konfigyr.identity.authorization.client;
+
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.cache.Cache;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import java.util.function.Function;
+
+/**
+ * A {@link RegisteredClientRepository} that caches lookups by both registration ID and client ID
+ * in a single Spring {@link Cache}, using prefixed string keys to avoid collisions between the
+ * two lookup strategies.
+ * <p>
+ * On any cache miss, the result is stored under both the {@code "id:<registrationId>"} and
+ * {@code "client-id:<clientId>"} keys so that later lookups by either key are served from
+ * cache without an additional delegate call.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@NullMarked
+@RequiredArgsConstructor
+public class CachingRegisteredClientRepository implements RegisteredClientRepository {
+
+	private static final String ID_PREFIX = "id:";
+	private static final String CLIENT_ID_PREFIX = "client-id:";
+
+	private final Cache cache;
+	private final RegisteredClientRepository delegate;
+
+	@Override
+	public void save(RegisteredClient registeredClient) {
+		delegate.save(registeredClient);
+	}
+
+	@Override
+	@Nullable
+	public RegisteredClient findById(String id) {
+		return lookup(ID_PREFIX, id, delegate::findById);
+	}
+
+	@Override
+	@Nullable
+	public RegisteredClient findByClientId(String clientId) {
+		return lookup(CLIENT_ID_PREFIX, clientId, delegate::findByClientId);
+	}
+
+	@Nullable
+	private RegisteredClient lookup(String prefix, String id, Function<String, @Nullable RegisteredClient> supplier) {
+		final String cacheKey = prefix + id;
+		final Cache.ValueWrapper cached = cache.get(cacheKey);
+
+		if (cached != null) {
+			return (RegisteredClient) cached.get();
+		}
+
+		final RegisteredClient client = supplier.apply(id);
+
+		if (client != null) {
+			cache.put(ID_PREFIX + client.getId(), client);
+			cache.put(CLIENT_ID_PREFIX + client.getClientId(), client);
+		} else {
+			cache.put(cacheKey, null);
+		}
+
+		return client;
+	}
+
+}

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepository.java
@@ -1,8 +1,10 @@
 package com.konfigyr.identity.authorization.client;
 
+import com.konfigyr.entity.EntityId;
 import com.konfigyr.identity.authorization.AuthorizationProperties;
 import com.konfigyr.security.OAuthScopes;
 import org.apache.commons.lang3.StringUtils;
+import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Record;
 import org.jspecify.annotations.NonNull;
@@ -30,13 +32,28 @@ public class RegisteredNamespaceClientRepository extends AbstractRegisteredClien
 	}
 
 	@Override
-	public RegisteredClient findById(String id) {
-		return lookup(id);
+	public RegisteredClient findById(String registrationId) {
+		if (StringUtils.isBlank(registrationId)) {
+			return null;
+		}
+
+		final EntityId id;
+
+		try {
+			id = EntityId.from(registrationId);
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+
+		return lookup(OAUTH_APPLICATIONS.ID.eq(id.get()));
 	}
 
 	@Override
 	public RegisteredClient findByClientId(String clientId) {
-		return lookup(clientId);
+		if (StringUtils.isBlank(clientId) || !clientId.startsWith("kfg-")) {
+			return null;
+		}
+		return lookup(OAUTH_APPLICATIONS.CLIENT_ID.eq(clientId));
 	}
 
 	@NonNull
@@ -45,12 +62,9 @@ public class RegisteredNamespaceClientRepository extends AbstractRegisteredClien
 		return SUPPORTED_GRANT_TYPES;
 	}
 
-	private RegisteredClient lookup(String id) {
-		if (StringUtils.isBlank(id) || !id.startsWith("kfg-")) {
-			return null;
-		}
-
+	private RegisteredClient lookup(Condition condition) {
 		return context.select(
+						OAUTH_APPLICATIONS.ID,
 						OAUTH_APPLICATIONS.NAME,
 						OAUTH_APPLICATIONS.CLIENT_ID,
 						OAUTH_APPLICATIONS.CLIENT_SECRET,
@@ -59,7 +73,7 @@ public class RegisteredNamespaceClientRepository extends AbstractRegisteredClien
 						OAUTH_APPLICATIONS.CREATED_AT
 				)
 				.from(OAUTH_APPLICATIONS)
-				.where(OAUTH_APPLICATIONS.CLIENT_ID.eq(id))
+				.where(condition)
 				.fetchOne(this::toRegisteredClient);
 	}
 
@@ -67,7 +81,7 @@ public class RegisteredNamespaceClientRepository extends AbstractRegisteredClien
 		final Collection<? extends GrantedAuthority> authorities = OAuthScopes.parse(record.get(OAUTH_APPLICATIONS.SCOPES))
 				.toAuthorities();
 
-		return createRegisteredClient(record.get(OAUTH_APPLICATIONS.CLIENT_ID))
+		return createRegisteredClient(record.get(OAUTH_APPLICATIONS.ID, EntityId.class).serialize())
 				.clientName(record.get(OAUTH_APPLICATIONS.NAME))
 				.clientId(record.get(OAUTH_APPLICATIONS.CLIENT_ID))
 				.clientIdIssuedAt(record.get(OAUTH_APPLICATIONS.CREATED_AT, Instant.class))

--- a/konfigyr-identity/src/main/resources/application.yml
+++ b/konfigyr-identity/src/main/resources/application.yml
@@ -41,6 +41,8 @@ konfigyr:
         - "https://oauth.pstmn.io/v1/callback"
       post-logout-redirect-uris:
         - "http://127.0.0.1:8080/"
+      cache:
+        spec: expireAfterWrite=5m,maximumSize=100
       token:
         access-token-time-to-live: 15m
         refresh-token-time-to-live: 7d

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/AbstractClientRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/AbstractClientRepositoryTest.java
@@ -20,10 +20,6 @@ import static org.assertj.core.api.Assertions.within;
 
 abstract class AbstractClientRepositoryTest {
 
-	static Consumer<RegisteredClient> assertClientId(String id, Duration issuedBefore) {
-		return assertClientId(id, id, issuedBefore);
-	}
-
 	static Consumer<RegisteredClient> assertClientId(String id, String clientId, Duration issuedBefore) {
 		return client -> {
 			assertThat(client.getId())

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/CachingRegisteredClientRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/CachingRegisteredClientRepositoryTest.java
@@ -1,0 +1,131 @@
+package com.konfigyr.identity.authorization.client;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.cache.concurrent.ConcurrentMapCache;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
+import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class CachingRegisteredClientRepositoryTest {
+
+	@Mock
+	RegisteredClientRepository delegate;
+
+	@Mock
+	RegisteredClient client;
+
+	ConcurrentMapCache cache;
+
+	CachingRegisteredClientRepository repository;
+
+	@BeforeEach
+	void setup() {
+		cache = new ConcurrentMapCache("test-client-cache", true);
+		repository = new CachingRegisteredClientRepository(cache, delegate);
+	}
+
+	@Test
+	@DisplayName("should delegate save to the underlying repository")
+	void shouldDelegateSave() {
+		assertThatNoException().isThrownBy(() -> repository.save(client));
+
+		verify(delegate).save(client);
+
+		assertThat(cache.getNativeCache())
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should return null and cache it when delegate returns no client for findById")
+	void shouldReturnNullForUnknownRegistrationId() {
+		assertThat(repository.findById("unknown")).isNull();
+		assertThat(repository.findById("unknown")).isNull();
+
+		verify(delegate).findById("unknown");
+
+		assertThat(cache.get("id:unknown"))
+				.isNotNull();
+	}
+
+	@Test
+	@DisplayName("should return null and cache it when delegate returns no client for findByClientId")
+	void shouldReturnNullForUnknownClientId() {
+		assertThat(repository.findByClientId("unknown")).isNull();
+		assertThat(repository.findByClientId("unknown")).isNull();
+
+		verify(delegate).findByClientId("unknown");
+
+		assertThat(cache.get("client-id:unknown"))
+				.isNotNull();
+	}
+
+	@Test
+	@DisplayName("should cache registered client on findById and not call delegate on subsequent lookups")
+	void shouldCacheFindById() {
+		doReturn("test-registration-id").when(client).getId();
+		doReturn("kfg-test-client-id").when(client).getClientId();
+		doReturn(client).when(delegate).findById("test-registration-id");
+
+		assertThat(repository.findById("test-registration-id"))
+				.isSameAs(client);
+
+		assertThat(repository.findById("test-registration-id"))
+				.isSameAs(client);
+
+		verify(delegate).findById("test-registration-id");
+	}
+
+	@Test
+	@DisplayName("should cache registered client on findByClientId and not call delegate on subsequent lookups")
+	void shouldCacheFindByClientId() {
+		doReturn("test-registration-id").when(client).getId();
+		doReturn("kfg-test-client-id").when(client).getClientId();
+		doReturn(client).when(delegate).findByClientId("kfg-test-client-id");
+
+		assertThat(repository.findByClientId("kfg-test-client-id"))
+				.isSameAs(client);
+
+		assertThat(repository.findByClientId("kfg-test-client-id"))
+				.isSameAs(client);
+
+		verify(delegate).findByClientId("kfg-test-client-id");
+	}
+
+	@Test
+	@DisplayName("should warm client ID cache key after a findById hit")
+	void shouldWarmClientIdCacheAfterFindById() {
+		doReturn("test-registration-id").when(client).getId();
+		doReturn("kfg-test-client-id").when(client).getClientId();
+		doReturn(client).when(delegate).findById("test-registration-id");
+
+		assertThat(repository.findById("test-registration-id")).isSameAs(client);
+		assertThat(repository.findByClientId("kfg-test-client-id")).isSameAs(client);
+
+		verify(delegate).findById("test-registration-id");
+		verify(delegate, never()).findByClientId(anyString());
+	}
+
+	@Test
+	@DisplayName("should warm registration ID cache key after a findByClientId hit")
+	void shouldWarmRegistrationIdCacheAfterFindByClientId() {
+		doReturn("test-registration-id").when(client).getId();
+		doReturn("kfg-test-client-id").when(client).getClientId();
+		doReturn(client).when(delegate).findByClientId("kfg-test-client-id");
+
+		assertThat(repository.findByClientId("kfg-test-client-id")).isSameAs(client);
+		assertThat(repository.findById("test-registration-id")).isSameAs(client);
+
+		verify(delegate).findByClientId("kfg-test-client-id");
+		verify(delegate, never()).findById(anyString());
+	}
+
+}

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.konfigyr.identity.authorization.client;
 
+import com.konfigyr.entity.EntityId;
 import com.konfigyr.identity.authorization.AuthorizationProperties;
 import com.konfigyr.test.TestContainers;
 import com.konfigyr.test.TestProfile;
@@ -66,7 +67,7 @@ class RegisteredNamespaceClientRepositoryTest extends AbstractClientRepositoryTe
 		assertThat(repository.findByClientId("kfg-A2c7mvoxEP1rb-_NQLvaZ5KJNTGR-oOp"))
 				.isNotNull()
 				.returns("Konfigyr active app", RegisteredClient::getClientName)
-				.satisfies(assertClientId("kfg-A2c7mvoxEP1rb-_NQLvaZ5KJNTGR-oOp", Duration.ofDays(7)))
+				.satisfies(assertClientId(EntityId.from(2).serialize(), "kfg-A2c7mvoxEP1rb-_NQLvaZ5KJNTGR-oOp", Duration.ofDays(7)))
 				.satisfies(assertClientSecret("4b6dHEXXnAEMM1AD4b6RhqamjFwMdhIRgpyBVJRu-Zk", Duration.ofDays(3)))
 				.satisfies(assertScopes(
 						"namespaces:read",
@@ -87,9 +88,11 @@ class RegisteredNamespaceClientRepositoryTest extends AbstractClientRepositoryTe
 	@Test
 	@DisplayName("should retrieve client by client registration identifier")
 	void retrieveByRegistrationId() {
-		assertThat(repository.findById("kfg-A2c7mvoxEP1AW1BUqzQXbS3NAivjfAqD"))
+		final var id = EntityId.from(1).serialize();
+
+		assertThat(repository.findById(id))
 				.returns("Konfigyr expired app", RegisteredClient::getClientName)
-				.satisfies(assertClientId("kfg-A2c7mvoxEP1AW1BUqzQXbS3NAivjfAqD", Duration.ofDays(30)))
+				.satisfies(assertClientId(id, "kfg-A2c7mvoxEP1AW1BUqzQXbS3NAivjfAqD", Duration.ofDays(30)))
 				.satisfies(assertClientSecret("10S6cd0JgdO6WCLmOLB46d-Enx7K20hKSF1qicfev5g", Duration.ofDays(3).negated()))
 				.satisfies(assertScopes(
 						"namespaces:read",


### PR DESCRIPTION
`RegisteredNamespaceClientRepository#findById` was querying `CLIENT_ID` instead of `ID`, meaning the Spring Authorization Server could never resolve a client by its registration ID.
Additionally, SAS calls `findById` and `findByClientId` on every token issuance with no caching, causing repeated DB round-trips for the same client.