### PR TITLE
Improvements after code analysis

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/account/controller/AccountController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/account/controller/AccountController.java
@@ -21,8 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.Map;
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/account")
@@ -46,10 +44,10 @@ class AccountController {
 
 	@PostMapping("/email")
 	@Transactional(readOnly = true)
-	Object issue(@RequestBody @Validated MailHolder holder, @NonNull Authentication authentication) {
+	MailVerificationResponse issue(@RequestBody @Validated MailHolder holder, @NonNull Authentication authentication) {
 		final Account account = retrieveAccountForAuthentication(authentication);
 		final String token = emailVerifier.issue(account, holder.email());
-		return Map.of("token", token, "email", holder.email());
+		return new MailVerificationResponse(token, holder.email());
 	}
 
 	@PutMapping("/email")
@@ -99,6 +97,10 @@ class AccountController {
 	}
 
 	record MailVerification(@NotEmpty String token, @NotEmpty String code) {
+
+	}
+
+	record MailVerificationResponse(String token, String email) {
 
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/security/WebSecurityConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/WebSecurityConfiguration.java
@@ -28,6 +28,8 @@ import org.springframework.security.web.context.DelegatingSecurityContextReposit
 import org.springframework.security.web.context.RequestAttributeSecurityContextRepository;
 import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.util.matcher.AnyRequestMatcher;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
 import tools.jackson.databind.ObjectMapper;
 
 import java.util.concurrent.TimeUnit;
@@ -70,7 +72,7 @@ public class WebSecurityConfiguration {
 				.authorizeHttpRequests(requests -> requests
 						.anyRequest().hasAuthority(OAuthScope.READ_PROFILES.getAuthority())
 				)
-				.cors(Customizer.withDefaults())
+				.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 				.csrf(csrf -> csrf.ignoringRequestMatchers("/configs/**"))
 				.logout(AbstractHttpConfigurer::disable)
 				.httpBasic(Customizer.withDefaults())
@@ -95,7 +97,7 @@ public class WebSecurityConfiguration {
 						.anyRequest()
 						.authenticated()
 				)
-				.cors(Customizer.withDefaults())
+				.cors(cors -> cors.configurationSource(corsConfigurationSource()))
 				.csrf(AbstractHttpConfigurer::disable)
 				.logout(AbstractHttpConfigurer::disable)
 				.httpBasic(AbstractHttpConfigurer::disable)
@@ -138,6 +140,20 @@ public class WebSecurityConfiguration {
 		return new DelegatingSecurityContextRepository(
 				new RequestAttributeSecurityContextRepository()
 		);
+	}
+
+	/**
+	 * Creates a {@link CorsConfigurationSource} that rejects all cross-origin requests by returning
+	 * an empty {@link CorsConfiguration} with no allowed origins, methods, or headers.
+	 * <p>
+	 * The Konfigyr REST API is intended for server-to-server communication only and must not be
+	 * invoked directly from a browser. Any request carrying an {@code Origin} header will be
+	 * denied by Spring Security's CORS filter with a {@code 403 Forbidden} response.
+	 *
+	 * @return CORS configuration source that blocks all cross-origin requests, never {@literal null}
+	 */
+	private static CorsConfigurationSource corsConfigurationSource() {
+		return ignore -> new CorsConfiguration();
 	}
 
 }

--- a/konfigyr-data/src/main/java/com/konfigyr/data/converter/JsonConverter.java
+++ b/konfigyr-data/src/main/java/com/konfigyr/data/converter/JsonConverter.java
@@ -52,7 +52,7 @@ public final class JsonConverter<T> extends AbstractConverter<String, T> {
 		Assert.notNull(mapper, "Object mapper must not be null");
 		Assert.notNull(type, "Target converter type must not be null");
 
-		return new JsonConverter<>(mapper, mapper.constructType(type));
+		return create(mapper, mapper.constructType(type));
 	}
 
 	/**

--- a/konfigyr-data/src/main/resources/migrations/oauth-authorizations/oauth-authorizations-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/oauth-authorizations/oauth-authorizations-1.0.0.xml
@@ -27,28 +27,28 @@
 				<constraints nullable="false"/>
 			</column>
 			<column name="authorized_scopes" type="varchar(1000)"/>
-			<column name="attributes" type="text"/>
-			<column name="state" type="varchar(500)"/>
+			<column name="attributes" type="bytea"/>
+			<column name="state_hash" type="bytea"/>
 			<column name="authorization_code_value" type="text"/>
 			<column name="authorization_code_issued_at" type="timestamptz"/>
 			<column name="authorization_code_expires_at" type="timestamptz"/>
-			<column name="authorization_code_metadata" type="text"/>
+			<column name="authorization_code_metadata" type="bytea"/>
 			<column name="access_token_value" type="bytea"/>
 			<column name="access_token_hash" type="bytea"/>
 			<column name="access_token_issued_at" type="timestamptz"/>
 			<column name="access_token_expires_at" type="timestamptz"/>
-			<column name="access_token_metadata" type="text"/>
+			<column name="access_token_metadata" type="bytea"/>
 			<column name="access_token_scopes" type="varchar(1000)"/>
 			<column name="oidc_id_token_value" type="bytea"/>
 			<column name="oidc_id_token_hash" type="bytea"/>
 			<column name="oidc_id_token_issued_at" type="timestamptz"/>
 			<column name="oidc_id_token_expires_at" type="timestamptz"/>
-			<column name="oidc_id_token_metadata" type="text"/>
+			<column name="oidc_id_token_metadata" type="bytea"/>
 			<column name="refresh_token_value" type="bytea"/>
 			<column name="refresh_token_hash" type="bytea"/>
 			<column name="refresh_token_issued_at" type="timestamptz"/>
 			<column name="refresh_token_expires_at" type="timestamptz"/>
-			<column name="refresh_token_metadata" type="text"/>
+			<column name="refresh_token_metadata" type="bytea"/>
 		</createTable>
     </changeSet>
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/rememberme/AccountRememberMeServices.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/rememberme/AccountRememberMeServices.java
@@ -158,7 +158,7 @@ public class AccountRememberMeServices implements RememberMeServices, LogoutHand
 		protected void onLoginSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
 			final String username = retrieveUserName(authentication);
 
-			// If we are unable to find a username do not generate any remember-me cookie
+			// If we are unable to find a username, do not generate any remember-me cookie
 			if (!StringUtils.hasLength(username)) {
 				logger.debug(LogMessage.format(
 						"Can not add remember-me cookie due to a missing username in: %s",
@@ -214,7 +214,7 @@ public class AccountRememberMeServices implements RememberMeServices, LogoutHand
 				return getUserDetailsService().loadUserByUsername(tokens[0]);
 			}
 
-			throw new InvalidCookieException("Cookie contained signature '" + tokens[2] + "' but expected '" + signature + "'");
+			throw new InvalidCookieException("Cookie contained signature '" + tokens[4] + "' but expected '" + signature + "'");
 		}
 
 		@Override

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationConfiguration.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationConfiguration.java
@@ -56,7 +56,9 @@ public class AuthorizationConfiguration implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() {
-		Security.addProvider(new BouncyCastleProvider());
+		if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+			Security.addProvider(new BouncyCastleProvider());
+		}
 	}
 
 	@Bean

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
@@ -28,6 +28,7 @@ import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames
 import org.springframework.security.oauth2.server.authorization.*;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClientRepository;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
 import org.springframework.util.Assert;
@@ -341,9 +342,9 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	}
 
 	@Async
-	@Transactional(label = "authorization-service.authorization-consent-revoked")
 	@DomainEventHandler(name = "authorization-consent-revoked", namespace = "authorization")
 	@TransactionalEventListener(classes = AuthorizationConsentEvent.Revoked.class)
+	@Transactional(propagation = Propagation.REQUIRES_NEW, label = "authorization-service.authorization-consent-revoked")
 	void onConsentRevoked(AuthorizationConsentEvent.Revoked event) {
 		final OAuth2AuthorizationConsent consent = event.consent();
 		remove(consent.getPrincipalName(), consent.getRegisteredClientId());

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
@@ -3,7 +3,7 @@ package com.konfigyr.identity.authorization;
 import com.konfigyr.crypto.KeysetOperations;
 import com.konfigyr.data.SettableRecord;
 import com.konfigyr.data.converter.EncryptionConverter;
-import com.konfigyr.data.converter.JsonConverter;
+import com.konfigyr.data.converter.JsonByteArrayConverter;
 import com.konfigyr.data.converter.MessageDigestConverter;
 import com.konfigyr.io.ByteArray;
 import io.micrometer.observation.annotation.Observed;
@@ -40,10 +40,7 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.*;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
+import java.util.function.*;
 
 import static com.konfigyr.data.tables.OauthAuthorizations.OAUTH_AUTHORIZATIONS;
 import static com.konfigyr.data.tables.OauthAuthorizationsConsents.OAUTH_AUTHORIZATIONS_CONSENTS;
@@ -69,7 +66,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 
 	/* jOOQ Converters */
 	private final EncryptionConverter encryptionConverter;
-	private final Converter<String, Map> attributeConverter;
+	private final Converter<ByteArray, Map> attributeConverter;
 	private final Converter<ByteArray, ByteArray> hashingConverter;
 	private final Converter<String, RegisteredClient> registeredClientConverter;
 	private final Converter<OffsetDateTime, Instant> instantConverter = Converter.of(
@@ -97,7 +94,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	) {
 		this.context = context;
 		this.publisher = publisher;
-		this.attributeConverter = JsonConverter.create(mapper, mapper.constructType(Map.class));
+		this.attributeConverter = JsonByteArrayConverter.create(mapper, mapper.constructType(Map.class));
 		this.hashingConverter = MessageDigestConverter.create("BLAKE2s-256", BouncyCastleProvider.PROVIDER_NAME);
 		this.encryptionConverter = EncryptionConverter.create(operations);
 		this.registeredClientConverter = Converter.fromNullable(String.class, RegisteredClient.class, repository::findById);
@@ -122,8 +119,8 @@ public class DefaultAuthorizationService implements AuthorizationService {
 				.set(OAUTH_AUTHORIZATIONS.PRINCIPAL_NAME, authorization.getPrincipalName())
 				.set(OAUTH_AUTHORIZATIONS.AUTHORIZATION_GRANT_TYPE, authorization.getAuthorizationGrantType(), grantTypeConverter)
 				.set(OAUTH_AUTHORIZATIONS.AUTHORIZED_SCOPES, authorization.getAuthorizedScopes(), scopesConverter)
-				.set(OAUTH_AUTHORIZATIONS.ATTRIBUTES, authorization.getAttributes(), attributeConverter)
-				.set(OAUTH_AUTHORIZATIONS.STATE, (String) authorization.getAttribute(OAuth2ParameterNames.STATE))
+				.with(applyState(authorization))
+				.with(applyAttributes(authorization))
 				.with(applyAuthorizationCode(authorization))
 				.with(applyAccessToken(authorization))
 				.with(applyRefreshToken(authorization))
@@ -205,14 +202,14 @@ public class DefaultAuthorizationService implements AuthorizationService {
 			final ByteArray hash = hashingConverter.to(ByteArray.fromString(token));
 
 			condition = DSL.or(
-					OAUTH_AUTHORIZATIONS.STATE.eq(token),
+					OAUTH_AUTHORIZATIONS.STATE_HASH.eq(hash),
 					OAUTH_AUTHORIZATIONS.AUTHORIZATION_CODE_VALUE.eq(token),
 					OAUTH_AUTHORIZATIONS.ACCESS_TOKEN_HASH.eq(hash),
 					OAUTH_AUTHORIZATIONS.OIDC_ID_TOKEN_HASH.eq(hash),
 					OAUTH_AUTHORIZATIONS.REFRESH_TOKEN_HASH.eq(hash)
 			);
 		} else if (AUTHORIZATION_STATE_TOKEN_TYPE.equals(type)) {
-			condition = OAUTH_AUTHORIZATIONS.STATE.eq(token);
+			condition = OAUTH_AUTHORIZATIONS.STATE_HASH.eq(hashingConverter.to(ByteArray.fromString(token)));
 		} else if (AUTHORIZATION_CODE_TOKEN_TYPE.equals(type)) {
 			condition = OAUTH_AUTHORIZATIONS.AUTHORIZATION_CODE_VALUE.eq(token);
 		} else if (OAuth2TokenType.ACCESS_TOKEN.equals(type)) {
@@ -315,7 +312,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	}
 
 	@Observed(name = "konfigyr.identity.authorization.cleanup")
-	@Scheduled(cron = "${konfigyr.authorization.cleanup.cron:0 * * * * *}")
+	@Scheduled(cron = "${konfigyr.authorization.cleanup.cron:0 0/15 * * * *}")
 	@Transactional(label = "authorization-service.cleanup-expired-authorizations")
 	void cleanup() {
 		final OffsetDateTime timestamp = OffsetDateTime.now(ZoneOffset.UTC);
@@ -344,6 +341,7 @@ public class DefaultAuthorizationService implements AuthorizationService {
 	}
 
 	@Async
+	@Transactional(label = "authorization-service.authorization-consent-revoked")
 	@DomainEventHandler(name = "authorization-consent-revoked", namespace = "authorization")
 	@TransactionalEventListener(classes = AuthorizationConsentEvent.Revoked.class)
 	void onConsentRevoked(AuthorizationConsentEvent.Revoked event) {
@@ -407,6 +405,30 @@ public class DefaultAuthorizationService implements AuthorizationService {
 				.from(OAUTH_AUTHORIZATIONS)
 				.where(condition)
 				.fetchOne(this::createAuthorization);
+	}
+
+	@NonNull
+	private UnaryOperator<SettableRecord> applyState(@NonNull OAuth2Authorization authorization) {
+		final String state = authorization.getAttribute(OAuth2ParameterNames.STATE);
+
+		if (StringUtils.hasText(state)) {
+			return record -> {
+				final ByteArray value = ByteArray.fromString(state);
+				return record.set(OAUTH_AUTHORIZATIONS.STATE_HASH, value, hashingConverter);
+			};
+		}
+
+		return UnaryOperator.identity();
+	}
+
+	@NonNull
+	private UnaryOperator<SettableRecord> applyAttributes(@NonNull OAuth2Authorization authorization) {
+		final ByteArray context = ByteArray.fromString(authorization.getId());
+
+		return record -> {
+			final Converter<ByteArray, Map> converter = encryptionConverter.with(context).andThen(attributeConverter);
+			return record.set(OAUTH_AUTHORIZATIONS.ATTRIBUTES, authorization.getAttributes(), converter);
+		};
 	}
 
 	@NonNull
@@ -516,7 +538,9 @@ public class DefaultAuthorizationService implements AuthorizationService {
 		}
 
 		if (record.get(OAUTH_AUTHORIZATIONS.OIDC_ID_TOKEN_VALUE) != null) {
-			final Map<String, Object> metadata = createAttributes(record, OAUTH_AUTHORIZATIONS.OIDC_ID_TOKEN_METADATA);
+			final Map<String, Object> metadata = createAttributes(
+					record, OAUTH_AUTHORIZATIONS.OIDC_ID_TOKEN_METADATA, attributeConverter
+			);
 
 			builder.token(
 					new OidcIdToken(
@@ -559,13 +583,30 @@ public class DefaultAuthorizationService implements AuthorizationService {
 		return builder.build();
 	}
 
-	private Consumer<Map<String, Object>> consumeAttributes(@NonNull Record record, @NonNull Field<String> field) {
-		return attributes -> attributes.putAll(createAttributes(record, field));
+	private Consumer<Map<String, Object>> consumeAttributes(@NonNull Record record, @NonNull Field<ByteArray> field) {
+		Converter<ByteArray, Map> converter;
+
+		// the OAuth authorization attributes are encrypted; therefore, we need to decrypt them
+		// first before we can use the JSON attributes converter and consume them
+		if (OAUTH_AUTHORIZATIONS.ATTRIBUTES.equals(field)) {
+			final String id = record.get(OAUTH_AUTHORIZATIONS.ID);
+			Assert.hasText(id, "OAuth authorization must have a unique identifier");
+
+			converter = encryptionConverter.with(id).andThen(attributeConverter);
+		} else {
+			converter = attributeConverter;
+		}
+
+		return attributes -> attributes.putAll(createAttributes(record, field, converter));
 	}
 
 	@SuppressWarnings("unchecked")
-	private Map<String, Object> createAttributes(@NonNull Record record, @NonNull Field<String> field) {
-		final Map<String, Object> value = record.get(field, attributeConverter);
+	private Map<String, Object> createAttributes(
+			@NonNull Record record,
+			@NonNull Field<ByteArray> field,
+			@NonNull Converter<ByteArray, Map> converter
+	) {
+		final Map<String, Object> value = record.get(field, converter);
 		return value == null ? Collections.emptyMap() : value;
 	}
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/KonfigyrRegisteredClientRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/client/KonfigyrRegisteredClientRepository.java
@@ -30,7 +30,11 @@ public class KonfigyrRegisteredClientRepository extends AbstractRegisteredClient
 					AuthorizationServerScopes.register(scopes);
 					scope.getIncluded().forEach(it -> scopes.add(it.getAuthority()));
 				}))
-				.clientSettings(createClientSettings().build())
+				.clientSettings(
+						createClientSettings()
+								.requireAuthorizationConsent(false)
+								.build()
+				)
 				.tokenSettings(createTokenSettings().build())
 				.build();
 	}

--- a/konfigyr-identity/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/konfigyr-identity/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -10,8 +10,8 @@
     {
       "name": "konfigyr.authorization.cleanup.cron",
       "type": "java.lang.String",
-      "defaultValue": "0 0 * * * *",
-      "description": "Specifies the interval of the cleanup job that would remove expired OAuth Authorizations. Defaults to every minute.",
+      "defaultValue": "0 0/15 * * * *",
+      "description": "Specifies the interval of the cleanup job that would remove expired OAuth Authorizations. Defaults to every 15 minutes.",
       "sourceType": "com.konfigyr.identity.authorization.AuthorizationService"
     }
   ]

--- a/konfigyr-identity/src/main/resources/application.yml
+++ b/konfigyr-identity/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     name: konfigyr-identity
 
   cache:
-    cache-names: crypto-keysets, user-cache
+    cache-names: crypto-keysets
     caffeine:
       spec: expireAfterWrite=1h
 

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/acceptance/AuthorizationCodeAcceptanceTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/acceptance/AuthorizationCodeAcceptanceTest.java
@@ -106,8 +106,10 @@ class AuthorizationCodeAcceptanceTest {
 
 		driver.get(uri.toUriString());
 
+		/* Should be kept in case we introduce 3rd party OAuth Clients with a `client_credentials` grant type
+
 		assertThatCurrentUri(driver)
-				.as("Should redirect to login page when not authenticated")
+				.as("Should redirect to consent page to authorize scopes")
 				.hasScheme(uri.getScheme())
 				.hasHost(uri.getHost())
 				.hasPort(uri.getPort())
@@ -133,6 +135,8 @@ class AuthorizationCodeAcceptanceTest {
 
 		assertThatElement(driver, "#consents button[type=\"submit\"]")
 				.satisfies(WebElement::submit);
+
+		 */
 
 		assertThatCurrentUri(driver)
 				.as("Should redirect to client with authorization code")

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/AbstractClientRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/AbstractClientRepositoryTest.java
@@ -92,13 +92,13 @@ abstract class AbstractClientRepositoryTest {
 				.returns(true, TokenSettings::isReuseRefreshTokens);
 	}
 
-	static Consumer<RegisteredClient> assertClientSettings() {
+	static Consumer<RegisteredClient> assertClientSettings(boolean requireAuthorizationConsent) {
 		return client -> assertThat(client.getClientSettings())
 				.isNotNull()
 				.returns(null, ClientSettings::getJwkSetUrl)
 				.returns(null, ClientSettings::getX509CertificateSubjectDN)
 				.returns(null, ClientSettings::getTokenEndpointAuthenticationSigningAlgorithm)
-				.returns(true, ClientSettings::isRequireAuthorizationConsent)
+				.returns(requireAuthorizationConsent, ClientSettings::isRequireAuthorizationConsent)
 				.returns(true, ClientSettings::isRequireProofKey);
 	}
 

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/KonfigyrRegisteredClientRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/KonfigyrRegisteredClientRepositoryTest.java
@@ -98,7 +98,7 @@ class KonfigyrRegisteredClientRepositoryTest extends AbstractClientRepositoryTes
 				))
 				.satisfies(assertClientAuthenticationMethods())
 				.satisfies(assertTokenSettings())
-				.satisfies(assertClientSettings())
+				.satisfies(assertClientSettings(false))
 				.satisfies(assertRedirectUris("http://localhost/callback", "https://konfigyr.com/callback"))
 				.satisfies(assertLogoutRedirectUris("http://localhost/logout-callback"));
 	}

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/RegisteredNamespaceClientRepositoryTest.java
@@ -80,7 +80,7 @@ class RegisteredNamespaceClientRepositoryTest extends AbstractClientRepositoryTe
 				.satisfies(assertAuthorizationGrantTypes(AuthorizationGrantType.CLIENT_CREDENTIALS))
 				.satisfies(assertClientAuthenticationMethods())
 				.satisfies(assertTokenSettings())
-				.satisfies(assertClientSettings())
+				.satisfies(assertClientSettings(true))
 				.satisfies(assertRedirectUris())
 				.satisfies(assertLogoutRedirectUris());
 	}
@@ -105,7 +105,7 @@ class RegisteredNamespaceClientRepositoryTest extends AbstractClientRepositoryTe
 				.satisfies(assertAuthorizationGrantTypes(AuthorizationGrantType.CLIENT_CREDENTIALS))
 				.satisfies(assertClientAuthenticationMethods())
 				.satisfies(assertTokenSettings())
-				.satisfies(assertClientSettings())
+				.satisfies(assertClientSettings(true))
 				.satisfies(assertRedirectUris())
 				.satisfies(assertLogoutRedirectUris());
 	}


### PR DESCRIPTION
- Fix misleading error message in `AccountRememberMeServices` to clarify signature mismatch error
- Register the BouncyCastleProvider only if not already registered
- Do not require authorization consent for konfigyr OAuth client
- Encrypt OAuth authorization attributes, update the cleanup cron and add missing transactional annotation
- Do not use untyped response in the `AccountController#issue` method handler
- Explicit deny-all CORS configuration source in security chains
