### PR TITLE
Spring cloud config importer

### DIFF
--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { FileCog, ImportIcon } from 'lucide-react';
+import { FileCog, ImportIcon, DatabaseBackup } from 'lucide-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Button } from '@konfigyr/components/ui/button';
 import {
@@ -63,10 +63,80 @@ export function FileConfigurationImporter ({ onChange }: {
   );
 }
 
-export function SpringCloudConfigurationImporter () {
+export function SpringCloudConfigurationImporter ({ onFetchConfig }: {
+  onFetchConfig: (username: string, password: string, url: string) => void | Promise<unknown>
+}) {
+  const usernameId = React.useId();
+  const passwordId = React.useId();
+  const configServerUrlId = React.useId();
+
+  const [username, setUsername] = useState('sire-app');
+  const [password, setPassword] = useState('');
+  const [configServerUrl, setConfigServerUrl] = useState('http://config.intern.dev.ebf.de/api/configs/sire-app/dev/master');
+
+  const isFetchConfigDisabled = !username.trim() || !password.trim() || !configServerUrl.trim();
+  const handleFetchConfig = useCallback(() => {
+    void onFetchConfig(username.trim(), password, configServerUrl.trim());
+  }, [configServerUrl, onFetchConfig, password, username]);
 
   return (
-    <h1>Spring cloud imported</h1>
+    <div className="space-y-4">
+      <Field>
+        <FieldLabel htmlFor={usernameId}>
+          <FormattedMessage
+            defaultMessage="User name"
+            description="Label for username input in Spring Cloud configuration importer."
+          />
+        </FieldLabel>
+        <Input
+          id={usernameId}
+          type="text"
+          autoComplete="username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+      </Field>
+
+      <Field>
+        <FieldLabel htmlFor={passwordId}>
+          <FormattedMessage
+            defaultMessage="Password"
+            description="Label for password input in Spring Cloud configuration importer."
+          />
+        </FieldLabel>
+        <Input
+          id={passwordId}
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </Field>
+
+      <Field>
+        <FieldLabel htmlFor={configServerUrlId}>
+          <FormattedMessage
+            defaultMessage="Config server URL"
+            description="Label for config server URL input in Spring Cloud configuration importer."
+          />
+        </FieldLabel>
+        <Input
+          id={configServerUrlId}
+          type="url"
+          placeholder="https://config.example.com"
+          value={configServerUrl}
+          onChange={(e) => setConfigServerUrl(e.target.value)}
+        />
+      </Field>
+
+      <Button type="button" disabled={isFetchConfigDisabled} onClick={handleFetchConfig}>
+        <DatabaseBackup/>
+        <FormattedMessage
+          defaultMessage="Fetch config"
+          description="Button label for fetching configuration from Spring Cloud Config server."
+        />
+      </Button>
+    </div>
   );
 }
 
@@ -77,7 +147,7 @@ export function PropertiesImportDialog ({ profile, onImport }: {
   const [open, setOpen] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
   const [importerType, setImporterType] = useState<ImporterType>(DEFAULT_IMPORTER_TYPE);
-  const { properties, reset, error, parseFile, isParsing, isError } = useConfigFileParser();
+  const { properties, reset, error, parseFile, fetchConfig, isParsing, isError } = useConfigFileParser();
 
   const onOpenChange = useCallback((state: boolean) => {
     setOpen(state);
@@ -97,7 +167,7 @@ export function PropertiesImportDialog ({ profile, onImport }: {
     setIsImporting(false);
   }, [onImport, properties]);
 
-  const isImportDisabled = importerType !== 'file' || properties.length === 0 || isImporting;
+  const isImportDisabled = properties.length === 0 || isImporting;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -156,7 +226,7 @@ export function PropertiesImportDialog ({ profile, onImport }: {
         )}
 
         {importerType === 'api' && (
-          <SpringCloudConfigurationImporter />
+          <SpringCloudConfigurationImporter onFetchConfig={fetchConfig} />
         )}
 
         <ConfigurationImporterStatus

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { z } from 'zod';
 import { DatabaseBackup, FileCog, ImportIcon } from 'lucide-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Button } from '@konfigyr/components/ui/button';
@@ -11,6 +12,7 @@ import {
   DialogTrigger,
 } from '@konfigyr/components/ui/dialog';
 import { Field, FieldDescription, FieldLabel } from '@konfigyr/components/ui/field';
+import { useForm, useFormSubmit } from '@konfigyr/components/ui/form';
 import { Input } from '@konfigyr/components/ui/input';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
 import { TabItem, Tabs } from '@konfigyr/components/ui/tab';
@@ -28,6 +30,15 @@ type ConfigurationImporterStatusProps = {
 type ImporterType = 'file' | 'api';
 
 const DEFAULT_IMPORTER_TYPE: ImporterType = 'file';
+
+const springCloudImporterSchema = z.object({
+  username: z.string().trim().min(1, { message: 'User name is required' }),
+  password: z.string().trim().min(1, { message: 'Password is required' }),
+  configServerUrl: z.string()
+    .trim()
+    .min(1, { message: 'Config server URL is required' })
+    .url({ message: 'Config server URL must be a valid URL' }),
+});
 
 export function FileConfigurationImporter ({ onChange }: {
   onChange: (file: File) => void,
@@ -66,77 +77,78 @@ export function FileConfigurationImporter ({ onChange }: {
 export function SpringCloudConfigurationImporter ({ onFetchConfig }: {
   onFetchConfig: (username: string, password: string, url: string) => void | Promise<unknown>
 }) {
-  const usernameId = React.useId();
-  const passwordId = React.useId();
-  const configServerUrlId = React.useId();
-
-  const [username, setUsername] = useState('');
-  const [password, setPassword] = useState('');
-  const [configServerUrl, setConfigServerUrl] = useState('');
-
-  const isFetchConfigDisabled = !username.trim() || !password.trim() || !configServerUrl.trim();
-  const handleFetchConfig = useCallback(() => {
-    void onFetchConfig(username.trim(), password, configServerUrl.trim());
-  }, [configServerUrl, onFetchConfig, password, username]);
+  const form = useForm({
+    defaultValues: {
+      username: '',
+      password: '',
+      configServerUrl: '',
+    },
+    validators: {
+      onSubmit: springCloudImporterSchema,
+    },
+    onSubmit: async ({ value }) => {
+      await onFetchConfig(value.username.trim(), value.password, value.configServerUrl.trim());
+    },
+  });
+  const onSubmit = useFormSubmit(form);
 
   return (
-    <div className="space-y-4">
-      <Field>
-        <FieldLabel htmlFor={usernameId}>
-          <FormattedMessage
-            defaultMessage="User name"
-            description="Label for username input in Spring Cloud configuration importer."
-          />
-        </FieldLabel>
-        <Input
-          id={usernameId}
-          type="text"
-          autoComplete="username"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+    <form.AppForm>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <form.AppField
+          name="username"
+          children={(field) => (
+            <field.Control
+              label={(
+                <FormattedMessage
+                  defaultMessage="User name"
+                  description="Label for username input in Spring Cloud configuration importer."
+                />
+              )}
+              render={<field.Input type="text" autoComplete="username" />}
+            />
+          )}
         />
-      </Field>
 
-      <Field>
-        <FieldLabel htmlFor={passwordId}>
-          <FormattedMessage
-            defaultMessage="Password"
-            description="Label for password input in Spring Cloud configuration importer."
-          />
-        </FieldLabel>
-        <Input
-          id={passwordId}
-          type="password"
-          autoComplete="current-password"
-          value={password}
-          onChange={(e) => setPassword(e.target.value)}
+        <form.AppField
+          name="password"
+          children={(field) => (
+            <field.Control
+              label={(
+                <FormattedMessage
+                  defaultMessage="Password"
+                  description="Label for password input in Spring Cloud configuration importer."
+                />
+              )}
+              render={<field.Input type="password" autoComplete="current-password" />}
+            />
+          )}
         />
-      </Field>
 
-      <Field>
-        <FieldLabel htmlFor={configServerUrlId}>
-          <FormattedMessage
-            defaultMessage="Config server URL"
-            description="Label for config server URL input in Spring Cloud configuration importer."
-          />
-        </FieldLabel>
-        <Input
-          id={configServerUrlId}
-          type="url"
-          placeholder="https://config.com/api/configs/app/profile/label"
-          value={configServerUrl}
-          onChange={(e) => setConfigServerUrl(e.target.value)}
+        <form.AppField
+          name="configServerUrl"
+          children={(field) => (
+            <field.Control
+              label={(
+                <FormattedMessage
+                  defaultMessage="Config server URL"
+                  description="Label for config server URL input in Spring Cloud configuration importer."
+                />
+              )}
+              render={<field.Input type="text" placeholder="https://config.com/api/configs/app/profile/label" />}
+            />
+          )}
         />
-      </Field>
 
-      <Button type="button" disabled={isFetchConfigDisabled} onClick={handleFetchConfig}>
-        <DatabaseBackup/>
-        <FormattedMessage
-          defaultMessage="Fetch config"
-          description="Button label for fetching configuration from Spring Cloud Config server."
-        />
-      </Button>
-    </div>
+        <form.Submit variant="default">
+          <DatabaseBackup/>
+          <FormattedMessage
+            defaultMessage="Fetch config"
+            description="Button label for fetching configuration from Spring Cloud Config server."
+          />
+        </form.Submit>
+      </form>
+    </form.AppForm>
   );
 }
 

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react';
-import { FileCog, ImportIcon, DatabaseBackup } from 'lucide-react';
+import { DatabaseBackup, FileCog, ImportIcon } from 'lucide-react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { Button } from '@konfigyr/components/ui/button';
 import {
@@ -13,9 +13,9 @@ import {
 import { Field, FieldDescription, FieldLabel } from '@konfigyr/components/ui/field';
 import { Input } from '@konfigyr/components/ui/input';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
+import { TabItem, Tabs } from '@konfigyr/components/ui/tab';
 import { ImportPropertiesLabel } from './messages';
 import type { ConfigurationProperty, Profile } from '@konfigyr/hooks/types';
-import { TabItem, Tabs } from '@konfigyr/components/ui/tab';
 
 type ConfigurationImporterStatusProps = {
   isParsing: boolean;
@@ -70,9 +70,9 @@ export function SpringCloudConfigurationImporter ({ onFetchConfig }: {
   const passwordId = React.useId();
   const configServerUrlId = React.useId();
 
-  const [username, setUsername] = useState('sire-app');
+  const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [configServerUrl, setConfigServerUrl] = useState('http://config.intern.dev.ebf.de/api/configs/sire-app/dev/master');
+  const [configServerUrl, setConfigServerUrl] = useState('');
 
   const isFetchConfigDisabled = !username.trim() || !password.trim() || !configServerUrl.trim();
   const handleFetchConfig = useCallback(() => {
@@ -123,7 +123,7 @@ export function SpringCloudConfigurationImporter ({ onFetchConfig }: {
         <Input
           id={configServerUrlId}
           type="url"
-          placeholder="https://config.example.com"
+          placeholder="https://config.com/api/configs/app/profile/label"
           value={configServerUrl}
           onChange={(e) => setConfigServerUrl(e.target.value)}
         />
@@ -199,7 +199,7 @@ export function PropertiesImportDialog ({ profile, onImport }: {
                 onClick={() => handleImporterTypeChange('file')}
               >
                 <FormattedMessage
-                  defaultMessage="From File"
+                  defaultMessage="From file"
                   description="Tab label for importing configuration properties from a file."
                 />
               </button>
@@ -213,8 +213,8 @@ export function PropertiesImportDialog ({ profile, onImport }: {
                 onClick={() => handleImporterTypeChange('api')}
               >
                 <FormattedMessage
-                  defaultMessage="From API"
-                  description="Tab label for importing configuration properties from an API."
+                  defaultMessage="From config server"
+                  description="Tab label for importing configuration properties from an Config Server."
                 />
               </button>
             }

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -15,6 +15,7 @@ import { Input } from '@konfigyr/components/ui/input';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
 import { ImportPropertiesLabel } from './messages';
 import type { ConfigurationProperty, Profile } from '@konfigyr/hooks/types';
+import { TabItem, Tabs } from '@konfigyr/components/ui/tab';
 
 type ConfigurationImporterStatusProps = {
   isParsing: boolean;
@@ -24,7 +25,11 @@ type ConfigurationImporterStatusProps = {
   amount: number;
 };
 
-export function ConfigurationImporter ({ onChange }: {
+type ImporterType = 'file' | 'api';
+
+const DEFAULT_IMPORTER_TYPE: ImporterType = 'file';
+
+export function FileConfigurationImporter ({ onChange }: {
   onChange: (file: File) => void,
 }) {
   const inputId = React.useId();
@@ -58,16 +63,30 @@ export function ConfigurationImporter ({ onChange }: {
   );
 }
 
+export function SpringCloudConfigurationImporter () {
+
+  return (
+    <h1>Spring cloud imported</h1>
+  );
+}
+
 export function PropertiesImportDialog ({ profile, onImport }: {
   onImport: (properties: Array<ConfigurationProperty<any>>) => void | Promise<unknown>
   profile: Profile
 }) {
   const [open, setOpen] = useState(false);
   const [isImporting, setIsImporting] = useState(false);
+  const [importerType, setImporterType] = useState<ImporterType>(DEFAULT_IMPORTER_TYPE);
   const { properties, reset, error, parseFile, isParsing, isError } = useConfigFileParser();
 
   const onOpenChange = useCallback((state: boolean) => {
     setOpen(state);
+    setImporterType(DEFAULT_IMPORTER_TYPE);
+    reset();
+  }, [reset]);
+
+  const handleImporterTypeChange = useCallback((type: ImporterType) => {
+    setImporterType(type);
     reset();
   }, [reset]);
 
@@ -78,8 +97,7 @@ export function PropertiesImportDialog ({ profile, onImport }: {
     setIsImporting(false);
   }, [onImport, properties]);
 
-  const isImportDisabled = properties.length === 0 || isImporting;
-
+  const isImportDisabled = importerType !== 'file' || properties.length === 0 || isImporting;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -102,7 +120,44 @@ export function PropertiesImportDialog ({ profile, onImport }: {
           </DialogTitle>
         </DialogHeader>
 
-        <ConfigurationImporter onChange={parseFile}/>
+        <Tabs>
+          <TabItem
+            render={
+              <button
+                type="button"
+                data-state={importerType === 'file' ? 'active' : undefined}
+                onClick={() => handleImporterTypeChange('file')}
+              >
+                <FormattedMessage
+                  defaultMessage="From File"
+                  description="Tab label for importing configuration properties from a file."
+                />
+              </button>
+            }
+          />
+          <TabItem
+            render={
+              <button
+                type="button"
+                data-state={importerType === 'api' ? 'active' : undefined}
+                onClick={() => handleImporterTypeChange('api')}
+              >
+                <FormattedMessage
+                  defaultMessage="From API"
+                  description="Tab label for importing configuration properties from an API."
+                />
+              </button>
+            }
+          />
+        </Tabs>
+
+        {importerType === 'file' && (
+          <FileConfigurationImporter onChange={parseFile}/>
+        )}
+
+        {importerType === 'api' && (
+          <SpringCloudConfigurationImporter />
+        )}
 
         <ConfigurationImporterStatus
           isParsing={isParsing}

--- a/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/properties-import-dialog.tsx
@@ -16,7 +16,9 @@ import { useForm, useFormSubmit } from '@konfigyr/components/ui/form';
 import { Input } from '@konfigyr/components/ui/input';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
 import { TabItem, Tabs } from '@konfigyr/components/ui/tab';
+import { FetchConfigSchema } from '@konfigyr/hooks/vault/-handler';
 import { ImportPropertiesLabel } from './messages';
+import type { FetchConfigRequest } from '@konfigyr/hooks/vault/-handler';
 import type { ConfigurationProperty, Profile } from '@konfigyr/hooks/types';
 
 type ConfigurationImporterStatusProps = {
@@ -30,15 +32,6 @@ type ConfigurationImporterStatusProps = {
 type ImporterType = 'file' | 'api';
 
 const DEFAULT_IMPORTER_TYPE: ImporterType = 'file';
-
-const springCloudImporterSchema = z.object({
-  username: z.string().trim().min(1, { message: 'User name is required' }),
-  password: z.string().trim().min(1, { message: 'Password is required' }),
-  configServerUrl: z.string()
-    .trim()
-    .min(1, { message: 'Config server URL is required' })
-    .url({ message: 'Config server URL must be a valid URL' }),
-});
 
 export function FileConfigurationImporter ({ onChange }: {
   onChange: (file: File) => void,
@@ -75,7 +68,7 @@ export function FileConfigurationImporter ({ onChange }: {
 }
 
 export function SpringCloudConfigurationImporter ({ onFetchConfig }: {
-  onFetchConfig: (username: string, password: string, url: string) => void | Promise<unknown>
+  onFetchConfig: (payload: FetchConfigRequest) => void | Promise<unknown>
 }) {
   const form = useForm({
     defaultValues: {
@@ -84,12 +77,17 @@ export function SpringCloudConfigurationImporter ({ onFetchConfig }: {
       configServerUrl: '',
     },
     validators: {
-      onSubmit: springCloudImporterSchema,
+      onSubmit: FetchConfigSchema,
     },
     onSubmit: async ({ value }) => {
-      await onFetchConfig(value.username.trim(), value.password, value.configServerUrl.trim());
+      await onFetchConfig({
+        username: value.username.trim(),
+        password: value.password.trim(),
+        configServerUrl: value.configServerUrl.trim(),
+      });
     },
   });
+
   const onSubmit = useFormSubmit(form);
 
   return (

--- a/konfigyr-frontend/src/hooks/vault/-handler.ts
+++ b/konfigyr-frontend/src/hooks/vault/-handler.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { createServerFn } from '@tanstack/react-start';
 
 export const FetchConfigSchema = z.object({
   username: z.string().trim().min(1, { message: 'User name is required' }),
@@ -11,7 +12,7 @@ export const FetchConfigSchema = z.object({
 
 export type FetchConfigRequest = z.infer<typeof FetchConfigSchema>;
 
-export async function fetchSpringConfigHandler({ data }: { data: FetchConfigRequest }) {
+async function fetchSpringConfig({ data }: { data: FetchConfigRequest }) {
   const auth = btoa(`${data.username}:${data.password}`);
   const response = await fetch(data.configServerUrl, {
     method: 'GET',
@@ -27,3 +28,7 @@ export async function fetchSpringConfigHandler({ data }: { data: FetchConfigRequ
 
   return await response.json();
 }
+
+export const fetchSpringConfigHandler = createServerFn({ method: 'GET' })
+  .inputValidator(FetchConfigSchema)
+  .handler(fetchSpringConfig);

--- a/konfigyr-frontend/src/hooks/vault/-handler.ts
+++ b/konfigyr-frontend/src/hooks/vault/-handler.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+export const FetchConfigSchema = z.object({
+  username: z.string().trim().min(1, { message: 'User name is required' }),
+  password: z.string().trim().min(1, { message: 'Password is required' }),
+  configServerUrl: z.string()
+    .trim()
+    .min(1, { message: 'Config server URL is required' })
+    .url({ message: 'Config server URL must be a valid URL' }),
+});
+
+export type FetchConfigRequest = z.infer<typeof FetchConfigSchema>;
+
+export async function fetchSpringConfigHandler({ data }: { data: FetchConfigRequest }) {
+  const auth = btoa(`${data.username}:${data.password}`);
+  const response = await fetch(data.configServerUrl, {
+    method: 'GET',
+    headers: {
+      Authorization: `Basic ${auth}`,
+      Accept: 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch configuration: ${response.status}`);
+  }
+
+  return await response.json();
+}

--- a/konfigyr-frontend/src/hooks/vault/changeset.ts
+++ b/konfigyr-frontend/src/hooks/vault/changeset.ts
@@ -245,26 +245,31 @@ export const useImportProperties = (changeset: ChangesetState) => {
 
   return useMutation({
     mutationFn: async (properties: Array<ConfigurationProperty<any>>): Promise<ChangesetState>=> {
-      const result: Array<ConfigurationProperty<any>> = [];
+      const importedByName = new Map(
+        properties.map(property => [property.name, property] as const),
+      );
 
-      properties.forEach(( property: ConfigurationProperty<any>) => {
-        const existing = changeset.properties.find(p => p.name === property.name);
-        if (existing) {
-          result.push(
-            {
-              ...existing,
-              value: property.value,
-              state: existing.state === ConfigurationPropertyState.ADDED ? ConfigurationPropertyState.ADDED : ConfigurationPropertyState.UPDATED,
-            },
-          );
-        } else {
-          result.push(
-            {
-              ...property,
-              state: ConfigurationPropertyState.ADDED,
-            },
-          );
+      const result: Array<ConfigurationProperty<any>> = changeset.properties.map(existing => {
+        const imported = importedByName.get(existing.name);
+        if (!imported) {
+          return existing;
         }
+
+        importedByName.delete(existing.name);
+        return {
+          ...existing,
+          value: imported.value,
+          state: existing.state === ConfigurationPropertyState.ADDED
+            ? ConfigurationPropertyState.ADDED
+            : ConfigurationPropertyState.UPDATED,
+        };
+      });
+
+      importedByName.forEach((property) => {
+        result.push({
+          ...property,
+          state: ConfigurationPropertyState.ADDED,
+        });
       });
 
       return Promise.resolve({

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -224,7 +224,7 @@ const parseSpringCloudConfigResponse = (payload: unknown): Array<ConfigurationPr
   // Spring Cloud returns sources in precedence order (highest first).
   // Merge from last to first so higher-precedence sources override lower ones.
   for (let i = propertySources.length - 1; i >= 0; i--) {
-    const source = (propertySources[i] as { source?: unknown })?.source;
+    const source = (propertySources[i] as { source?: unknown }).source;
     if (source && typeof source === 'object' && !Array.isArray(source)) {
       Object.assign(mergedSource, source);
     }
@@ -246,7 +246,7 @@ const parseSpringCloudConfigResponse = (payload: unknown): Array<ConfigurationPr
  * - `properties` - The parsed configuration properties.
  * - `error` - An error message if parsing fails.
  * - `parseFile` - Async function to parse a given `File`.
- * - `fetchConfig` - Async function to fetch JSON configuration from API and parse it.
+ * - `fetchConfig` - Async function to fetch JSON configuration from the config server API and parse it.
  * - `reset` - Function to clear parsed data and errors.
  * - `isParsing` - Indicates whether a parse operation is currently in progress.
  * - `isError` - Indicates whether the latest parse operation failed.
@@ -280,7 +280,7 @@ export function useConfigFileParser () {
       setIsParsing(false);
       setError(e instanceof Error ? e : new Error('Parse error'));
     }
-  }
+  };
 
   const parseFile = async (file: File)=> {
     await runParseTask(async () => {
@@ -299,9 +299,9 @@ export function useConfigFileParser () {
 
       throw new Error('Unsupported file type');
     });
-  }
+  };
 
-   const fetchConfig = async (username: string, password: string, url: string) =>  {
+  const fetchConfig = async (username: string, password: string, url: string) => {
     await runParseTask(async () => {
       const auth = btoa(`${username}:${password}`);
       const response = await fetch(url, {
@@ -319,7 +319,7 @@ export function useConfigFileParser () {
       const parsedJsonObject = await response.json();
       return parseSpringCloudConfigResponse(parsedJsonObject);
     });
-  }
+  };
 
   const reset = () => {
     parseSequenceRef.current++;

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -1,14 +1,9 @@
 import { useRef, useState } from 'react';
 import { PropertyTransitionType } from '@konfigyr/hooks/vault/types';
 import { parse } from 'yaml';
-import { createServerFn } from '@tanstack/react-start';
-import { FetchConfigSchema, fetchSpringConfigHandler } from '@konfigyr/hooks/vault/-handler';
+import { fetchSpringConfigHandler } from '@konfigyr/hooks/vault/-handler';
 import type { FetchConfigRequest } from '@konfigyr/hooks/vault/-handler';
 import type { ConfigurationProperty } from '@konfigyr/hooks/vault/types';
-
-const fetchSpringConfig = createServerFn({ method: 'GET' })
-  .inputValidator(FetchConfigSchema)
-  .handler(fetchSpringConfigHandler);
 
 /**
  * Builds a configuration property object from a name/value pair.
@@ -310,7 +305,7 @@ export function useConfigFileParser () {
 
   const fetchConfig = async (payload: FetchConfigRequest) => {
     await runParseTask(async () => {
-      const response = await fetchSpringConfig({
+      const response = await fetchSpringConfigHandler({
         data: payload,
       });
       return parseSpringCloudConfigResponse(response);

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -205,6 +205,35 @@ const parseJsonFile = (text?: string): Array<ConfigurationProperty<string>> => {
 };
 
 /**
+ * Parses Spring Cloud Config server response and converts effective `propertySources[*].source` entries into flat configuration properties.
+ *
+ * @param payload - Raw JSON payload returned by Spring Cloud Config server
+ */
+const parseSpringCloudConfigResponse = (payload: unknown): Array<ConfigurationProperty<string>> => {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid configuration response');
+  }
+
+  const propertySources = (payload as { propertySources?: unknown }).propertySources;
+  if (!Array.isArray(propertySources)) {
+    throw new Error('Invalid configuration response: missing propertySources');
+  }
+
+  const mergedSource: Record<string, unknown> = {};
+
+  // Spring Cloud returns sources in precedence order (highest first).
+  // Merge from last to first so higher-precedence sources override lower ones.
+  for (let i = propertySources.length - 1; i >= 0; i--) {
+    const source = (propertySources[i] as { source?: unknown })?.source;
+    if (source && typeof source === 'object' && !Array.isArray(source)) {
+      Object.assign(mergedSource, source);
+    }
+  }
+
+  return jsonToProperties(mergedSource);
+};
+
+/**
  * React hook for parsing configuration files into structured properties.
  *
  * Supports the following file formats:
@@ -217,6 +246,7 @@ const parseJsonFile = (text?: string): Array<ConfigurationProperty<string>> => {
  * - `properties` - The parsed configuration properties.
  * - `error` - An error message if parsing fails.
  * - `parseFile` - Async function to parse a given `File`.
+ * - `fetchConfig` - Async function to fetch JSON configuration from API and parse it.
  * - `reset` - Function to clear parsed data and errors.
  * - `isParsing` - Indicates whether a parse operation is currently in progress.
  * - `isError` - Indicates whether the latest parse operation failed.
@@ -228,26 +258,13 @@ export function useConfigFileParser () {
   const [isParsing, setIsParsing] = useState(false);
   const parseSequenceRef = useRef(0);
 
-  async function parseFile (file: File) {
+  const runParseTask = async (task: () => Promise<Array<ConfigurationProperty<string>>>) => {
     const currentSequence = ++parseSequenceRef.current;
     setIsParsing(true);
     setError(undefined);
 
     try {
-      const text = await file.text();
-      const name = file.name.toLowerCase();
-
-      let parsedProperties: Array<ConfigurationProperty<string>> = [];
-
-      if (name.endsWith('.json')) {
-        parsedProperties = parseJsonFile(text);
-      } else if (name.endsWith('.properties')) {
-        parsedProperties = parsePropertiesFile(text);
-      } else if (name.endsWith('.yaml') || name.endsWith('.yml')) {
-        parsedProperties = parseYamlFile(text);
-      } else {
-        throw new Error('Unsupported file type');
-      }
+      const parsedProperties = await task();
 
       if (parseSequenceRef.current !== currentSequence) {
         return;
@@ -265,6 +282,45 @@ export function useConfigFileParser () {
     }
   }
 
+  const parseFile = async (file: File)=> {
+    await runParseTask(async () => {
+      const text = await file.text();
+      const name = file.name.toLowerCase();
+
+      if (name.endsWith('.json')) {
+        return parseJsonFile(text);
+      }
+      if (name.endsWith('.properties')) {
+        return parsePropertiesFile(text);
+      }
+      if (name.endsWith('.yaml') || name.endsWith('.yml')) {
+        return parseYamlFile(text);
+      }
+
+      throw new Error('Unsupported file type');
+    });
+  }
+
+   const fetchConfig = async (username: string, password: string, url: string) =>  {
+    await runParseTask(async () => {
+      const auth = btoa(`${username}:${password}`);
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: {
+          Authorization: `Basic ${auth}`,
+          Accept: 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Failed to fetch configuration: ${response.status}`);
+      }
+
+      const parsedJsonObject = await response.json();
+      return parseSpringCloudConfigResponse(parsedJsonObject);
+    });
+  }
+
   const reset = () => {
     parseSequenceRef.current++;
     setProperties([]);
@@ -276,6 +332,7 @@ export function useConfigFileParser () {
     properties,
     error,
     parseFile,
+    fetchConfig,
     reset,
     isParsing,
     isError: !!error,

--- a/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
+++ b/konfigyr-frontend/src/hooks/vault/config-file-parser.tsx
@@ -1,7 +1,14 @@
 import { useRef, useState } from 'react';
 import { PropertyTransitionType } from '@konfigyr/hooks/vault/types';
 import { parse } from 'yaml';
+import { createServerFn } from '@tanstack/react-start';
+import { FetchConfigSchema, fetchSpringConfigHandler } from '@konfigyr/hooks/vault/-handler';
+import type { FetchConfigRequest } from '@konfigyr/hooks/vault/-handler';
 import type { ConfigurationProperty } from '@konfigyr/hooks/vault/types';
+
+const fetchSpringConfig = createServerFn({ method: 'GET' })
+  .inputValidator(FetchConfigSchema)
+  .handler(fetchSpringConfigHandler);
 
 /**
  * Builds a configuration property object from a name/value pair.
@@ -301,23 +308,12 @@ export function useConfigFileParser () {
     });
   };
 
-  const fetchConfig = async (username: string, password: string, url: string) => {
+  const fetchConfig = async (payload: FetchConfigRequest) => {
     await runParseTask(async () => {
-      const auth = btoa(`${username}:${password}`);
-      const response = await fetch(url, {
-        method: 'GET',
-        headers: {
-          Authorization: `Basic ${auth}`,
-          Accept: 'application/json',
-        },
+      const response = await fetchSpringConfig({
+        data: payload,
       });
-
-      if (!response.ok) {
-        throw new Error(`Failed to fetch configuration: ${response.status}`);
-      }
-
-      const parsedJsonObject = await response.json();
-      return parseSpringCloudConfigResponse(parsedJsonObject);
+      return parseSpringCloudConfigResponse(response);
     });
   };
 

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { cleanup, waitFor, within } from '@testing-library/react';
 import { renderWithMessageProvider } from '@konfigyr/test/helpers/messages';
 import { PropertiesImportDialog } from '@konfigyr/components/vault/properties/properties-import-dialog';
@@ -14,13 +14,16 @@ const YAML_FILE = `
 `;
 
 describe('components | vault | properties | <PropertiesImportDialog/>', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   afterEach(() => cleanup());
 
   test('should render disabled Import button for the immutable profile', () => {
-    const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport} profile={profiles.deprecated} />,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.deprecated}/>,
     );
 
     expect(result.getByRole('button', { name: 'Import' })).toBeDisabled();
@@ -30,7 +33,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport} profile={profiles.development} />,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development}/>,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));
@@ -45,7 +48,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport} profile={profiles.development} />,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development}/>,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));
@@ -89,7 +92,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport} profile={profiles.development} />,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development}/>,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));
@@ -109,7 +112,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     await user.click(importButton);
 
     await waitFor(() => {
-      expect(onImport).toHaveBeenCalledExactlyOnceWith( [
+      expect(onImport).toHaveBeenCalledExactlyOnceWith([
         {
           name: 'server.port',
           schema: {
@@ -131,7 +134,7 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
     const result = renderWithMessageProvider(
-      <PropertiesImportDialog onImport={onImport} profile={profiles.development} />,
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development}/>,
     );
 
     await user.click(result.getByRole('button', { name: 'Import' }));
@@ -152,4 +155,83 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     expect(onImport).not.toHaveBeenCalled();
   });
 
+  test('should fetch properties from config server and submit import', async () => {
+    const user = userEvent.setup();
+    const onImport = vi.fn().mockResolvedValue(undefined);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        propertySources: [
+          { name: 'highest', source: { 'app.log.level': 'warn' } },
+          { name: 'lowest', source: { 'app.environment': 'dev', 'app.log.level': 'info' } },
+        ],
+      }),
+    } as Response);
+
+    const result = renderWithMessageProvider(
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development}/>,
+    );
+
+    await user.click(result.getByRole('button', { name: 'Import' }));
+    await waitFor(() => expect(result.getByRole('dialog')).toBeInTheDocument());
+
+    await user.click(within(result.getByRole('dialog')).getByRole('tab', { name: 'From config server' }));
+
+    await user.type(result.getByLabelText('User name'), 'test-user');
+    await user.type(result.getByLabelText('Password'), 'test-pwd');
+    await user.type(result.getByLabelText('Config server URL'), 'http://config.com/api/configs/test-app/dev/master');
+
+    await user.click(result.getByRole('button', { name: 'Fetch config' }));
+
+    await waitFor(() => {
+      expect(result.getByText('Ready for import')).toBeInTheDocument();
+      expect(result.getByText(/there are 2 new configuration properties ready for import/i)).toBeInTheDocument();
+    });
+
+    const importButton = within(result.getByRole('dialog')).getByRole('button', { name: 'Import' });
+    await user.click(importButton);
+
+    await waitFor(() => {
+      expect(onImport).toHaveBeenCalledExactlyOnceWith(
+        [
+          {
+            'name': 'app.environment',
+            'schema': {
+              'type': 'string',
+            },
+            'state': 'ADDED',
+            'typeName': 'string',
+            'value': {
+              'decoded': 'dev',
+              'encoded': 'dev',
+            },
+          },
+          {
+            'name': 'app.log.level',
+            'schema': {
+              'type': 'string',
+            },
+            'state': 'ADDED',
+            'typeName': 'string',
+            'value': {
+              'decoded': 'warn',
+              'encoded': 'warn',
+            },
+          },
+        ],
+      );
+    });
+
+    expect(fetchSpy).toHaveBeenCalledExactlyOnceWith(
+      'http://config.com/api/configs/test-app/dev/master',
+      {
+        method: 'GET',
+        'headers': {
+          'Accept': 'application/json',
+          'Authorization': 'Basic dGVzdC11c2VyOnRlc3QtcHdk',
+        },
+      },
+    );
+  });
 });
+

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -13,6 +13,23 @@ const YAML_FILE = `
     port: 8080
 `;
 
+vi.mock('@tanstack/react-start', () => {
+  return {
+    createServerFn: () => {
+      const chain = {
+        inputValidator() {
+          return chain;
+        },
+        handler(handler: (...args: Array<any>) => Promise<any> | any) {
+          return async (...args: Array<any>) => await handler(...args);
+        },
+      };
+
+      return chain;
+    },
+  };
+});
+
 describe('components | vault | properties | <PropertiesImportDialog/>', () => {
   beforeEach(() => {
     vi.restoreAllMocks();

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -155,6 +155,30 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     expect(onImport).not.toHaveBeenCalled();
   });
 
+  test('should validate config server URL on submit', async () => {
+    const user = userEvent.setup();
+    const onImport = vi.fn().mockResolvedValue(undefined);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    const result = renderWithMessageProvider(
+      <PropertiesImportDialog onImport={onImport} profile={profiles.development}/>,
+    );
+
+    await user.click(result.getByRole('button', { name: 'Import' }));
+    await waitFor(() => expect(result.getByRole('dialog')).toBeInTheDocument());
+    await user.click(within(result.getByRole('dialog')).getByRole('tab', { name: 'From config server' }));
+
+    await user.type(result.getByLabelText('User name'), 'test-user');
+    await user.type(result.getByLabelText('Password'), 'test-pwd');
+    await user.type(result.getByLabelText('Config server URL'), 'not-a-url');
+
+    await user.click(result.getByRole('button', { name: 'Fetch config' }));
+
+    await waitFor(() => {
+      expect(result.getByText('Config server URL must be a valid URL')).toBeInTheDocument();
+    });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
   test('should fetch properties from config server and submit import', async () => {
     const user = userEvent.setup();
     const onImport = vi.fn().mockResolvedValue(undefined);
@@ -181,7 +205,9 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     await user.type(result.getByLabelText('Password'), 'test-pwd');
     await user.type(result.getByLabelText('Config server URL'), 'http://config.com/api/configs/test-app/dev/master');
 
-    await user.click(result.getByRole('button', { name: 'Fetch config' }));
+    const fetchButton = result.getByRole('button', { name: 'Fetch config' });
+    expect(fetchButton).toBeEnabled();
+    await user.click(fetchButton);
 
     await waitFor(() => {
       expect(result.getByText('Ready for import')).toBeInTheDocument();
@@ -234,4 +260,3 @@ describe('components | vault | properties | <PropertiesImportDialog/>', () => {
     );
   });
 });
-

--- a/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
+++ b/konfigyr-frontend/test/components/vault/properties/properties-import-dialog.test.tsx
@@ -13,21 +13,9 @@ const YAML_FILE = `
     port: 8080
 `;
 
-vi.mock('@tanstack/react-start', () => {
-  return {
-    createServerFn: () => {
-      const chain = {
-        inputValidator() {
-          return chain;
-        },
-        handler(handler: (...args: Array<any>) => Promise<any> | any) {
-          return async (...args: Array<any>) => await handler(...args);
-        },
-      };
-
-      return chain;
-    },
-  };
+vi.mock('@tanstack/react-start', async () => {
+  const { mockTanstackReactStart } = await import('@konfigyr/test/helpers/mocks/tanstack-react-start');
+  return mockTanstackReactStart();
 });
 
 describe('components | vault | properties | <PropertiesImportDialog/>', () => {

--- a/konfigyr-frontend/test/helpers/mocks/tanstack-react-start.ts
+++ b/konfigyr-frontend/test/helpers/mocks/tanstack-react-start.ts
@@ -1,0 +1,18 @@
+export const createServerFnMock = () => {
+  const chain = {
+    inputValidator() {
+      return chain;
+    },
+    handler(handler: (...args: Array<any>) => Promise<any> | any) {
+      return async (...args: Array<any>) => await handler(...args);
+    },
+  };
+
+  return chain;
+};
+
+export const mockTanstackReactStart = () => {
+  return {
+    createServerFn: createServerFnMock,
+  };
+};

--- a/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
+++ b/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
@@ -2,6 +2,23 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
 
+vi.mock('@tanstack/react-start', () => {
+  return {
+    createServerFn: () => {
+      const chain = {
+        inputValidator() {
+          return chain;
+        },
+        handler(handler: (...args: Array<any>) => Promise<any> | any) {
+          return async (...args: Array<any>) => await handler(...args);
+        },
+      };
+
+      return chain;
+    },
+  };
+});
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -17,6 +34,16 @@ const mockFile = (name: string, text: string | Promise<string>): File => {
     name,
     text: () => typeof text === 'string' ? Promise.resolve(text) : text,
   } as File;
+};
+
+const mockJsonFetch = (body: unknown, init: ResponseInit = {}) => {
+  vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+    return Promise.resolve(
+      new Response(JSON.stringify(body), {
+        ...init,
+      }),
+    );
+  });
 };
 
 describe('hooks | vault | useConfigFileParser', () => {
@@ -219,15 +246,12 @@ describe('hooks | vault | useConfigFileParser', () => {
   });
 
   test('should fetch config from config server and merge propertySources in one object', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({
-        propertySources: [
-          { name: 'high', source: { 'feature.flag': true } },
-          { name: 'low', source: { 'feature.flag': false, 'service.name': 'api' } },
-        ],
-      }),
-    } as Response);
+    mockJsonFetch({
+      propertySources: [
+        { name: 'high', source: { 'feature.flag': true } },
+        { name: 'low', source: { 'feature.flag': false, 'service.name': 'api' } },
+      ],
+    });
 
     const { result } = renderHook(() => useConfigFileParser());
 
@@ -239,10 +263,12 @@ describe('hooks | vault | useConfigFileParser', () => {
       });
     });
 
-    expect(result.current.properties).toMatchObject([
-      { name: 'feature.flag', value: { encoded: 'true', decoded: 'true' } },
-      { name: 'service.name', value: { encoded: 'api', decoded: 'api' } },
-    ]);
+    await waitFor(() => {
+      expect(result.current.properties).toMatchObject([
+        { name: 'feature.flag', value: { encoded: 'true', decoded: 'true' } },
+        { name: 'service.name', value: { encoded: 'api', decoded: 'api' } },
+      ]);
+    });
     expect(result.current.error).toBeUndefined();
     expect(result.current.isParsing).toBe(false);
     expect(result.current.isError).toBe(false);
@@ -250,10 +276,7 @@ describe('hooks | vault | useConfigFileParser', () => {
   });
 
   test('should expose error when config server response does not contain propertySources', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: true,
-      json: () => Promise.resolve({ name: 'broken-payload' }),
-    } as Response);
+    mockJsonFetch({ name: 'broken-payload' });
 
     const { result } = renderHook(() => useConfigFileParser());
 
@@ -265,20 +288,18 @@ describe('hooks | vault | useConfigFileParser', () => {
       });
     });
 
-    expect(result.current.properties).toStrictEqual([]);
-    expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toContain('Invalid configuration response: missing propertySources');
+    await waitFor(() => {
+      expect(result.current.properties).toStrictEqual([]);
+      expect(result.current.error).toBeDefined();
+      expect(result.current.error?.message).toContain('Invalid configuration response: missing propertySources');
+    });
     expect(result.current.isParsing).toBe(false);
     expect(result.current.isError).toBe(true);
     expect(result.current.isReady).toBe(false);
   });
 
   test('should expose error when Config Server request returns 401', async () => {
-    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
-      ok: false,
-      status: 401,
-      json: () => Promise.resolve({}),
-    } as Response);
+    mockJsonFetch('Failed to fetch configuration: 401', { status: 401 });
 
     const { result } = renderHook(() => useConfigFileParser());
 
@@ -290,9 +311,11 @@ describe('hooks | vault | useConfigFileParser', () => {
       });
     });
 
-    expect(result.current.properties).toStrictEqual([]);
-    expect(result.current.error).toBeDefined();
-    expect(result.current.error?.message).toBe('Failed to fetch configuration: 401');
+    await waitFor(() => {
+      expect(result.current.properties).toStrictEqual([]);
+      expect(result.current.error).toBeDefined();
+      expect(result.current.error?.message).toBe('Failed to fetch configuration: 401');
+    });
     expect(result.current.isParsing).toBe(false);
     expect(result.current.isError).toBe(true);
     expect(result.current.isReady).toBe(false);

--- a/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
+++ b/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
@@ -2,21 +2,9 @@ import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
 
-vi.mock('@tanstack/react-start', () => {
-  return {
-    createServerFn: () => {
-      const chain = {
-        inputValidator() {
-          return chain;
-        },
-        handler(handler: (...args: Array<any>) => Promise<any> | any) {
-          return async (...args: Array<any>) => await handler(...args);
-        },
-      };
-
-      return chain;
-    },
-  };
+vi.mock('@tanstack/react-start', async () => {
+  const { mockTanstackReactStart } = await import('@konfigyr/test/helpers/mocks/tanstack-react-start');
+  return mockTanstackReactStart();
 });
 
 function deferred<T>() {

--- a/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
+++ b/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
@@ -1,5 +1,5 @@
 import { act, renderHook, waitFor } from '@testing-library/react';
-import { describe, expect, test } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { useConfigFileParser } from '@konfigyr/hooks/vault/config-file-parser';
 
 function deferred<T>() {
@@ -20,6 +20,10 @@ const mockFile = (name: string, text: string | Promise<string>): File => {
 };
 
 describe('hooks | vault | useConfigFileParser', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('should expose ready state by default', () => {
     const { result } = renderHook(() => useConfigFileParser());
 
@@ -212,5 +216,73 @@ describe('hooks | vault | useConfigFileParser', () => {
     expect(result.current.isParsing).toBe(false);
     expect(result.current.isError).toBe(false);
     expect(result.current.isReady).toBe(true);
+  });
+
+  test('should fetch config from config server and merge propertySources in one object', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        propertySources: [
+          { name: 'high', source: { 'feature.flag': true } },
+          { name: 'low', source: { 'feature.flag': false, 'service.name': 'api' } },
+        ],
+      }),
+    } as Response);
+
+    const { result } = renderHook(() => useConfigFileParser());
+
+    await act(async () => {
+      await result.current.fetchConfig('user', 'password', 'https://config.example.test');
+    });
+
+    expect(result.current.properties).toMatchObject([
+      { name: 'feature.flag', value: { encoded: 'true', decoded: 'true' } },
+      { name: 'service.name', value: { encoded: 'api', decoded: 'api' } },
+    ]);
+    expect(result.current.error).toBeUndefined();
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isReady).toBe(true);
+  });
+
+  test('should expose error when config server response does not contain propertySources', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ name: 'broken-payload' }),
+    } as Response);
+
+    const { result } = renderHook(() => useConfigFileParser());
+
+    await act(async () => {
+      await result.current.fetchConfig('user', 'pass', 'https://config.example.test');
+    });
+
+    expect(result.current.properties).toStrictEqual([]);
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.message).toContain('Invalid configuration response: missing propertySources');
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isReady).toBe(false);
+  });
+
+  test('should expose error when Config Server request returns 401', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: () => Promise.resolve({}),
+    } as Response);
+
+    const { result } = renderHook(() => useConfigFileParser());
+
+    await act(async () => {
+      await result.current.fetchConfig('user', 'wrong-password', 'https://config.example.test');
+    });
+
+    expect(result.current.properties).toStrictEqual([]);
+    expect(result.current.error).toBeDefined();
+    expect(result.current.error?.message).toBe('Failed to fetch configuration: 401');
+    expect(result.current.isParsing).toBe(false);
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isReady).toBe(false);
   });
 });

--- a/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
+++ b/konfigyr-frontend/test/hooks/vault/config-file-parser.test.tsx
@@ -232,7 +232,11 @@ describe('hooks | vault | useConfigFileParser', () => {
     const { result } = renderHook(() => useConfigFileParser());
 
     await act(async () => {
-      await result.current.fetchConfig('user', 'password', 'https://config.example.test');
+      await result.current.fetchConfig({
+        username: 'user',
+        password: 'password',
+        configServerUrl: 'https://config.example.test',
+      });
     });
 
     expect(result.current.properties).toMatchObject([
@@ -254,7 +258,11 @@ describe('hooks | vault | useConfigFileParser', () => {
     const { result } = renderHook(() => useConfigFileParser());
 
     await act(async () => {
-      await result.current.fetchConfig('user', 'pass', 'https://config.example.test');
+      await result.current.fetchConfig({
+        username: 'user',
+        password: 'pass',
+        configServerUrl: 'https://config.example.test',
+      });
     });
 
     expect(result.current.properties).toStrictEqual([]);
@@ -275,7 +283,11 @@ describe('hooks | vault | useConfigFileParser', () => {
     const { result } = renderHook(() => useConfigFileParser());
 
     await act(async () => {
-      await result.current.fetchConfig('user', 'wrong-password', 'https://config.example.test');
+      await result.current.fetchConfig({
+        username: 'user',
+        password: 'wrong-password',
+        configServerUrl: 'https://config.example.test',
+      });
     });
 
     expect(result.current.properties).toStrictEqual([]);


### PR DESCRIPTION
- Added API-based properties import using Spring Cloud Config
- Extended `PropertiesImportDialog` with import type tabs:
  - File import
  - API import

<img width="558" height="555" alt="Screenshot 2026-05-26 at 09 02 35" src="https://github.com/user-attachments/assets/ef68d696-7229-4347-acf4-cb3bd22a638f" />
