### PR TITLE
Introduce Claude Code skills and agents system

### DIFF
--- a/.claude/agents/backend-engineer.md
+++ b/.claude/agents/backend-engineer.md
@@ -1,0 +1,183 @@
+# Backend Engineer Agent
+
+**Role:** Orchestrates development of `konfigyr-api` or `konfigyr-identity` Gradle modules using
+Spring Modulith, jOOQ, and DDD patterns.
+
+**When to invoke:**
+```
+/agent backend-engineer
+```
+
+**What this loads:**
+- `/skill spring-modulith-ddd` — Module creation, domain modeling, service interfaces
+- `/skill jooq-queries` — Database queries, generated code
+- `/skill liquibase-migrations` — Schema changes, migration management
+- `/skill spring-security-oauth2` — OAuth2 scopes, @RequiresScope, auth patterns
+- `/skill spring-testing` — Integration tests, unit tests, controller tests
+- `/skill entity-modeling` — Aggregates, value objects, builders
+- `/skill cross-module-events` — Event publishing, listeners, domain events
+
+---
+
+## Workflow: Adding a New Feature to konfigyr-api
+
+### Phase 1: Understand the Domain
+
+**Ask yourself:**
+- Which module owns this feature? (namespace, vault, audit, kms, etc.)
+- Is this a new aggregate or an operation on an existing one?
+- Which other modules need to react to this change? (cross-module dependencies)
+
+**Load:** `/skill project-overview` (if unsure about domains)
+
+### Phase 2: Design the Domain Model
+
+**Steps:**
+1. Define the aggregate root (record with Builder)
+2. Define value objects (records, immutable)
+3. Define domain exceptions
+4. Define the service interface (e.g., `NamespaceManager`)
+
+**Load:** `/skill entity-modeling` (for aggregate patterns, builders, validation)
+
+**Verification:**
+- [ ] All domain objects are immutable records
+- [ ] Builder validates invariants in `build()`
+- [ ] No Spring or jOOQ types in domain layer
+- [ ] Compiler errors only? (not logical errors)
+
+### Phase 3: Design Database Schema
+
+**Steps:**
+1. Sketch the tables needed for this aggregate
+2. Create Liquibase changeset (XML format)
+3. Run `./gradlew generateJooq` to regenerate table classes
+
+**Load:** `/skill liquibase-migrations` (for schema design, changeset format)
+
+**Verification:**
+- [ ] Changeset compiles (valid XML, correct changeSet IDs)
+- [ ] `./gradlew generateJooq` runs without errors
+- [ ] Generated jOOQ classes imported in IDE
+- [ ] Constraints match business rules (unique, foreign keys, NOT NULL)
+
+### Phase 4: Implement Service
+
+**Steps:**
+1. Create service interface (e.g., `NamespaceManager`, `@Repository`)
+2. Create `Default<Name>` implementation (package-private, jOOQ-aware)
+3. Implement CRUD + business logic methods
+4. Publish domain events on state changes
+5. Create `{Module}AutoConfiguration` to wire beans
+
+**Load:** `/skill spring-modulith-ddd` (for service patterns, @Repository, AutoConfiguration)
+
+**Verification:**
+- [ ] Service interface is public, implementation is package-private
+- [ ] DSLContext only used inside `Default<Name>`, never leaked
+- [ ] Domain events published via `ApplicationEventPublisher`
+- [ ] No circular dependencies between modules
+- [ ] AutoConfiguration auto-wires all beans
+
+### Phase 5: Create REST Endpoint
+
+**Steps:**
+1. Create controller in `controller/` subpackage (package-private)
+2. Add `@RequiresScope` annotation for authorization
+3. Validate input with `@Valid`
+4. Delegate to service interface
+5. Map response to DTO (never return domain objects directly)
+
+**Load:** `/skill spring-security-oauth2` (for @RequiresScope patterns, scope hierarchy)
+
+**Verification:**
+- [ ] Controller is package-private, in `controller/` subpackage
+- [ ] Request/response are DTOs, not domain objects
+- [ ] `@RequiresScope` enforces OAuth2 scope requirement
+- [ ] 4xx/5xx error responses documented in OpenAPI comments
+
+### Phase 6: Write Tests
+
+**Steps:**
+1. Write domain unit tests (no database, no Spring)
+2. Write integration tests (service + database, extends `AbstractIntegrationTest`)
+3. Write controller tests (MockMvc, extends `AbstractControllerTest`)
+4. Verify cross-module events are published
+
+**Load:** `/skill spring-testing` (for test base classes, patterns, assertions)
+
+**Verification:**
+- [ ] All tests use Arrange-Act-Assert pattern
+- [ ] Integration tests assert both domain behavior AND database state
+- [ ] Controller tests verify auth (with/without `@RequiresScope`)
+- [ ] Event tests use `AssertablePublishedEvents`
+- [ ] `./gradlew test` passes, no skipped tests
+
+### Phase 7: Cross-Module Integration
+
+**Steps:**
+1. If another module needs to react to your domain event, add a listener
+2. Use `@TransactionalEventListener` (fires after commit, safer)
+3. Document the cross-module dependency in the listener code
+
+**Load:** `/skill cross-module-events` (for event patterns, listener conventions)
+
+**Verification:**
+- [ ] Event listeners use `@TransactionalEventListener`, not `@EventListener`
+- [ ] Listener is in the listening module, not the publishing module
+- [ ] No circular event dependencies (Module A → B → A)
+- [ ] Event documentation explains why Module B cares about Module A's event
+
+### Phase 8: Final Verification
+
+```
+./gradlew clean build --dry-run     # Code compiles
+./gradlew generateJooq              # Regenerate jOOQ (if schema changed)
+./gradlew test                       # All tests pass
+```
+
+**Checklist:**
+- [ ] Code compiles without warnings
+- [ ] All tests pass (unit + integration + controller)
+- [ ] No `@Value`, only `@ConfigurationProperties`
+- [ ] No Lombok on domain objects (OK on implementation classes)
+- [ ] No hardcoded strings for environment config
+- [ ] Cross-module dependencies documented
+- [ ] Git commits are logical and clear
+- [ ] Code simpler than when I started
+
+---
+
+## Key Do's and Don'ts
+
+### Do
+
+✅ Define aggregates first, then figure out storage  
+✅ Keep domain objects immutable (records + builders)  
+✅ Use jOOQ's fluent API, never raw SQL strings  
+✅ Publish domain events for cross-module side effects  
+✅ Keep DSLContext inside `Default<Name>` implementations  
+✅ Use `@RequiresScope` to protect endpoints  
+✅ Test at three levels: unit (domain), integration (service), controller (API)
+
+### Don't
+
+❌ Expose DSLContext to controllers or other modules  
+❌ Use `@Value("${property.name}")` — use `@ConfigurationProperties` instead  
+❌ Add Lombok to domain objects (records are explicit enough)  
+❌ Skip running `generateJooq` after schema changes  
+❌ Create interfaces for single implementations  
+❌ Fetch related entities in a loop (N+1 problem)  
+❌ Directly call another module's service — publish an event instead
+
+---
+
+## When to Ask for Help
+
+- "What are the aggregate boundaries for this feature?"
+- "Which module should this logic live in?"
+- "Should this be a separate domain event or part of an existing one?"
+- "Is this schema design normalized correctly?"
+- "Does this cross-module dependency create a cycle?"
+
+These are architecture questions — ask upfront, not after coding!

--- a/.claude/agents/frontend-engineer.md
+++ b/.claude/agents/frontend-engineer.md
@@ -1,0 +1,223 @@
+# Frontend Engineer Agent
+
+**Role:** Orchestrates development of `konfigyr-frontend` using React 19, TanStack Start, and TanStack Query.
+
+**When to invoke:**
+```
+/agent frontend-engineer
+```
+
+**What this loads:**
+- `/skill tanstack-routing` — File-based routes, loaders, navigation
+- `/skill tanstack-queries` — Data fetching, caching, query keys
+- `/skill react-components` — Component patterns, props, conventions
+- `/skill tailwind-styling` — Tailwind utilities, CSS variables, dark mode
+- `/skill oidc-authentication` — Session, token management, auth flows
+- `/skill frontend-testing` — Testing components, hooks, routes with MSW
+- `/skill form-handling` — TanStack Form patterns
+
+---
+
+## Workflow: Adding a New Feature to konfigyr-frontend
+
+### Phase 1: Understand the Page/Feature
+
+**Ask yourself:**
+- What is the user doing? (reading, creating, updating, deleting config)
+- Which API endpoints do we need? (GET /api/..., POST /api/...)
+- Does this require authentication? (almost everything does)
+- What are the loading, success, and error states?
+
+**Load:** `/skill project-overview` (if unsure about domains and API contracts)
+
+### Phase 2: Design the Route Structure
+
+**Steps:**
+1. Decide where the page lives in `src/routes/`
+2. Determine if it needs a loader (prefetch data server-side)
+3. Plan the URL structure (nested routes, dynamic segments)
+4. Identify any form handlers needed (-handler.ts files)
+
+**Load:** `/skill tanstack-routing` (for file-based routing conventions, loaders)
+
+**Verification:**
+- [ ] Route file path reflects URL structure
+- [ ] Loader is defined if page shows prefetched data
+- [ ] Dynamic segments use `$param` convention
+- [ ] Form handlers are colocated with their routes
+
+### Phase 3: Design Data Fetching (Query Hooks)
+
+**Steps:**
+1. Identify all API endpoints needed (GET /api/..., POST /api/...)
+2. Create query options factories in `src/hooks/<domain>/query.ts`
+3. Create mutation hooks for state changes
+4. Plan query key structure and invalidation strategy
+
+**Load:** `/skill tanstack-queries` (for query options, mutations, cache keys)
+
+**Verification:**
+- [ ] Query keys are unique and hierarchical (e.g., `['namespace', slug]`)
+- [ ] All queries have a `staleTime` set (defaults: read-only = `Infinity`, mutable = `0`)
+- [ ] Mutations invalidate/update relevant queries on success
+- [ ] No direct `ky` or `fetch` calls outside `src/lib/http.ts`
+
+### Phase 4: Build the Component
+
+**Steps:**
+1. Create component file in `src/components/<domain>/`
+2. Define TypeScript interface for props
+3. Use `useSuspenseQuery` for prefetched data, `useQuery` for client-side
+4. Handle loading/error states (usually wrapped in Suspense/Error boundary)
+5. Use Tailwind utilities + design tokens (CSS variables) for styling
+
+**Load:** `/skill react-components` (for component conventions, data fetching)
+
+**Load:** `/skill tailwind-styling` (for styling patterns, design tokens)
+
+**Verification:**
+- [ ] Component has TypeScript interface for props
+- [ ] No `export default` (named exports only)
+- [ ] Data fetching via hooks, not inline `ky` calls
+- [ ] Styling uses Tailwind utilities + CSS custom properties
+- [ ] Dark mode supported (use `dark:` variants)
+
+### Phase 5: Handle Forms & Mutations
+
+**Steps:**
+1. If form needed: create TanStack Form hook
+2. Define form schema (validation rules)
+3. Create mutation hook for submit handler
+4. Wire form to the route's `-handler.ts` file
+5. Validate on both client and server
+
+**Load:** `/skill form-handling` (for TanStack Form patterns, validation)
+
+**Verification:**
+- [ ] Form uses TanStack Form (not HTML form elements)
+- [ ] Validation is schema-based (e.g., Zod)
+- [ ] Mutation is triggered by form submission
+- [ ] Error states displayed to user
+- [ ] Loading state shows during submit
+
+### Phase 6: Authentication & Authorization
+
+**Steps:**
+1. Check: does user need specific role to see this page?
+2. If protected: use `<AccountProvider>` (already in `_authenticated` layout)
+3. Access current user: `const account = useAccount()`
+4. Pass auth token: automatically attached to all `/api/*` calls
+5. Handle 401/403 responses (middleware redirects or component hides feature)
+
+**Load:** `/skill oidc-authentication` (for session, token, access patterns)
+
+**Verification:**
+- [ ] Page is inside `_authenticated` layout if protected
+- [ ] No tokens accessed directly (middleware handles it)
+- [ ] `useAccount()` used only inside `AccountProvider`
+- [ ] 403 errors handled gracefully (show "access denied" or hide feature)
+
+### Phase 7: Write Tests
+
+**Steps:**
+1. Write hook tests (renderHook, MSW intercepts API calls)
+2. Write component tests (render, screen.find, fireEvent)
+3. Write route tests (createRouter, navigating between pages)
+4. Mock API responses via MSW handlers in `test/msw/handlers.ts`
+
+**Load:** `/skill frontend-testing` (for test utilities, MSW patterns)
+
+**Verification:**
+- [ ] No real API calls made (MSW intercepts all)
+- [ ] Tests use `createWrapper()` and `createRouter()` utilities
+- [ ] Component tests assert UI state (buttons, text, forms)
+- [ ] Async data loading awaited with `waitFor`
+- [ ] `npm run test:ci` passes (lint + type-check + coverage)
+
+### Phase 8: Styling Polish
+
+**Steps:**
+1. Apply Tailwind utilities for layout (flexbox, grid, spacing)
+2. Use CSS variables for colors (`bg-primary`, `text-destructive`)
+3. Add dark mode support (`dark:bg-slate-900`)
+4. Test on mobile (responsive design)
+5. Ensure accessibility (contrast, focus states)
+
+**Load:** `/skill tailwind-styling` (for design tokens, responsive, dark mode)
+
+**Verification:**
+- [ ] All colors use CSS custom properties (no hardcoded colors)
+- [ ] Dark mode works (`dark:` variants)
+- [ ] Mobile responsive (no fixed widths breaking layout)
+- [ ] Focus states visible (keyboard navigation)
+- [ ] Contrast ratios meet WCAG AA
+
+### Phase 9: Final Verification
+
+```
+npm run lint              # ESLint check
+npm run test:ci          # Type-check + lint + tests
+npm run build            # Production build succeeds
+```
+
+**Checklist:**
+- [ ] No TypeScript `any` types without comments
+- [ ] All imports use aliases (`@konfigyr/components`, etc.)
+- [ ] No `ky` imports outside `src/lib/http.ts`
+- [ ] No environment secrets in client code
+- [ ] Tests pass with coverage
+- [ ] Build succeeds (no warnings)
+- [ ] Dark mode works
+- [ ] Mobile responsive
+
+---
+
+## Key Do's and Don'ts
+
+### Do
+
+✅ Use file-based routes (`src/routes/`)  
+✅ Fetch data through query hooks, never direct `ky` calls  
+✅ Use `useSuspenseQuery` in route components (loader pre-fetches)  
+✅ Validate forms with TanStack Form + schema  
+✅ Style with Tailwind utilities + CSS custom properties  
+✅ Use `cn()` for conditional class merging  
+✅ Test with MSW (Mock Service Worker) — no real API calls  
+✅ Keep components small and focused
+
+### Don't
+
+❌ Import `ky` directly (always use `src/lib/http.ts`)  
+❌ Use `export default` (named exports only)  
+❌ Access tokens directly (middleware handles it)  
+❌ Call API without going through hooks  
+❌ Hardcode colors (use CSS custom properties)  
+❌ Skip dark mode support (`dark:` variants)  
+❌ Use `any` types in TypeScript  
+❌ Disable form validation
+
+---
+
+## TanStack Routing Quick Reference
+
+| Pattern | Meaning |
+|---------|---------|
+| `index.tsx` | `/` for that path segment |
+| `$param.tsx` | Dynamic segment (e.g., `$namespace` = `/namespace/:namespace`) |
+| `-handler.ts` | Form submission handler (POST, PATCH) |
+| `_authenticated/route.tsx` | Pathless layout wrapping children with `AccountProvider` |
+| `api/$.ts` | Catch-all proxy to backend REST API |
+| `loader: ({ context, params })` | Prefetch data before rendering page |
+
+---
+
+## When to Ask for Help
+
+- "What are the aggregate boundaries for this feature?" (ask backend engineer)
+- "Should this be a new page or part of an existing one?"
+- "How should this form integrate with the backend API?"
+- "What should the query key structure be for cache invalidation?"
+- "Is this styled correctly for dark mode?"
+- "Should we prefetch this data in the loader?"
+
+These are design/architecture questions — ask upfront, not after coding!

--- a/.claude/skills/backend/cross-module-events/SKILL.md
+++ b/.claude/skills/backend/cross-module-events/SKILL.md
@@ -1,0 +1,648 @@
+---
+name: cross-module-events
+description: Publishing domain events between modules, listening to events with @TransactionalEventListener, sealed event class hierarchies, and event-driven communication. Use when features span multiple modules or need decoupled side effects.
+---
+
+# Cross-Module Events
+
+## Overview
+
+Modules communicate through domain events, not direct service calls. This keeps modules loosely coupled and enables features to react to state changes in other modules.
+
+**Example:** When a namespace is created in the `namespace` module, the `audit` module listens and logs the creation. They don't know about each other directly.
+
+---
+
+## Domain Events (Sealed Classes)
+
+Domain events are sealed class hierarchies representing state changes. Each module publishes events from its domain.
+
+### Basic Event Hierarchy
+
+```java
+// namespace/NamespaceEvent.java
+public abstract sealed class NamespaceEvent extends EntityEvent implements Supplier<Namespace>
+        permits NamespaceEvent.Created, 
+                NamespaceEvent.Renamed, 
+                NamespaceEvent.Deleted,
+                NamespaceEvent.StatusChanged {
+
+    private final Namespace namespace;
+
+    protected NamespaceEvent(Namespace namespace) {
+        super(namespace.id());
+        this.namespace = namespace;
+    }
+
+    @Override
+    public Namespace get() { 
+        return namespace; 
+    }
+
+    // ===== Created Event =====
+    @DomainEvent(name = "created", namespace = "namespaces")
+    public static final class Created extends NamespaceEvent {
+        public Created(Namespace namespace) { 
+            super(namespace); 
+        }
+    }
+
+    // ===== Renamed Event =====
+    @DomainEvent(name = "renamed", namespace = "namespaces")
+    public static final class Renamed extends NamespaceEvent {
+        private final Slug from;
+        private final Slug to;
+
+        public Renamed(Namespace namespace, Slug from, Slug to) {
+            super(namespace);
+            this.from = from;
+            this.to = to;
+        }
+
+        public Slug from() { return from; }
+        public Slug to() { return to; }
+    }
+
+    // ===== Deleted Event =====
+    @DomainEvent(name = "deleted", namespace = "namespaces")
+    public static final class Deleted extends NamespaceEvent {
+        public Deleted(Namespace namespace) { 
+            super(namespace); 
+        }
+    }
+
+    // ===== Status Changed Event =====
+    @DomainEvent(name = "statusChanged", namespace = "namespaces")
+    public static final class StatusChanged extends NamespaceEvent {
+        private final NamespaceStatus from;
+        private final NamespaceStatus to;
+
+        public StatusChanged(Namespace namespace, NamespaceStatus from, NamespaceStatus to) {
+            super(namespace);
+            this.from = from;
+            this.to = to;
+        }
+
+        public NamespaceStatus from() { return from; }
+        public NamespaceStatus to() { return to; }
+    }
+}
+```
+
+### Base Event Class
+
+```java
+// shared/EntityEvent.java
+public abstract class EntityEvent implements ApplicationEvent {
+    private final EntityId entityId;
+    private final Instant timestamp;
+
+    protected EntityEvent(EntityId entityId) {
+        this.entityId = entityId;
+        this.timestamp = Instant.now();
+    }
+
+    public EntityId getEntityId() {
+        return entityId;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+}
+```
+
+---
+
+## Publishing Events
+
+Publish events from the service implementation using `ApplicationEventPublisher`:
+
+```java
+// namespace/DefaultNamespaceManager.java
+@Slf4j
+@RequiredArgsConstructor
+class DefaultNamespaceManager implements NamespaceManager {
+
+    private final DSLContext context;
+    private final ApplicationEventPublisher publisher;
+
+    @Override
+    @Transactional(label = "namespace-create")
+    public Namespace create(@NonNull NamespaceDefinition definition) {
+        // Create namespace in database
+        Namespace namespace = context.insertInto(NAMESPACES)
+                .set(NAMESPACES.SLUG, definition.slug().get())
+                .set(NAMESPACES.NAME, definition.name())
+                .returning(NAMESPACES.fields())
+                .fetchOne(DefaultNamespaceManager::toNamespace);
+
+        Assert.state(namespace != null, "Failed to insert namespace");
+
+        // ===== Publish Event =====
+        publisher.publishEvent(new NamespaceEvent.Created(namespace));
+
+        return namespace;
+    }
+
+    @Override
+    @Transactional(label = "namespace-rename")
+    public Namespace rename(@NonNull String slug, @NonNull String newName) {
+        Namespace existing = findBySlug(slug)
+                .orElseThrow(() -> new NamespaceNotFoundException(slug));
+
+        // Update database
+        Namespace updated = context.update(NAMESPACES)
+                .set(NAMESPACES.NAME, newName)
+                .set(NAMESPACES.UPDATED_AT, OffsetDateTime.now())
+                .where(NAMESPACES.SLUG.eq(slug))
+                .returning(NAMESPACES.fields())
+                .fetchOne(DefaultNamespaceManager::toNamespace);
+
+        Assert.state(updated != null, "Failed to update namespace");
+
+        // ===== Publish Event with Details =====
+        publisher.publishEvent(
+                new NamespaceEvent.Renamed(updated, Slug.of(slug), Slug.of(newName))
+        );
+
+        return updated;
+    }
+
+    @Override
+    @Transactional(label = "namespace-delete")
+    public void delete(@NonNull String slug) {
+        Namespace existing = findBySlug(slug)
+                .orElseThrow(() -> new NamespaceNotFoundException(slug));
+
+        context.deleteFrom(NAMESPACES)
+                .where(NAMESPACES.SLUG.eq(slug))
+                .execute();
+
+        // ===== Publish Event =====
+        publisher.publishEvent(new NamespaceEvent.Deleted(existing));
+    }
+}
+```
+
+---
+
+## Listening to Events
+
+Listen to events in other modules using `@TransactionalEventListener`:
+
+### @TransactionalEventListener (Recommended)
+
+Fires AFTER the publishing transaction commits. Safer for side effects:
+
+```java
+// audit/AuditEventListener.java
+@Slf4j
+@RequiredArgsConstructor
+@Component
+class AuditEventListener {
+
+    private final AuditEventRepository auditEventRepository;
+
+    @TransactionalEventListener(
+            id = "audit.namespace-created",
+            classes = NamespaceEvent.Created.class
+    )
+    public void on(NamespaceEvent.Created event) {
+        log.info("Namespace created: {}", event.get().slug());
+
+        AuditEvent auditEvent = AuditEvent.builder()
+                .entityType("namespace")
+                .entityId(event.getEntityId())
+                .eventType("namespace.created")
+                .actionType("CREATE")
+                .timestamp(event.getTimestamp())
+                .details(
+                        Map.of(
+                                "slug", event.get().slug(),
+                                "name", event.get().name()
+                        )
+                )
+                .build();
+
+        auditEventRepository.insert(auditEvent);
+    }
+
+    @TransactionalEventListener(
+            id = "audit.namespace-deleted",
+            classes = NamespaceEvent.Deleted.class
+    )
+    public void on(NamespaceEvent.Deleted event) {
+        log.info("Namespace deleted: {}", event.get().slug());
+
+        AuditEvent auditEvent = AuditEvent.builder()
+                .entityType("namespace")
+                .entityId(event.getEntityId())
+                .eventType("namespace.deleted")
+                .actionType("DELETE")
+                .timestamp(event.getTimestamp())
+                .details(Map.of("slug", event.get().slug()))
+                .build();
+
+        auditEventRepository.insert(auditEvent);
+    }
+}
+```
+
+### @EventListener (Use When Not in Transaction)
+
+Fires immediately, even if publishing transaction fails. Use for fire-and-forget operations:
+
+```java
+// notification/NotificationEventListener.java
+@Slf4j
+@RequiredArgsConstructor
+@Component
+class NotificationEventListener {
+
+    private final Mailer mailer;
+
+    // Use when you want to send email regardless of transaction
+    @EventListener(classes = NamespaceEvent.Created.class)
+    public void on(NamespaceEvent.Created event) {
+        // This fires immediately, not after transaction commits
+        Namespace ns = event.get();
+        
+        try {
+            mailer.send(Mail.builder()
+                    .to(ns.owner().email())
+                    .subject("Namespace Created: " + ns.name())
+                    .template("namespace-created")
+                    .context(Map.of("namespace", ns))
+                    .build()
+            );
+        } catch (Exception e) {
+            log.error("Failed to send namespace notification", e);
+            // Don't throw: failure to send email shouldn't fail the operation
+        }
+    }
+}
+```
+
+---
+
+## Event Listener Patterns
+
+### Listen to Multiple Event Types
+
+```java
+@Component
+class MetricsListener {
+
+    @TransactionalEventListener
+    public void on(NamespaceEvent.Created event) {
+        metrics.recordCreated("namespace");
+    }
+
+    @TransactionalEventListener
+    public void on(NamespaceEvent.Deleted event) {
+        metrics.recordDeleted("namespace");
+    }
+
+    @TransactionalEventListener
+    public void on(VaultEvent.Created event) {
+        metrics.recordCreated("vault");
+    }
+}
+```
+
+### Conditional Listening
+
+```java
+@Component
+class NotificationListener {
+
+    @TransactionalEventListener(
+            condition = "@featureFlags.isEnabled('send-notifications')"
+    )
+    public void on(NamespaceEvent.Created event) {
+        // Only listen if feature flag is enabled
+        sendNotification(event);
+    }
+}
+```
+
+### Async Event Processing
+
+```java
+@Component
+class AsyncProcessingListener {
+
+    private final TaskScheduler taskScheduler;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void on(NamespaceEvent.Created event) {
+        // Schedule async task after transaction commits
+        taskScheduler.schedule(
+                () -> processNamespaceAsync(event),
+                Instant.now().plusSeconds(5)
+        );
+    }
+
+    private void processNamespaceAsync(NamespaceEvent.Created event) {
+        // Heavy lifting happens here, outside transaction
+        log.info("Processing namespace async: {}", event.get().slug());
+    }
+}
+```
+
+---
+
+## Testing Domain Events
+
+### Assert Event Published
+
+```java
+@Test
+void shouldPublishNamespaceCreatedEvent(AssertablePublishedEvents events) {
+    // Arrange
+    NamespaceDefinition definition = NamespaceDefinition.builder()
+            .owner(EntityId.from(1L))
+            .slug("test")
+            .name("Test")
+            .build();
+
+    // Act
+    Namespace created = manager.create(definition);
+
+    // Assert
+    events.assertThat()
+            .contains(NamespaceEvent.Created.class)
+            .matching(event -> event.get().id().equals(created.id()));
+}
+```
+
+### Assert Event Listener Triggered
+
+```java
+@Test
+void shouldLogAuditEventWhenNamespaceCreated(
+        AssertablePublishedEvents events,
+        AuditEventRepository auditRepository) {
+
+    // Arrange
+    NamespaceDefinition definition = NamespaceDefinition.builder()
+            .owner(EntityId.from(1L))
+            .slug("test")
+            .name("Test")
+            .build();
+
+    // Act
+    Namespace created = manager.create(definition);
+
+    // Assert - Event published
+    events.assertThat()
+            .contains(NamespaceEvent.Created.class);
+
+    // Assert - Listener executed and audit record created
+    List<AuditEvent> auditLogs = auditRepository.findByEntityId(created.id());
+    assertThat(auditLogs)
+            .isNotEmpty()
+            .anyMatch(log -> log.getEventType().equals("namespace.created"));
+}
+```
+
+### Test Event Listener in Isolation
+
+```java
+@Test
+void shouldCreateAuditEventOnNamespaceCreated() {
+    // Arrange
+    Namespace namespace = Namespace.builder()
+            .id(EntityId.from(1L))
+            .slug("test")
+            .name("Test")
+            .build();
+
+    NamespaceEvent.Created event = new NamespaceEvent.Created(namespace);
+
+    // Act
+    auditListener.on(event);
+
+    // Assert
+    then(auditRepository).should().insert(argThat(audit ->
+            audit.getEventType().equals("namespace.created") &&
+            audit.getEntityId().equals(EntityId.from(1L))
+    ));
+}
+```
+
+---
+
+## Event Sourcing Considerations
+
+If you later want event sourcing, design events now:
+
+```java
+// Make events self-contained (can be replayed)
+@DomainEvent(name = "created", namespace = "namespaces")
+public static final class Created extends NamespaceEvent {
+    public Created(Namespace namespace) { 
+        super(namespace); 
+    }
+    
+    // Include all data needed to reconstruct state
+    // Don't rely on external services to fill in details
+}
+
+// Snapshot structure if needed later
+public record NamespaceSnapshot(
+        Namespace namespace,
+        OffsetDateTime snapshotTime,
+        List<NamespaceEvent> eventsSinceSnapshot
+) { }
+```
+
+---
+
+## Event Ordering & Guarantees
+
+### Ordering Within Same Module
+
+Events published in the same transaction execute in order:
+
+```java
+@Transactional
+public void renameAndArchive(String slug, String newName) {
+    // These happen in order
+    manager.rename(slug, newName);  // Fires Renamed event
+    manager.archive(slug);          // Fires Archived event
+}
+```
+
+### Cross-Module Ordering
+
+No guaranteed order between events from different modules. Design defensively:
+
+```java
+// ✓ Good: Listeners can handle out-of-order events
+@TransactionalEventListener
+public void on(NamespaceEvent.Created event) {
+    if (already exists) {
+        log.debug("Already processed this event");
+        return;
+    }
+    process(event);
+}
+
+// ✗ Bad: Assumes specific order
+@TransactionalEventListener
+public void on(NamespaceEvent.Deleted event) {
+    // Assumes Renamed event fired before this
+    // Not guaranteed!
+}
+```
+
+---
+
+## Common Patterns
+
+### Saga Pattern (Multi-Step Process)
+
+```java
+// vault/VaultCreatedSaga.java
+@Component
+class VaultCreatedSaga {
+
+    @TransactionalEventListener
+    public void on(VaultEvent.Created event) {
+        Vault vault = event.get();
+        
+        // Step 1: Initialize vault
+        initializeVault(vault);
+        
+        // Step 2: Create default profile
+        publisher.publishEvent(new VaultEvent.DefaultProfileCreated(vault));
+    }
+}
+
+// audit/VaultAuditListener.java
+@Component
+class VaultAuditListener {
+
+    @TransactionalEventListener
+    public void on(VaultEvent.DefaultProfileCreated event) {
+        // Reacts to the saga step
+        logAuditEvent("vault.default-profile-created", event.get());
+    }
+}
+```
+
+### Dead Letter Queue Pattern
+
+```java
+@Component
+class ReliableEventListener {
+
+    private final DeadLetterQueue deadLetterQueue;
+
+    @TransactionalEventListener
+    public void on(NamespaceEvent.Created event) {
+        try {
+            processNamespace(event);
+        } catch (Exception e) {
+            log.error("Failed to process event", e);
+            deadLetterQueue.enqueue(event);  // Retry later
+        }
+    }
+}
+```
+
+---
+
+## Common Mistakes
+
+### ❌ Direct Service Call Instead of Event
+
+```java
+// ✗ Wrong: Tight coupling
+class NamespaceManager {
+    private final AuditLogger auditLogger;
+    
+    public Namespace create(NamespaceDefinition def) {
+        Namespace ns = // ... create
+        auditLogger.log("Created", ns);  // Direct call!
+        return ns;
+    }
+}
+
+// ✓ Correct: Event-driven
+class NamespaceManager {
+    private final ApplicationEventPublisher publisher;
+    
+    public Namespace create(NamespaceDefinition def) {
+        Namespace ns = // ... create
+        publisher.publishEvent(new NamespaceEvent.Created(ns));
+        return ns;
+    }
+}
+```
+
+### ❌ Using @EventListener When Transaction Needed
+
+```java
+// ✗ Wrong: Event fires even if transaction rolls back
+@EventListener
+public void on(NamespaceEvent.Created event) {
+    database.insert(...);  // May not persist if tx rolls back
+}
+
+// ✓ Correct: Ensure event fires only after commit
+@TransactionalEventListener
+public void on(NamespaceEvent.Created event) {
+    database.insert(...);  // Guaranteed to run after commit
+}
+```
+
+### ❌ Circular Event Publishing
+
+```java
+// ✗ Wrong: A publishes event that B listens to, B publishes event that A listens to
+class AListener {
+    @TransactionalEventListener
+    public void on(BEvent.Created event) {
+        publisher.publishEvent(new AEvent.Created(...));  // Cycle!
+    }
+}
+
+class BListener {
+    @TransactionalEventListener
+    public void on(AEvent.Created event) {
+        publisher.publishEvent(new BEvent.Created(...));  // Cycle!
+    }
+}
+
+// ✓ Correct: Avoid cycles, use saga pattern for multi-step processes
+```
+
+---
+
+## Verification Checklist
+
+- [ ] All state changes publish events
+- [ ] Events are sealed classes with specific subtypes
+- [ ] Events include all data needed by listeners
+- [ ] Listeners use `@TransactionalEventListener` (not `@EventListener`)
+- [ ] Listeners are in the listening module, not publishing module
+- [ ] No circular event dependencies
+- [ ] Event listeners tested in isolation
+- [ ] Events tested with integration tests
+- [ ] Error handling in listeners (don't let listener failure fail main operation)
+- [ ] No direct service calls between modules (events only)
+- [ ] Listeners are idempotent (can handle same event twice)
+
+---
+
+## When to Ask for Help
+
+- "Should this be an event or a direct service call?"
+- "What data should this event include?"
+- "How do I handle event listener failures?"
+- "Is there a circular dependency in my events?"
+- "Should I use @EventListener or @TransactionalEventListener?"
+- "How do I test this event-driven feature?"

--- a/.claude/skills/backend/entity-modeling/SKILL.md
+++ b/.claude/skills/backend/entity-modeling/SKILL.md
@@ -1,0 +1,580 @@
+---
+name: entity-modeling
+description: Designing and implementing domain objects as immutable records, creating value objects, building aggregates with validation, and understanding aggregate boundaries. Use when designing new domain features or refactoring domain models.
+---
+
+# Entity Modeling & Domain Objects
+
+## Core Principles
+
+**Immutability** — All domain objects are immutable. Use `record` types, never getters/setters.
+
+**Validation in Constructor** — Invariants are validated when objects are built, not later.
+
+**No Spring Annotations** — Domain objects don't know about Spring, jOOQ, or HTTP.
+
+**Builder Pattern** — Complex aggregates use inner `Builder` classes for construction.
+
+**Value Objects** — Represent domain concepts with no identity (Email, Slug, Scope). Also records.
+
+---
+
+## Aggregate Root
+
+An aggregate root is the entry point to a cluster of related objects. It enforces invariants on the whole aggregate.
+
+### Aggregate Root Record
+
+```java
+@AggregateRoot
+public record Namespace(
+        @NonNull @Identity EntityId id,
+        @NonNull String slug,
+        @NonNull String name,
+        @Nullable String description,
+        @NonNull Avatar avatar,
+        @Nullable OffsetDateTime createdAt,
+        @Nullable OffsetDateTime updatedAt
+) implements Serializable {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private EntityId id;
+        private String slug;
+        private String name;
+        private String description;
+        private Avatar avatar;
+        private OffsetDateTime createdAt;
+        private OffsetDateTime updatedAt;
+
+        // Setters
+        public Builder id(EntityId id) { this.id = id; return this; }
+        public Builder slug(String slug) { this.slug = slug; return this; }
+        public Builder name(String name) { this.name = name; return this; }
+        public Builder description(String description) { this.description = description; return this; }
+        public Builder avatar(Avatar avatar) { this.avatar = avatar; return this; }
+        public Builder createdAt(OffsetDateTime createdAt) { this.createdAt = createdAt; return this; }
+        public Builder updatedAt(OffsetDateTime updatedAt) { this.updatedAt = updatedAt; return this; }
+
+        // Build with validation
+        public Namespace build() {
+            Assert.notNull(id, "Namespace entity identifier can not be null");
+            Assert.hasText(slug, "Namespace slug can not be blank");
+            Assert.hasText(name, "Namespace name can not be blank");
+            
+            // Validate invariants
+            if (!isValidSlug(slug)) {
+                throw new IllegalArgumentException("Invalid slug format: " + slug);
+            }
+            
+            return new Namespace(id, slug, name, description, avatar, createdAt, updatedAt);
+        }
+
+        private boolean isValidSlug(String slug) {
+            return slug.matches("^[a-z0-9-]+$") && slug.length() > 0 && slug.length() <= 255;
+        }
+    }
+}
+```
+
+### Aggregate Root with Behavior
+
+Aggregates can have behavior methods (not just getters):
+
+```java
+@AggregateRoot
+public record Namespace(
+        @NonNull EntityId id,
+        @NonNull String slug,
+        @NonNull String name,
+        @NonNull NamespaceStatus status
+) implements Serializable {
+
+    public static Builder builder() { return new Builder(); }
+
+    // Behavior: transition state
+    public NamespaceEvent.StatusChanged changeStatus(NamespaceStatus newStatus) {
+        if (status == newStatus) {
+            throw new InvalidStateTransitionException("Already in " + status);
+        }
+        
+        if (status == ARCHIVED && newStatus != ACTIVE) {
+            throw new InvalidStateTransitionException("Cannot change status of archived namespace");
+        }
+
+        return new NamespaceEvent.StatusChanged(this, status, newStatus);
+    }
+
+    // Behavior: check if namespace is active
+    public boolean isActive() {
+        return status == NamespaceStatus.ACTIVE;
+    }
+
+    // ... rest of builder omitted
+}
+```
+
+---
+
+## Value Objects
+
+Value objects represent domain concepts without identity. They're compared by value, not identity.
+
+### Simple Value Objects (Single Property)
+
+```java
+@ValueObject
+public record Slug(String value) implements Serializable {
+    
+    public Slug {
+        Assert.hasText(value, "Slug cannot be blank");
+        if (!value.matches("^[a-z0-9-]+$")) {
+            throw new IllegalArgumentException("Invalid slug format: " + value);
+        }
+    }
+
+    public String get() {
+        return value;
+    }
+}
+
+@ValueObject
+public record Email(String value) implements Serializable {
+    
+    public Email {
+        Assert.hasText(value, "Email cannot be blank");
+        if (!isValidEmail(value)) {
+            throw new IllegalArgumentException("Invalid email format: " + value);
+        }
+    }
+
+    private static boolean isValidEmail(String email) {
+        return email.matches("^[A-Za-z0-9+_.-]+@(.+)$");
+    }
+}
+
+@ValueObject
+public record UserId(Long value) implements Serializable {
+    
+    public UserId {
+        Assert.notNull(value, "UserId cannot be null");
+        Assert.state(value > 0, "UserId must be positive");
+    }
+
+    public Long get() {
+        return value;
+    }
+
+    public static UserId from(Long id) {
+        return new UserId(id);
+    }
+}
+```
+
+### Complex Value Objects (Multiple Properties)
+
+```java
+@ValueObject
+public record Avatar(
+        @NonNull String url,
+        @NonNull String format,
+        Long size
+) implements Serializable {
+
+    public Avatar {
+        Assert.hasText(url, "Avatar URL cannot be blank");
+        Assert.hasText(format, "Avatar format cannot be blank");
+        
+        if (!isValidUrl(url)) {
+            throw new IllegalArgumentException("Invalid avatar URL: " + url);
+        }
+        
+        if (!isValidFormat(format)) {
+            throw new IllegalArgumentException("Invalid avatar format: " + format);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String url;
+        private String format;
+        private Long size;
+
+        public Builder url(String url) { this.url = url; return this; }
+        public Builder format(String format) { this.format = format; return this; }
+        public Builder size(Long size) { this.size = size; return this; }
+
+        public Avatar build() {
+            Assert.hasText(url, "URL is required");
+            Assert.hasText(format, "Format is required");
+            return new Avatar(url, format, size);
+        }
+    }
+
+    private static boolean isValidUrl(String url) {
+        return url.startsWith("https://") || url.startsWith("http://");
+    }
+
+    private static boolean isValidFormat(String format) {
+        return format.matches("^(png|jpg|jpeg|gif)$");
+    }
+}
+```
+
+---
+
+## Domain Commands (Value Objects as Input)
+
+Commands represent user intent. They're typically value objects passed to service methods.
+
+```java
+@ValueObject
+public record CreateNamespaceCommand(
+        @NonNull EntityId owner,
+        @NonNull Slug slug,
+        @NonNull String name,
+        @Nullable String description
+) implements Serializable {
+
+    public CreateNamespaceCommand {
+        Assert.notNull(owner, "Owner is required");
+        Assert.notNull(slug, "Slug is required");
+        Assert.hasText(name, "Name is required");
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private EntityId owner;
+        private Slug slug;
+        private String name;
+        private String description;
+
+        public Builder owner(EntityId owner) { this.owner = owner; return this; }
+        public Builder slug(Slug slug) { this.slug = slug; return this; }
+        public Builder name(String name) { this.name = name; return this; }
+        public Builder description(String description) { this.description = description; return this; }
+
+        public CreateNamespaceCommand build() {
+            return new CreateNamespaceCommand(owner, slug, name, description);
+        }
+    }
+}
+
+// Usage in service
+@Override
+public Namespace create(CreateNamespaceCommand command) {
+    // command is already validated by constructor
+    Namespace namespace = new Namespace(
+            EntityId.generate(),
+            command.slug(),
+            command.name(),
+            command.description(),
+            Avatar.empty(),
+            OffsetDateTime.now(),
+            OffsetDateTime.now()
+    );
+    return repository.save(namespace);
+}
+```
+
+---
+
+## Enums as Value Objects
+
+```java
+@ValueObject
+public enum NamespaceRole {
+    OWNER("Namespace owner with full access"),
+    ADMIN("Administrator with most permissions"),
+    MEMBER("Regular member with read access"),
+    VIEWER("Read-only access");
+
+    private final String description;
+
+    NamespaceRole(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public boolean canDelete() {
+        return this == OWNER;
+    }
+
+    public boolean canManageMembers() {
+        return this == OWNER || this == ADMIN;
+    }
+}
+```
+
+---
+
+## EntityId (Generic Identifier)
+
+A wrapper for entity identifiers:
+
+```java
+@ValueObject
+public record EntityId(Long value) implements Serializable {
+
+    public EntityId {
+        Assert.notNull(value, "EntityId cannot be null");
+    }
+
+    public Long get() {
+        return value;
+    }
+
+    public static EntityId from(Long id) {
+        return new EntityId(id);
+    }
+
+    public static EntityId generate() {
+        // Generate a new unique ID (UUID → Long, snowflake, etc.)
+        return new EntityId(System.currentTimeMillis());
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+}
+```
+
+---
+
+## Aggregate Boundaries
+
+Aggregates should be:
+- **Small**: 1-3 root entities per aggregate
+- **Focused**: Represent a single business concept
+- **Bounded**: Clear boundaries with other aggregates
+
+### Good Aggregate Design
+
+```java
+// Aggregate: Namespace
+// Root entity: Namespace
+// Child entities: None (members are in separate aggregate)
+@AggregateRoot
+public record Namespace(...) { }
+
+// Aggregate: NamespaceMember
+// Root entity: NamespaceMember
+// References: namespace_id (foreign key, not object reference)
+@AggregateRoot
+public record NamespaceMember(
+        @NonNull EntityId id,
+        @NonNull EntityId namespaceId,  // Reference, not embedded object
+        @NonNull EntityId accountId,
+        @NonNull NamespaceRole role
+) { }
+```
+
+### Bad Aggregate Design
+
+```java
+// ✗ Don't do this: Loading entire tree of objects
+@AggregateRoot
+public record Namespace(
+        EntityId id,
+        String slug,
+        List<NamespaceMember> members,      // ❌ Too much coupling
+        List<Vault> vaults,                  // ❌ Too many responsibilities
+        List<AuditLog> auditLogs            // ❌ Should be separate aggregate
+) { }
+
+// ✓ Do this: Keep aggregates focused
+@AggregateRoot
+public record Namespace(
+        EntityId id,
+        String slug
+) { }
+
+// Separate aggregate
+@AggregateRoot
+public record NamespaceMember(
+        EntityId id,
+        EntityId namespaceId,  // Reference only
+        EntityId accountId,
+        NamespaceRole role
+) { }
+```
+
+---
+
+## Validation Strategy
+
+### Constructor-Level Validation
+
+```java
+public record Email(String value) {
+    public Email {
+        Assert.hasText(value, "Email cannot be blank");
+        if (!isValidEmail(value)) {
+            throw new IllegalArgumentException("Invalid email: " + value);
+        }
+    }
+}
+```
+
+### Builder-Level Validation
+
+```java
+public static final class Builder {
+    public Namespace build() {
+        Assert.notNull(id, "ID required");
+        Assert.hasText(slug, "Slug required");
+        Assert.hasText(name, "Name required");
+        
+        // Cross-field validation
+        if (name.length() > 255) {
+            throw new IllegalArgumentException("Name too long");
+        }
+        
+        return new Namespace(id, slug, name, ...);
+    }
+}
+```
+
+### Domain Service Validation
+
+```java
+@Component
+class NamespaceValidator {
+    public void validateUniqueSlug(Slug slug, NamespaceRepository repo) {
+        if (repo.existsBySlug(slug)) {
+            throw new NamespaceExistsException("Slug already exists: " + slug);
+        }
+    }
+
+    public void validateOwnerAccess(EntityId userId, Namespace namespace) {
+        if (!namespace.owner().equals(userId)) {
+            throw new AccessDeniedException("Access denied");
+        }
+    }
+}
+
+// Usage in service
+@Override
+public Namespace create(CreateNamespaceCommand command) {
+    validator.validateUniqueSlug(command.slug(), repository);
+    
+    Namespace namespace = Namespace.builder()
+            .id(EntityId.generate())
+            .slug(command.slug().get())
+            .name(command.name())
+            .owner(command.owner())
+            .build();
+    
+    return repository.save(namespace);
+}
+```
+
+---
+
+## Comparison and Equality
+
+Records automatically provide `equals()` and `hashCode()` based on fields:
+
+```java
+Email email1 = new Email("user@example.com");
+Email email2 = new Email("user@example.com");
+
+assertThat(email1).isEqualTo(email2);  // ✓ True (same value)
+assertThat(email1).isSameAs(email2);   // ✗ False (different objects)
+```
+
+Use this for assertions:
+
+```java
+@Test
+void shouldCreateEmailValueObject() {
+    Email email = new Email("user@example.com");
+    Email other = new Email("user@example.com");
+    
+    assertThat(email).isEqualTo(other);  // Records compare by value
+}
+
+@Test
+void shouldRejectInvalidEmail() {
+    assertThatThrownBy(() -> new Email("invalid"))
+            .isInstanceOf(IllegalArgumentException.class);
+}
+```
+
+---
+
+## Serialization
+
+Records are automatically `Serializable` if all fields are serializable:
+
+```java
+@AggregateRoot
+public record Namespace(
+        EntityId id,           // Serializable if EntityId is
+        String slug,           // ✓ String is Serializable
+        OffsetDateTime createdAt  // ✓ OffsetDateTime is Serializable
+) implements Serializable {
+    // Automatically serializable
+}
+```
+
+If you need custom serialization:
+
+```java
+@AggregateRoot
+public record Namespace(...) implements Serializable {
+    
+    private static final long serialVersionUID = 1L;
+
+    @Serial
+    private Object writeReplace() {
+        // Custom serialization logic
+    }
+
+    @Serial
+    private void readObject(ObjectInputStream stream) {
+        // Custom deserialization logic
+    }
+}
+```
+
+---
+
+## Verification Checklist
+
+- [ ] All domain objects are `record` types (immutable)
+- [ ] No `@Setter` or getter methods on aggregates
+- [ ] Validation happens in constructor or `build()`
+- [ ] No Spring or jOOQ annotations on domain objects
+- [ ] Aggregate roots have `@AggregateRoot` annotation
+- [ ] Value objects have `@ValueObject` annotation
+- [ ] Builder classes have proper fluent API (`return this`)
+- [ ] Cross-field validation in `build()` method
+- [ ] Aggregates are small and focused
+- [ ] Foreign keys are EntityId values, not object references
+- [ ] Invariants enforced (nullability, ranges, formats)
+- [ ] Exceptions thrown for invalid state (not validation warnings)
+
+---
+
+## When to Ask for Help
+
+- "Is this a separate aggregate or part of the same one?"
+- "Should this be a value object or an aggregate?"
+- "How do I model this one-to-many relationship?"
+- "What should be validated where (constructor vs builder vs service)?"
+- "Is this aggregate too large?"
+- "How do I prevent invalid state transitions?"

--- a/.claude/skills/backend/jooq-patterns/SKILL.md
+++ b/.claude/skills/backend/jooq-patterns/SKILL.md
@@ -1,0 +1,383 @@
+---
+name: jooq-queries
+description: Writing database queries with jOOQ, understanding generated table/column references, common query patterns, and when to run ./gradlew generateJooq. Use when working with database access or understanding how generated code works.
+---
+
+# jOOQ Queries
+
+## Generated Code Structure
+
+After running `./gradlew generateJooq`, jOOQ generates classes in `build/generated-sources/jooq/`:
+
+```
+build/generated-sources/jooq/com/konfigyr/data/
+├── Tables.java              # All table references (NAMESPACES, NAMESPACE_MEMBERS, ACCOUNTS, etc.)
+├── Records.java             # Record types for each table
+├── Fields.java              # Column field references
+└── tables/
+    ├── Namespaces.java      # NAMESPACES table class
+    ├── NamespaceMembers.java
+    └── ...
+```
+
+**Always import table references statically in service implementations:**
+
+```java
+import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
+import static com.konfigyr.data.tables.NamespaceMembers.NAMESPACE_MEMBERS;
+```
+
+---
+
+## Common Query Patterns
+
+### SELECT (Simple)
+
+```java
+// Fetch all records
+List<Record> all = dsl.selectFrom(NAMESPACES).fetch();
+
+// Fetch one record by ID
+Optional<Namespace> namespace = context.selectFrom(NAMESPACES)
+        .where(NAMESPACES.ID.eq(id))
+        .fetchOptional(DefaultNamespaceManager::toNamespace);
+
+// Fetch with WHERE condition
+List<Namespace> active = context.selectFrom(NAMESPACES)
+        .where(NAMESPACES.STATUS.eq("ACTIVE"))
+        .fetch(DefaultNamespaceManager::toNamespace);
+```
+
+### SELECT with Filtering
+
+```java
+// Build dynamic conditions
+List<Condition> conditions = new ArrayList<>();
+
+if (searchQuery.hasSlug()) {
+        conditions.add(NAMESPACES.SLUG.likeIgnoreCase("%" + searchQuery.slug() + "%"));
+        }
+        if (searchQuery.hasOwner()) {
+        conditions.add(NAMESPACES.OWNER_ID.eq(searchQuery.owner().get()));
+        }
+
+List<Namespace> results = context.selectFrom(NAMESPACES)
+        .where(DSL.and(conditions))
+        .fetch(DefaultNamespaceManager::toNamespace);
+```
+
+### SELECT with JOIN
+
+```java
+// Join to filter or fetch related data
+List<Namespace> activeWithMembers = context.select(NAMESPACES.fields())
+                .from(NAMESPACES)
+                .join(NAMESPACE_MEMBERS).on(NAMESPACES.ID.eq(NAMESPACE_MEMBERS.NAMESPACE_ID))
+                .where(DSL.and(
+                        NAMESPACES.STATUS.eq("ACTIVE"),
+                        NAMESPACE_MEMBERS.ROLE.eq("ADMIN")
+                ))
+                .fetch(DefaultNamespaceManager::toNamespace);
+```
+
+### SELECT with EXISTS Subquery (Safer for N+1 Prevention)
+
+Instead of fetching related entities in a loop, use EXISTS to filter:
+
+```java
+// "Find all namespaces that have at least one admin member"
+List<Namespace> withAdmins = context.selectFrom(NAMESPACES)
+                .where(DSL.exists(
+                        DSL.select(NAMESPACE_MEMBERS.ID)
+                                .from(NAMESPACE_MEMBERS)
+                                .where(DSL.and(
+                                        NAMESPACE_MEMBERS.NAMESPACE_ID.eq(NAMESPACES.ID),
+                                        NAMESPACE_MEMBERS.ROLE.eq("ADMIN")
+                                ))
+                ))
+                .fetch(DefaultNamespaceManager::toNamespace);
+```
+
+### SELECT with Ordering & Pagination
+
+```java
+Page<Namespace> page = context.selectFrom(NAMESPACES)
+        .where(conditions)
+        .orderBy(NAMESPACES.CREATED_AT.desc(), NAMESPACES.NAME.asc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch(DefaultNamespaceManager::toNamespace);
+
+long total = context.fetchCount(
+        DSL.selectFrom(NAMESPACES).where(conditions)
+);
+
+return new PageImpl<>(page, pageable, total);
+```
+
+### SELECT with COUNT
+
+```java
+long count = context.selectCount()
+        .from(NAMESPACES)
+        .where(NAMESPACES.STATUS.eq("ACTIVE"))
+        .fetchOne(Record1::value1);
+
+boolean exists = context.fetchExists(
+        DSL.selectFrom(NAMESPACES).where(NAMESPACES.SLUG.eq("konfigyr"))
+);
+```
+
+### INSERT
+
+```java
+Namespace created = context.insertInto(NAMESPACES)
+        .set(NAMESPACES.ID, EntityId.generate().map(EntityId::get))
+        .set(NAMESPACES.SLUG, definition.slug().get())
+        .set(NAMESPACES.NAME, definition.name())
+        .set(NAMESPACES.CREATED_AT, OffsetDateTime.now())
+        .set(NAMESPACES.UPDATED_AT, OffsetDateTime.now())
+        .returning(NAMESPACES.fields())
+        .fetchOne(DefaultNamespaceManager::toNamespace);
+
+Assert.state(created != null, "Failed to insert namespace");
+```
+
+### INSERT BATCH
+
+```java
+List<InsertValuesStepN> batch = namespaces.stream()
+        .map(n -> context.insertInto(NAMESPACES)
+                .set(NAMESPACES.ID, n.id().get())
+                .set(NAMESPACES.SLUG, n.slug())
+                .set(NAMESPACES.NAME, n.name()))
+        .collect(Collectors.toList());
+
+context.batch(batch).execute();
+```
+
+### UPDATE
+
+```java
+int updated = context.update(NAMESPACES)
+        .set(NAMESPACES.NAME, newName)
+        .set(NAMESPACES.UPDATED_AT, OffsetDateTime.now())
+        .where(NAMESPACES.ID.eq(id))
+        .execute();
+
+Assert.state(updated > 0, "Namespace not found: " + id);
+```
+
+### DELETE
+
+```java
+int deleted = context.deleteFrom(NAMESPACES)
+        .where(NAMESPACES.ID.eq(id))
+        .execute();
+
+if (deleted == 0) {
+        throw new NamespaceNotFoundException(id);
+}
+```
+
+---
+
+## Type Mapping
+
+By default, jOOQ maps database types to Java types. Common mappings:
+
+| Database Type | Java Type |
+|---------------|-----------|
+| `BIGINT` | `Long` |
+| `VARCHAR` | `String` |
+| `BOOLEAN` | `Boolean` |
+| `TIMESTAMP` | `LocalDateTime` |
+| `TIMESTAMPTZ` | `OffsetDateTime` |
+| `UUID` | `UUID` |
+| `JSON` | `String` (usually) |
+
+**Custom type conversion in mapper:**
+
+```java
+private static Namespace toNamespace(Record record) {
+    return Namespace.builder()
+            .id(EntityId.from(record.get(NAMESPACES.ID)))
+            .slug(record.get(NAMESPACES.SLUG))
+            .name(record.get(NAMESPACES.NAME))
+            .createdAt(record.get(NAMESPACES.CREATED_AT))
+            .build();
+}
+```
+
+---
+
+## When to Run ./gradlew generateJooq
+
+**After ANY database schema change:**
+
+1. Create Liquibase changeset (XML file in `konfigyr-data/src/main/resources/migrations/`)
+2. Run: `./gradlew generateJooq`
+3. Import new generated tables in your service implementation
+4. Use the new table references in queries
+5. Commit both changeset AND generated code
+
+**Never:**
+- Manually edit generated jOOQ classes
+- Skip running `generateJooq` after schema changes
+- Add business logic to generated classes
+
+---
+
+## Performance Tips
+
+### Avoid N+1 Queries
+
+❌ **Bad:**
+```java
+List<Namespace> namespaces = context.selectFrom(NAMESPACES).fetch();
+namespaces.forEach(n -> {
+n.members = context.selectFrom(NAMESPACE_MEMBERS)
+            .where(NAMESPACE_MEMBERS.NAMESPACE_ID.eq(n.id()))
+        .fetch();  // This loop causes N+1
+});
+```
+
+✅ **Good:**
+```java
+// Use EXISTS to filter in a single query
+List<Namespace> activeWithMembers = context.selectFrom(NAMESPACES)
+                .where(DSL.exists(
+                        DSL.select(NAMESPACE_MEMBERS.ID)
+                                .from(NAMESPACE_MEMBERS)
+                                .where(NAMESPACE_MEMBERS.NAMESPACE_ID.eq(NAMESPACES.ID))
+                ))
+                .fetch(DefaultNamespaceManager::toNamespace);
+```
+
+### Index Frequently Filtered Columns
+
+In Liquibase changesets, create indexes for columns used in WHERE clauses:
+
+```xml
+<createIndex tableName="namespaces" indexName="idx_namespace_slug">
+    <column name="slug" />
+</createIndex>
+
+<createIndex tableName="namespace_members" indexName="idx_member_namespace_id">
+<column name="namespace_id" />
+</createIndex>
+```
+
+### Use LIMIT for List Operations
+
+Always paginate list results to avoid fetching millions of rows:
+
+```java
+List<Namespace> recentNamespaces = context.selectFrom(NAMESPACES)
+        .orderBy(NAMESPACES.CREATED_AT.desc())
+        .limit(100)  // Always set a limit
+        .fetch(DefaultNamespaceManager::toNamespace);
+```
+
+---
+
+## Debugging Queries
+
+### Print Generated SQL
+
+```java
+// Enable debug logging in application.yml
+logging:
+level:
+org.jooq: DEBUG
+
+// Or print directly
+System.out.println(context.selectFrom(NAMESPACES).getSQL());
+```
+
+### Test Queries in Integration Tests
+
+Use `AbstractIntegrationTest` base class which provides a real database via Testcontainers.
+
+```java
+@Test
+void shouldFetchNamespaceBySlug() {
+    Namespace namespace = context.selectFrom(NAMESPACES)
+            .where(NAMESPACES.SLUG.eq("konfigyr"))
+            .fetchOne(DefaultNamespaceManager::toNamespace);
+
+    assertThat(namespace).isNotNull().extracting(Namespace::slug)
+            .isEqualTo("konfigyr");
+}
+```
+
+---
+
+## Common Gotchas
+
+### Null Pointer Exception in Mapping
+
+If a record field is null, jOOQ returns null. Always check:
+
+```java
+// Safe:
+UUID id = record.get(NAMESPACES.ID);
+if (id != null) {
+        // use it
+        }
+
+// Or use Optional:
+Optional<String> description = Optional.ofNullable(record.get(NAMESPACES.DESCRIPTION));
+```
+
+### String Comparisons Are Case-Sensitive
+
+Use `likeIgnoreCase()` for case-insensitive filtering:
+
+```java
+// Case-sensitive (won't match "Konfigyr"):
+context.selectFrom(NAMESPACES)
+        .where(NAMESPACES.SLUG.like("konfigyr"))
+
+// Case-insensitive (matches "Konfigyr", "KONFIGYR", etc.):
+        context.selectFrom(NAMESPACES)
+        .where(NAMESPACES.SLUG.likeIgnoreCase("konfigyr"))
+```
+
+### Type Mismatches
+
+Always ensure WHERE condition types match column types:
+
+```java
+// ✗ Wrong: String compared to Long
+context.selectFrom(NAMESPACES)
+        .where(NAMESPACES.ID.eq("123"))  // ERROR
+
+// ✓ Correct: Long to Long
+        context.selectFrom(NAMESPACES)
+        .where(NAMESPACES.ID.eq(123L))
+```
+
+---
+
+## Verification Checklist
+
+- [ ] All table references imported statically
+- [ ] No raw SQL strings used (always use generated table references)
+- [ ] No N+1 queries (use EXISTS for filtering related data)
+- [ ] `./gradlew generateJooq` run after schema changes
+- [ ] Generated code committed alongside migrations
+- [ ] Frequently filtered columns have indexes
+- [ ] List queries have LIMIT applied
+- [ ] NULL values handled in mapping functions
+- [ ] Type conversions correct in mappers
+- [ ] Database queries tested in integration tests
+
+---
+
+## When to Ask for Help
+
+- "How do I avoid N+1 queries for this relationship?"
+- "Should I use a JOIN or EXISTS subquery?"
+- "How do I make this query more efficient?"
+- "What's the correct type mapping for this column?"

--- a/.claude/skills/backend/liquibase-migrations/SKILL.md
+++ b/.claude/skills/backend/liquibase-migrations/SKILL.md
@@ -1,0 +1,492 @@
+---
+name: liquibase-migrations
+description: Creating and managing database schema with Liquibase, running migration tasks, and regenerating jOOQ code after schema changes. Use when modifying database structure, adding new tables, or changing columns.
+---
+
+# Liquibase Migrations
+
+## Overview
+
+Liquibase manages all schema changes in changesets stored in `konfigyr-data/src/main/resources/migrations/`. After each schema change:
+
+1. Create/update XML changeset file
+2. Run `./gradlew generateJooq` to regenerate jOOQ table classes
+3. Import generated table references in service implementations
+4. Commit both changeset AND generated code
+
+---
+
+## Changeset Format (XML)
+
+Changesets are **XML** (not YAML or SQL). Each changeset has a unique `id` and `author`.
+
+### Basic Structure
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <changeSet author="vspasic" id="1.0.0-create-namespaces-table" context="identity or api">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="namespaces" /></not>
+        </preConditions>
+
+        <comment>Initial namespaces table migration</comment>
+
+        <createTable tableName="namespaces"
+                     remarks="Top-level tenant container for Konfigyr.">
+            <column name="id" type="bigint" autoIncrement="true">
+                <constraints primaryKey="true" nullable="false" />
+            </column>
+            <column name="slug" type="varchar(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="name" type="varchar(255)">
+                <constraints nullable="false" />
+            </column>
+            <column name="description" type="text">
+                <constraints nullable="true" />
+            </column>
+            <column name="created_at" type="timestamptz" defaultValue="NOW()">
+                <constraints nullable="false" />
+            </column>
+            <column name="updated_at" type="timestamptz" defaultValue="NOW()">
+                <constraints nullable="false" />
+            </column>
+        </createTable>
+
+        <addUniqueConstraint
+                tableName="namespaces"
+                columnNames="slug"
+                constraintName="unique_namespace_slug" />
+
+        <createIndex tableName="namespaces" indexName="idx_namespace_slug">
+            <column name="slug" />
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>
+```
+
+### Key Attributes
+
+| Attribute | Purpose |
+|-----------|---------|
+| `id` | Unique identifier for this changeset (format: `VERSION-description`, e.g., `1.0.0-create-table`) |
+| `author` | Person who created the changeset (your name or initials) |
+| `context` | When to apply: `identity`, `api`, or `identity or api` |
+| `preConditions` | Check before running (e.g., `not<tableExists>` to avoid duplicate creates) |
+| `onFail` | If precondition fails: `MARK_RAN` (continue) or `FAIL` (error) |
+
+---
+
+## Common Operations
+
+### Create Table
+
+```xml
+<changeSet author="vspasic" id="1.0.0-create-accounts-table" context="identity or api">
+    <preConditions onFail="MARK_RAN">
+        <not><tableExists tableName="accounts" /></not>
+    </preConditions>
+
+    <createTable tableName="accounts" remarks="User accounts from external OAuth providers.">
+        <column name="id" type="bigint" autoIncrement="true">
+            <constraints primaryKey="true" nullable="false" />
+        </column>
+        <column name="email" type="varchar(255)">
+            <constraints nullable="false" unique="true" />
+        </column>
+        <column name="first_name" type="varchar(255)">
+            <constraints nullable="true" />
+        </column>
+        <column name="last_name" type="varchar(255)">
+            <constraints nullable="true" />
+        </column>
+        <column name="avatar_url" type="text">
+            <constraints nullable="true" />
+        </column>
+        <column name="created_at" type="timestamptz" defaultValue="NOW()">
+            <constraints nullable="false" />
+        </column>
+    </createTable>
+
+    <createIndex tableName="accounts" indexName="idx_account_email">
+        <column name="email" />
+    </createIndex>
+</changeSet>
+```
+
+### Add Column
+
+```xml
+<changeSet author="vspasic" id="1.0.1-add-status-to-namespaces" context="api">
+    <preConditions onFail="MARK_RAN">
+        <not><columnExists tableName="namespaces" columnName="status" /></not>
+    </preConditions>
+
+    <addColumn tableName="namespaces">
+        <column name="status" type="varchar(20)" defaultValue="ACTIVE">
+            <constraints nullable="false" />
+        </column>
+    </addColumn>
+</changeSet>
+```
+
+### Drop Column
+
+```xml
+<changeSet author="vspasic" id="1.0.2-remove-legacy-field" context="api">
+    <preConditions onFail="MARK_RAN">
+        <columnExists tableName="namespaces" columnName="deprecated_field" />
+    </preConditions>
+
+    <dropColumn tableName="namespaces" columnName="deprecated_field" />
+</changeSet>
+```
+
+### Add Foreign Key
+
+```xml
+<changeSet author="vspasic" id="1.0.0-create-namespace-members-table" context="api">
+    <createTable tableName="namespace_members">
+        <column name="id" type="bigint" autoIncrement="true">
+            <constraints primaryKey="true" nullable="false" />
+        </column>
+        <column name="namespace_id" type="bigint">
+            <constraints nullable="false" />
+        </column>
+        <column name="account_id" type="bigint">
+            <constraints nullable="false" />
+        </column>
+        <column name="role" type="varchar(20)">
+            <constraints nullable="false" />
+        </column>
+    </createTable>
+
+    <addForeignKeyConstraint
+            baseTableName="namespace_members"
+            baseColumnNames="namespace_id"
+            constraintName="fk_namespace_member_namespace"
+            referencedTableName="namespaces"
+            referencedColumnNames="id"
+            onDelete="CASCADE" />
+
+    <addForeignKeyConstraint
+            baseTableName="namespace_members"
+            baseColumnNames="account_id"
+            constraintName="fk_namespace_member_account"
+            referencedTableName="accounts"
+            referencedColumnNames="id"
+            onDelete="CASCADE" />
+</changeSet>
+```
+
+### Create Unique Constraint
+
+```xml
+<changeSet author="vspasic" id="1.0.1-add-unique-member-constraint" context="api">
+    <preConditions onFail="MARK_RAN">
+        <not>
+            <uniqueConstraintExists tableName="namespace_members" columnNames="namespace_id,account_id" />
+        </not>
+    </preConditions>
+
+    <addUniqueConstraint
+            tableName="namespace_members"
+            columnNames="namespace_id,account_id"
+            constraintName="unique_namespace_member" />
+</changeSet>
+```
+
+### Create Index
+
+```xml
+<changeSet author="vspasic" id="1.0.0-create-indices" context="api">
+    <createIndex tableName="namespace_members" indexName="idx_member_namespace_id">
+        <column name="namespace_id" />
+    </createIndex>
+
+    <createIndex tableName="namespace_members" indexName="idx_member_account_id">
+        <column name="account_id" />
+    </createIndex>
+</changeSet>
+```
+
+---
+
+## File Organization
+
+Changesets are organized by module in separate directories:
+
+```
+konfigyr-data/src/main/resources/migrations/
+├── changelog.xml               # Master file that includes all modules
+├── namespace/
+│   ├── namespaces-1.0.0.xml   # Create namespaces table
+│   └── namespaces-1.0.1.xml   # Add status column
+├── account/
+│   └── accounts-1.0.0.xml     # Create accounts table
+├── vault/
+│   └── vault-1.0.0.xml
+├── kms/
+│   └── kms-1.0.0.xml
+└── audit/
+    └── audit-1.0.0.xml
+```
+
+**master changelog.xml:**
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd">
+
+    <includeAll path="namespace" relativeToChangelogFile="true" />
+    <includeAll path="account" relativeToChangelogFile="true" />
+    <includeAll path="vault" relativeToChangelogFile="true" />
+    <includeAll path="kms" relativeToChangelogFile="true" />
+    <includeAll path="audit" relativeToChangelogFile="true" />
+
+</databaseChangeLog>
+```
+
+---
+
+## Workflow: Adding a New Table
+
+### Step 1: Create Changeset File
+
+Create `konfigyr-data/src/main/resources/migrations/<module>/<module>-1.0.0.xml`
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog ...>
+    <changeSet author="yourname" id="1.0.0-create-my-table" context="identity or api">
+        <preConditions onFail="MARK_RAN">
+            <not><tableExists tableName="my_table" /></not>
+        </preConditions>
+
+        <createTable tableName="my_table">
+            <!-- columns -->
+        </createTable>
+    </changeSet>
+</databaseChangeLog>
+```
+
+### Step 2: Regenerate jOOQ Code
+
+```bash
+./gradlew generateJooq
+```
+
+This:
+1. Starts a Testcontainer with PostgreSQL
+2. Runs all Liquibase changesets
+3. Generates jOOQ table classes based on the schema
+4. Cleans up the container
+
+### Step 3: Import Generated Tables
+
+In your service implementation:
+```java
+import static com.konfigyr.data.tables.MyTable.MY_TABLE;
+
+// Now use MY_TABLE in queries
+```
+
+### Step 4: Commit Both Files
+
+Commit both:
+- The changeset XML file
+- The generated jOOQ code in `build/generated-sources/jooq/`
+
+---
+
+## Naming Conventions
+
+### Changeset IDs
+
+Format: `<VERSION>-<description>`
+
+```
+1.0.0-create-namespaces-table
+1.0.1-add-status-column
+2.0.0-rename-field-to-new-name
+```
+
+**Increment version when:**
+- Major schema redesign: 2.0.0
+- Adding new table: 1.0.1
+- Modifying existing table: 1.0.2
+
+### Table Names
+
+- Use snake_case: `namespace_members`
+- Pluralize when representing a collection: `namespaces`, `accounts`
+- Avoid abbreviations: `account_namespace_members` (not `acc_ns_members`)
+
+### Column Names
+
+- Use snake_case: `created_at`, `namespace_id`
+- Use `_at` suffix for timestamps: `created_at`, `updated_at`
+- Use `_id` suffix for foreign keys: `namespace_id`, `account_id`
+
+### Constraint Names
+
+- Foreign key: `fk_<table>_<referenced_table>`
+    - Example: `fk_namespace_member_account`
+- Unique: `unique_<table>_<columns>`
+    - Example: `unique_namespace_slug` or `unique_namespace_member`
+- Index: `idx_<table>_<columns>`
+    - Example: `idx_namespace_slug`, `idx_member_namespace_id`
+
+---
+
+## Context Attribute
+
+Use `context` to control which deployment gets this changeset:
+
+```
+context="identity"          # Only apply to identity provider
+context="api"               # Only apply to REST API
+context="identity or api"   # Apply to both
+```
+
+**Typical split:**
+- `identity`: User account tables, auth tokens
+- `api`: Namespace, vault, kms, audit
+- `identity or api`: Shared reference data
+
+---
+
+## Safety Checks (Preconditions)
+
+Always use preconditions to prevent errors on re-runs or deployments:
+
+```xml
+<!-- Check table doesn't exist before creating -->
+<preConditions onFail="MARK_RAN">
+    <not><tableExists tableName="namespaces" /></not>
+</preConditions>
+
+<!-- Check column doesn't exist before adding -->
+<preConditions onFail="MARK_RAN">
+    <not><columnExists tableName="namespaces" columnName="status" /></not>
+</preConditions>
+
+<!-- Check constraint doesn't exist before adding -->
+<preConditions onFail="MARK_RAN">
+    <not>
+        <uniqueConstraintExists tableName="namespaces" columnNames="slug" />
+    </not>
+</preConditions>
+```
+
+---
+
+## Data Types
+
+| Liquibase Type | PostgreSQL Type | Java Type |
+|---|---|---|
+| `bigint` | `BIGINT` | `Long` |
+| `varchar(255)` | `VARCHAR(255)` | `String` |
+| `text` | `TEXT` | `String` |
+| `boolean` | `BOOLEAN` | `Boolean` |
+| `int` | `INTEGER` | `Integer` |
+| `decimal(10,2)` | `DECIMAL(10,2)` | `BigDecimal` |
+| `timestamp` | `TIMESTAMP` | `LocalDateTime` |
+| `timestamptz` | `TIMESTAMP WITH TIME ZONE` | `OffsetDateTime` |
+| `uuid` | `UUID` | `UUID` |
+| `json` | `JSON` | `String` (usually) |
+
+---
+
+## Common Mistakes
+
+### ❌ Creating Same Table Twice
+
+```xml
+<!-- First deployment -->
+<changeSet id="1.0.0-create-table">
+    <createTable tableName="users"> ... </createTable>
+</changeSet>
+
+<!-- Second deployment (without precondition) - FAILS! -->
+<changeSet id="1.0.0-create-table">
+    <createTable tableName="users"> ... </createTable>
+</changeSet>
+```
+
+**Fix:** Always add preconditions:
+```xml
+<preConditions onFail="MARK_RAN">
+    <not><tableExists tableName="users" /></not>
+</preConditions>
+```
+
+### ❌ Missing Foreign Key Constraints
+
+Forgetting to add constraints can lead to orphaned data.
+
+```xml
+<!-- ✗ Bad: No foreign key -->
+<createTable tableName="namespace_members">
+    <column name="namespace_id" type="bigint" />
+</createTable>
+
+<!-- ✓ Good: Foreign key with cascade delete -->
+<addForeignKeyConstraint
+        baseTableName="namespace_members"
+        baseColumnNames="namespace_id"
+        referencedTableName="namespaces"
+        referencedColumnNames="id"
+        onDelete="CASCADE" />
+```
+
+### ❌ Forgetting to Run generateJooq
+
+After schema changes, you MUST run `./gradlew generateJooq` to regenerate jOOQ table classes.
+
+```bash
+# ✗ Wrong: Changeset created but jOOQ code not regenerated
+git add migrations/namespace/namespace-1.0.1.xml
+git commit -m "Add status column"
+
+# ✓ Correct: Both changeset and generated code committed
+./gradlew generateJooq
+git add migrations/namespace/namespace-1.0.1.xml
+git add build/generated-sources/jooq/...
+git commit -m "Add status column to namespace"
+```
+
+---
+
+## Verification Checklist
+
+- [ ] Changeset has unique `id` and `author`
+- [ ] Preconditions prevent re-run failures
+- [ ] File in correct module directory (`migrations/<module>/`)
+- [ ] All table/column names follow snake_case convention
+- [ ] Foreign keys use `onDelete="CASCADE"` where appropriate
+- [ ] Indexes created for frequently filtered columns
+- [ ] `./gradlew generateJooq` runs successfully
+- [ ] Generated jOOQ code committed with changeset
+- [ ] Both files (changeset + generated code) in same commit
+- [ ] No hardcoded data (use `defaultValue` only for technical defaults)
+
+---
+
+## When to Ask for Help
+
+- "Should I create an index for this column?"
+- "What's the correct way to model this relationship?"
+- "How do I safely rename a column with existing data?"
+- "Do I need a cascade delete for this foreign key?"
+- "generateJooq is failing—how do I debug?"

--- a/.claude/skills/backend/spring-modulith-ddd/SKILL.md
+++ b/.claude/skills/backend/spring-modulith-ddd/SKILL.md
@@ -1,0 +1,390 @@
+---
+name: spring-modulith-ddd
+description: Creating new modules, defining domain objects (aggregates, value objects), service interfaces, and wiring beans via AutoConfiguration. Use when designing a new feature or refactoring existing modules.
+---
+
+# Spring Modulith & Domain-Driven Design
+
+## Core Concepts
+
+**Module** — A logical boundary representing a business domain (namespace, vault, audit, kms). Modules communicate via events, never direct dependencies.
+
+**Aggregate** — A cluster of domain objects (entities, value objects) with a root entity that guarantees invariants. In Konfigyr, aggregates are immutable `record` types with inner `Builder` classes.
+
+**Value Object** — An immutable domain concept with no identity (Email, Slug, UserId). Also records.
+
+**Service Interface** — Public contract for a module's operations (e.g., `NamespaceManager`). Annotated with `@Repository` (jmolecules).
+
+**Default Implementation** — Package-private class holding jOOQ `DSLContext`. Named `Default<InterfaceName>`. Never exposed outside the module.
+
+---
+
+## Creating a New Module
+
+### Step 1: Plan the Module Structure
+
+Before any code, answer:
+- What is the business domain this module represents?
+- What aggregates live in this module? (usually 1-3 per module)
+- Which other modules does it depend on (event-wise)?
+- What are the primary use cases (CRUD, business logic)?
+
+**Module directory structure:**
+```
+src/main/java/com/konfigyr/<module>/
+├── <Aggregate>.java                           # Aggregate root (record + Builder)
+├── <ValueObject>.java                         # Value objects (records)
+├── <Module>Exception.java                     # Base domain exception
+├── <Specific>Exception.java                   # Specific exceptions
+├── <Module>Manager.java                       # Service interface (@Repository)
+├── Default<Module>Manager.java                # jOOQ implementation (package-private)
+├── <Module>Event.java                         # Domain events (sealed class)
+├── <Module>AutoConfiguration.java             # Spring beans wiring
+└── controller/
+    ├── <Aggregate>Controller.java             # REST controller (package-private)
+    └── Assemblers.java                        # RepresentationModelAssembler factories
+```
+
+### Step 2: Define Domain Objects
+
+**Aggregate Root (record with Builder):**
+```java
+// com.konfigyr.namespace.Namespace
+@AggregateRoot
+public record Namespace(
+                @NonNull @Identity EntityId id,
+                @NonNull String slug,
+                @NonNull String name,
+                @Nullable String description,
+                @NonNull Avatar avatar,
+                @Nullable OffsetDateTime createdAt,
+                @Nullable OffsetDateTime updatedAt
+        ) implements Serializable {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private EntityId id;
+        private String slug;
+        private String name;
+        private String description;
+        private Avatar avatar;
+        private OffsetDateTime createdAt;
+        private OffsetDateTime updatedAt;
+
+        public Builder id(EntityId id) { this.id = id; return this; }
+        public Builder slug(String slug) { this.slug = slug; return this; }
+        public Builder name(String name) { this.name = name; return this; }
+        // ... other setters
+
+        public Namespace build() {
+            Assert.notNull(id, "Namespace entity identifier can not be null");
+            Assert.hasText(slug, "Namespace slug can not be blank");
+            Assert.hasText(name, "Namespace name can not be blank");
+            // Validate invariants here, throw exceptions if invalid
+            return new Namespace(id, slug, name, description, avatar, createdAt, updatedAt);
+        }
+    }
+}
+```
+
+**Value Objects (immutable records):**
+```java
+@ValueObject
+public record NamespaceDefinition(
+        @NonNull EntityId owner,
+        @NonNull Slug slug,
+        @NonNull String name,
+        @Nullable String description
+) implements Serializable {
+    public NamespaceDefinition {
+        Assert.notNull(owner, "Owner is required");
+        Assert.notNull(slug, "Slug is required");
+        Assert.hasText(name, "Name is required");
+    }
+}
+```
+
+**Domain Exceptions:**
+```java
+public abstract class NamespaceException extends RuntimeException {
+    public NamespaceException(String message) { super(message); }
+    public NamespaceException(String message, Throwable cause) { super(message, cause); }
+}
+
+public final class NamespaceNotFoundException extends NamespaceException {
+    public NamespaceNotFoundException(String slug) {
+        super("Namespace not found: " + slug);
+    }
+}
+
+public final class NamespaceExistsException extends NamespaceException {
+    public NamespaceExistsException(String slug) {
+        super("Namespace already exists: " + slug);
+    }
+}
+```
+
+### Step 3: Define Service Interface
+
+Service interfaces are public, use `@Repository` annotation (from jmolecules), and define CRUD + business logic methods.
+
+```java
+// com.konfigyr.namespace.NamespaceManager
+@NullMarked
+@Repository
+public interface NamespaceManager {
+
+    Page<Namespace> search(SearchQuery query);
+
+    Optional<Namespace> findById(EntityId id);
+
+    Optional<Namespace> findBySlug(String slug);
+
+    boolean exists(String slug);
+
+    @DomainEventPublisher(publishes = "namespaces.created")
+    Namespace create(NamespaceDefinition definition);
+
+    @DomainEventPublisher(publishes = "namespaces.renamed")
+    Namespace update(String slug, NamespaceDefinition definition);
+
+    void delete(String slug);
+}
+```
+
+### Step 4: Implement Service with jOOQ
+
+Implementation is package-private (`Default<Name>`), holds `DSLContext`, and uses jOOQ directly. Never expose `DSLContext` outside this class.
+
+```java
+// com.konfigyr.namespace.DefaultNamespaceManager
+@Slf4j
+@RequiredArgsConstructor
+class DefaultNamespaceManager implements NamespaceManager {
+
+    private final DSLContext context;
+    private final ApplicationEventPublisher publisher;
+
+    @NonNull
+    @Override
+    @Transactional(readOnly = true, label = "namespace-slug-lookup")
+    public Optional<Namespace> findBySlug(@NonNull String slug) {
+        return fetch(NAMESPACES.SLUG.eq(slug));
+    }
+
+    @NonNull
+    @Override
+    @Transactional(label = "namespace-create")
+    public Namespace create(@NonNull NamespaceDefinition definition) {
+        final Namespace namespace = context.insertInto(NAMESPACES)
+                .set(NAMESPACES.ID, EntityId.generate().map(EntityId::get))
+                .set(NAMESPACES.SLUG, definition.slug().get())
+                .set(NAMESPACES.NAME, definition.name())
+                .set(NAMESPACES.CREATED_AT, OffsetDateTime.now())
+                .set(NAMESPACES.UPDATED_AT, OffsetDateTime.now())
+                .returning(NAMESPACES.fields())
+                .fetchOne(DefaultNamespaceManager::toNamespace);
+
+        Assert.state(namespace != null, () -> "Could not create namespace from: " + definition);
+
+        publisher.publishEvent(new NamespaceEvent.Created(namespace));
+        return namespace;
+    }
+
+    private Optional<Namespace> fetch(Condition condition) {
+        return context.selectFrom(NAMESPACES)
+                .where(condition)
+                .fetchOptional(DefaultNamespaceManager::toNamespace);
+    }
+
+    private static Namespace toNamespace(Record record) {
+        return Namespace.builder()
+                .id(EntityId.from(record.get(NAMESPACES.ID)))
+                .slug(record.get(NAMESPACES.SLUG))
+                .name(record.get(NAMESPACES.NAME))
+                .description(record.get(NAMESPACES.DESCRIPTION))
+                .createdAt(record.get(NAMESPACES.CREATED_AT))
+                .updatedAt(record.get(NAMESPACES.UPDATED_AT))
+                .build();
+    }
+}
+```
+
+**Key patterns:**
+- Private static mapper method (`toNamespace`) converts jOOQ Record to domain object
+- All transactions labeled (`@Transactional(label = "...")`
+- `DSLContext` used only inside this class
+- Domain events published via `ApplicationEventPublisher`
+
+### Step 5: Define Domain Events
+
+Domain events are sealed class hierarchies. Publish them when state changes. Other modules listen via `@TransactionalEventListener`.
+
+```java
+// com.konfigyr.namespace.NamespaceEvent
+public abstract sealed class NamespaceEvent extends EntityEvent implements Supplier<Namespace>
+        permits NamespaceEvent.Created, NamespaceEvent.Renamed, NamespaceEvent.Deleted {
+
+    private final Namespace namespace;
+
+    protected NamespaceEvent(Namespace namespace) {
+        super(namespace.id());
+        this.namespace = namespace;
+    }
+
+    @Override
+    public Namespace get() { return namespace; }
+
+    @DomainEvent(name = "created", namespace = "namespaces")
+    public static final class Created extends NamespaceEvent {
+        public Created(Namespace namespace) { super(namespace); }
+    }
+
+    @DomainEvent(name = "renamed", namespace = "namespaces")
+    public static final class Renamed extends NamespaceEvent {
+        private final Slug from;
+        private final Slug to;
+
+        public Renamed(Namespace namespace, Slug from, Slug to) {
+            super(namespace);
+            this.from = from;
+            this.to = to;
+        }
+
+        public Slug from() { return from; }
+        public Slug to() { return to; }
+    }
+
+    @DomainEvent(name = "deleted", namespace = "namespaces")
+    public static final class Deleted extends NamespaceEvent {
+        public Deleted(Namespace namespace) { super(namespace); }
+    }
+}
+```
+
+### Step 6: Wire Beans via AutoConfiguration
+
+Each module has an `@AutoConfiguration` class that uses `@ConditionalOnMissingBean` for testability.
+
+```java
+// com.konfigyr.namespace.NamespaceManagementAutoConfiguration
+@AutoConfiguration
+@RequiredArgsConstructor
+@AutoConfigureAfter(JooqAutoConfiguration.class)
+public class NamespaceManagementAutoConfiguration {
+
+    private final DSLContext context;
+    private final ApplicationEventPublisher applicationEventPublisher;
+
+    @Bean
+    @ConditionalOnMissingBean(NamespaceManager.class)
+    NamespaceManager defaultNamespaceManager() {
+        return new DefaultNamespaceManager(context, applicationEventPublisher);
+    }
+}
+```
+
+### Step 7: Create REST Controller
+
+Controllers are in a `controller/` subpackage, package-private, thin, and delegate to the service interface.
+
+```java
+// com.konfigyr.namespace.controller.NamespaceController
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/namespaces")
+class NamespaceController {
+
+    private final NamespaceManager namespaces;
+
+    @GetMapping("/{slug}")
+    @RequiresScope(OAuthScope.READ_NAMESPACES)
+    EntityModel<Namespace> get(@PathVariable String slug) {
+        return namespaces.findBySlug(slug)
+                .map(Assemblers.namespace()::toModel)
+                .orElseThrow(() -> new NamespaceNotFoundException(slug));
+    }
+
+    @PostMapping
+    @RequiresScope(OAuthScope.WRITE_NAMESPACES)
+    ResponseEntity<EntityModel<Namespace>> create(@Valid @RequestBody NamespaceDefinition definition) {
+        final Namespace namespace = namespaces.create(definition);
+        return ResponseEntity.created(URI.create("/namespaces/" + namespace.slug()))
+                .body(Assemblers.namespace().toModel(namespace));
+    }
+}
+```
+
+---
+
+## Common Patterns
+
+### N-to-1 Relationships in Queries
+
+Use EXISTS subqueries instead of joins when filtering by related data:
+
+```java
+// Don't do N+1:
+List<Namespace> all = context.selectFrom(NAMESPACES).fetch();
+all.forEach(ns -> ns.members = context.selectFrom(NAMESPACE_MEMBERS)
+        .where(NAMESPACE_MEMBERS.NAMESPACE_ID.eq(ns.id()))
+        .fetch());
+
+// Do this instead:
+List<Namespace> members = context.selectFrom(NAMESPACES)
+        .where(DSL.exists(
+                DSL.select(NAMESPACE_MEMBERS.ID)
+                        .from(NAMESPACE_MEMBERS)
+                        .where(DSL.and(
+                                NAMESPACE_MEMBERS.NAMESPACE_ID.eq(NAMESPACES.ID),
+                                NAMESPACE_MEMBERS.ROLE.eq("ADMIN")
+                        ))
+        ))
+        .fetch(DefaultNamespaceManager::toNamespace);
+```
+
+### Pagination with DSL
+
+```java
+Page<Namespace> results = context.selectFrom(NAMESPACES)
+        .where(conditions)
+        .orderBy(NAMESPACES.CREATED_AT.desc())
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch(DefaultNamespaceManager::toNamespace);
+
+long total = context.fetchCount(
+        DSL.selectFrom(NAMESPACES).where(conditions)
+);
+
+return new PageImpl<>(results, pageable, total);
+```
+
+---
+
+## Verification Checklist
+
+- [ ] Aggregate is immutable `record` with inner `Builder`
+- [ ] Builder validates invariants in `build()` method
+- [ ] Service interface is public with `@Repository`
+- [ ] Implementation is package-private, named `Default<Name>`
+- [ ] `DSLContext` only used inside `Default<Name>`, never leaked
+- [ ] Domain events published via `ApplicationEventPublisher`
+- [ ] AutoConfiguration uses `@ConditionalOnMissingBean`
+- [ ] Controller is package-private in `controller/` subpackage
+- [ ] No Spring annotations on domain objects
+- [ ] No jOOQ types in domain layer
+- [ ] All transactions labeled
+- [ ] Mapper methods are private static
+
+---
+
+## When to Ask for Help
+
+- "Should this be a new aggregate or part of an existing one?"
+- "How do I model this relationship without creating circular dependencies?"
+- "Is this service interface too broad or too narrow?"
+- "Do I need to publish an event here?"

--- a/.claude/skills/backend/spring-security-oauth2/SKILL.md
+++ b/.claude/skills/backend/spring-security-oauth2/SKILL.md
@@ -1,0 +1,519 @@
+---
+name: spring-security-oauth2
+description: Using @RequiresScope annotation for OAuth2 scope validation, understanding scope hierarchy, protecting endpoints, testing authentication. Use when protecting REST endpoints, enforcing access control, or handling OAuth2 tokens.
+---
+
+# Spring Security & OAuth2 Scopes
+
+## Overview
+
+Konfigyr uses OAuth2 JWT tokens issued by the Identity Provider (`konfigyr-identity`). All REST API endpoints are protected by JWT scopes enforced via the custom `@RequiresScope` annotation.
+
+The Identity Provider is an **identity broker**: it accepts authentication from external providers (GitHub, GitLab, Google, SAML enterprise IdPs) and translates them into a single standardised Konfigyr JWT. The REST API only ever validates against konfigyr-identity — no external JWKS endpoints or multi-issuer configuration is needed.
+
+**User token flow (frontend):**
+1. Frontend authenticates via Authorization Code + PKCE with konfigyr-identity
+2. konfigyr-identity issues PS256 JWT with `scope` claim and Konfigyr-internal `sub`
+3. Frontend includes token in `Authorization: Bearer <token>` header
+4. REST API validates token signature against konfigyr-identity's JWKS endpoint
+5. REST API checks `@RequiresScope` annotation matches token scopes
+6. If scope missing → 403 Forbidden
+
+**Machine token flow (namespace OAuth2 clients):**
+1. CI/CD pipeline or build plugin authenticates via Client Credentials with konfigyr-identity
+2. konfigyr-identity issues PS256 JWT with `scope` claim and `kfg_namespace` claim
+3. Plugin/pipeline includes token in `Authorization: Bearer <token>` header
+4. Same scope enforcement applies
+
+### Token types and their claims
+
+There are two distinct token personas. Code that reads JWT claims must account for both:
+
+| Claim | User token | Namespace client token |
+|-------|-----------|----------------------|
+| `sub` | Konfigyr Account ID (internal, **not** the external provider's UID) | OAuth2 client ID |
+| `email` | User's email address | not present |
+| `scope` | User's granted scopes | Client's granted scopes (e.g. `metadata:upload`) |
+| `kfg_namespace` | not present | Namespace `EntityId` — use this to identify which namespace the client belongs to |
+
+> `sub` is always a Konfigyr-internal identifier. It will never be a GitHub username or external UID — the broker normalises all external identities before issuing the token.
+
+---
+
+## @RequiresScope Annotation
+
+Use `@RequiresScope` on controller methods to enforce OAuth2 scope requirements.
+
+### Basic Usage
+
+```java
+@RestController
+@RequestMapping("/namespaces")
+@RequiredArgsConstructor
+class NamespaceController {
+
+    private final NamespaceManager namespaces;
+
+    @GetMapping("/{slug}")
+    @RequiresScope(OAuthScope.READ_NAMESPACES)
+    EntityModel<Namespace> get(@PathVariable String slug) {
+        return namespaces.findBySlug(slug)
+                .map(Assemblers.namespace()::toModel)
+                .orElseThrow(() -> new NamespaceNotFoundException(slug));
+    }
+
+    @PostMapping
+    @RequiresScope(OAuthScope.WRITE_NAMESPACES)
+    ResponseEntity<EntityModel<Namespace>> create(@Valid @RequestBody NamespaceDefinition definition) {
+        Namespace namespace = namespaces.create(definition);
+        return ResponseEntity.created(URI.create("/namespaces/" + namespace.slug()))
+                .body(Assemblers.namespace().toModel(namespace));
+    }
+
+    @DeleteMapping("/{slug}")
+    @RequiresScope(OAuthScope.DELETE_NAMESPACES)
+    ResponseEntity<Void> delete(@PathVariable String slug) {
+        namespaces.delete(slug);
+        return ResponseEntity.noContent().build();
+    }
+}
+```
+
+### Available Scopes
+
+`OAuthScope` is an enum in `konfigyr-core`. Always use the enum constant, never raw strings:
+
+```java
+// ✓ Correct: Use enum
+@RequiresScope(OAuthScope.READ_NAMESPACES)
+
+// ✗ Wrong: Don't use raw strings
+@RequiresScope("read:namespaces")
+```
+
+**Common scopes:**
+- `READ_NAMESPACES` — Read namespace metadata
+- `WRITE_NAMESPACES` — Create/update namespaces
+- `DELETE_NAMESPACES` — Delete namespaces
+- `READ_VAULT` — Read vault entries
+- `WRITE_VAULT` — Write vault entries
+- `READ_AUDIT` — Read audit logs
+- `MANAGE_KMS` — Manage encryption keys
+- `MANAGE_MEMBERS` — Invite/remove members
+
+---
+
+## Scope Hierarchy
+
+Scopes form a hierarchy—broader scopes imply narrower ones:
+
+```
+WRITE implies READ
+DELETE is independent
+MANAGE_* scopes don't imply READ/WRITE
+```
+
+**Examples:**
+- Client with `WRITE_NAMESPACES` can also call `READ_NAMESPACES` endpoints
+- Client with `DELETE_NAMESPACES` can only delete (must separately grant READ or WRITE)
+- `MANAGE_KMS` doesn't grant READ/WRITE to other resources
+
+---
+
+## Error Responses
+
+### 403 Forbidden (Missing Scope)
+
+When a token lacks required scope:
+
+```json
+HTTP/1.1 403 Forbidden
+Content-Type: application/problem+json
+
+{
+  "type": "about:blank",
+  "title": "Forbidden",
+  "status": 403,
+  "detail": "Access denied: missing required scope 'read:namespaces'"
+}
+```
+
+### 401 Unauthorized (No Token)
+
+When request has no token or token is invalid:
+
+```json
+HTTP/1.1 401 Unauthorized
+Content-Type: application/problem+json
+WWW-Authenticate: Bearer realm="konfigyr"
+
+{
+  "type": "about:blank",
+  "title": "Unauthorized",
+  "status": 401,
+  "detail": "Full authentication is required to access this resource"
+}
+```
+
+---
+
+## Testing with @RequiresScope
+
+### Test: With Valid Scope
+
+```java
+@WebMvcTest(NamespaceController.class)
+class NamespaceControllerTest extends AbstractControllerTest {
+
+    @MockBean
+    private NamespaceManager namespaces;
+
+    @Test
+    @DisplayName("should return namespace when scopes valid")
+    void shouldGetNamespaceWithValidScope() throws Exception {
+        Namespace konfigyr = Namespace.builder()
+                .id(EntityId.from(1L))
+                .slug("konfigyr")
+                .name("Konfigyr")
+                .build();
+
+        given(namespaces.findBySlug("konfigyr"))
+                .willReturn(Optional.of(konfigyr));
+
+        mvc.get().uri("/namespaces/konfigyr")
+                .with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+                .exchange()
+                .assertThat()
+                .hasStatusOk()
+                .bodyJson()
+                .convertTo(Namespace.class)
+                .returns("konfigyr", Namespace::slug);
+    }
+}
+```
+
+### Test: Without Scope (403 Forbidden)
+
+```java
+@Test
+@DisplayName("should return 403 when scope missing")
+void shouldReturn403WhenScopeMissing() throws Exception {
+    mvc.get().uri("/namespaces/konfigyr")
+            .with(authentication(TestPrincipals.jane()))  // No scopes
+            .exchange()
+            .assertThat()
+            .satisfies(forbidden(OAuthScope.READ_NAMESPACES));
+}
+```
+
+Helper method `forbidden()`:
+```java
+private static Consumer<MvcTestResult> forbidden(OAuthScope... requiredScopes) {
+    return result -> {
+        assertThat(result.getStatus()).isEqualTo(HttpStatus.FORBIDDEN);
+        assertThat(result.getResponse().getContentAsString())
+                .contains("missing required scope");
+    };
+}
+```
+
+### Test: Without Authentication (401 Unauthorized)
+
+```java
+@Test
+@DisplayName("should return 401 when no token provided")
+void shouldReturn401WhenNoAuthentication() throws Exception {
+    mvc.get().uri("/namespaces/konfigyr")
+            .exchange()
+            .assertThat()
+            .satisfies(unauthorized());
+}
+```
+
+Helper method `unauthorized()`:
+```java
+private static Consumer<MvcTestResult> unauthorized() {
+    return result -> {
+        assertThat(result.getStatus()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    };
+}
+```
+
+---
+
+## Access Current User
+
+Inside a secured endpoint, access the current user via Spring Security:
+
+```java
+@GetMapping("/me")
+@RequiresScope(OAuthScope.READ_ACCOUNT)
+AccountDetails getCurrentUser(Authentication auth) {
+    JwtAuthenticationToken token = (JwtAuthenticationToken) auth;
+    String accountId = token.getClaim("sub");  // Subject (user ID)
+    String email = token.getClaim("email");
+    // ... fetch account details, return response
+}
+```
+
+Or use a custom annotation:
+
+```java
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CurrentUser {}
+
+// Resolver:
+@Component
+public class CurrentUserResolver implements HandlerMethodArgumentResolver {
+    @Override
+    public Object resolveArgument(MethodParameter parameter, /* ... */) {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        JwtAuthenticationToken token = (JwtAuthenticationToken) auth;
+        return token.getClaim("sub");
+    }
+}
+
+// Usage:
+@GetMapping("/me")
+@RequiresScope(OAuthScope.READ_ACCOUNT)
+AccountDetails getCurrentUser(@CurrentUser String userId) {
+    // userId automatically injected
+}
+```
+
+---
+
+## Common Patterns
+
+### Class-Level Scope
+
+Apply same scope to all methods in a controller:
+
+```java
+@RestController
+@RequestMapping("/vault")
+@RequiresScope(OAuthScope.READ_VAULT)
+class VaultController {
+    // All methods require READ_VAULT or higher
+}
+```
+
+### Multiple Scopes (Any One Required)
+
+If endpoint requires multiple scopes, list them:
+
+```java
+@PostMapping("/entries")
+@RequiresScope({OAuthScope.WRITE_VAULT, OAuthScope.ADMIN})
+ResponseEntity<Void> createEntry(@RequestBody VaultEntry entry) {
+    // Accepts if client has WRITE_VAULT OR ADMIN
+}
+```
+
+### Accessing Token Claims
+
+Inside secured methods:
+
+```java
+@GetMapping("/protected")
+@RequiresScope(OAuthScope.READ_NAMESPACES)
+ResponseEntity<String> protectedEndpoint(
+        JwtAuthenticationToken token,
+        Authentication auth) {
+    
+    // JWT claims
+    String userId = token.getClaim("sub");
+    String email = token.getClaim("email");
+    List<String> scopes = token.getClaim("scope");
+    
+    return ResponseEntity.ok("User: " + email);
+}
+```
+
+---
+
+## Configuration
+
+OAuth2 configuration in `application.yml`:
+
+```yaml
+spring:
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://localhost:8081  # Identity Provider URL
+          jwk-set-uri: http://localhost:8081/oauth2/authorization/jwks
+          claim-set-uri: http://localhost:8081/oauth2/authorization/claims
+
+# Custom scope configuration (if needed)
+konfigyr:
+  security:
+    scopes:
+      - name: read:namespaces
+        description: Read namespace metadata
+      - name: write:namespaces
+        description: Create and update namespaces
+```
+
+---
+
+## Environment Variables
+
+```bash
+# Identity Provider
+KONFIGYR_ID_URL=http://localhost:8081
+
+# OAuth2 Client (for SSO, if needed)
+KONFIGYR_OAUTH_CLIENT_ID=konfigyr-api
+KONFIGYR_OAUTH_CLIENT_SECRET=...
+
+# JWT Verification
+KONFIGYR_JWT_ISSUER=http://localhost:8081
+KONFIGYR_JWT_JWKS_URI=http://localhost:8081/.well-known/jwks.json
+```
+
+---
+
+## Debugging
+
+### Check Token in Browser
+
+```javascript
+// In browser DevTools console after login:
+const token = sessionStorage.getItem('access_token');
+console.log(JSON.parse(atob(token.split('.')[1])));  // Decode JWT payload
+```
+
+Output:
+```json
+{
+  "sub": "user-123",
+  "email": "user@example.com",
+  "scope": "read:namespaces write:namespaces",
+  "exp": 1701234567,
+  "iat": 1701230967
+}
+```
+
+### Enable Security Logging
+
+```yaml
+logging:
+  level:
+    org.springframework.security: DEBUG
+```
+
+---
+
+## Common Mistakes
+
+### ❌ Using Raw String Scopes
+
+```java
+// ✗ Wrong: String instead of enum
+@RequiresScope("read:namespaces")
+
+// ✓ Correct: Use OAuthScope enum
+@RequiresScope(OAuthScope.READ_NAMESPACES)
+```
+
+### ❌ Missing @RequiresScope on Public Endpoint
+
+```java
+// ✗ Wrong: No scope protection
+@GetMapping("/{slug}")
+EntityModel<Namespace> get(@PathVariable String slug) { ... }
+
+// ✓ Correct: Even read endpoints need scopes
+@GetMapping("/{slug}")
+@RequiresScope(OAuthScope.READ_NAMESPACES)
+EntityModel<Namespace> get(@PathVariable String slug) { ... }
+```
+
+### ❌ Checking Scope in Code Instead of Annotation
+
+```java
+// ✗ Wrong: Manual scope checking
+if (!token.getScopes().contains("read:namespaces")) {
+    throw new AccessDeniedException("...");
+}
+
+// ✓ Correct: Use @RequiresScope annotation
+@RequiresScope(OAuthScope.READ_NAMESPACES)
+```
+
+### ❌ Trusting User Input as Authorization Signal
+
+```java
+// ✗ Wrong: Client-provided scope claim
+@GetMapping
+String getData(@RequestParam String scope) {
+    if (scope.equals("admin")) { ... }  // Not authenticated!
+}
+
+// ✓ Correct: Use authenticated token
+@RequiresScope(OAuthScope.ADMIN)
+String getData() { ... }
+```
+
+---
+
+## Scope Design Best Practices
+
+### Be Specific
+
+```java
+// ✗ Too broad: One scope for everything
+@RequiresScope(OAuthScope.ADMIN)
+
+// ✓ Specific: Granular scopes
+@RequiresScope(OAuthScope.READ_AUDIT)
+@RequiresScope(OAuthScope.WRITE_VAULT)
+```
+
+### Follow Hierarchy
+
+```
+READ → WRITE → DELETE
+Basic operations → Advanced operations
+```
+
+### Document in OpenAPI
+
+```java
+@Operation(summary = "Get namespace details")
+@ApiResponse(
+    responseCode = "403",
+    description = "Missing required scope: read:namespaces"
+)
+@GetMapping("/{slug}")
+@RequiresScope(OAuthScope.READ_NAMESPACES)
+EntityModel<Namespace> get(@PathVariable String slug) { ... }
+```
+
+---
+
+## Verification Checklist
+
+- [ ] All endpoints have `@RequiresScope` annotation
+- [ ] Scope values use `OAuthScope` enum, not raw strings
+- [ ] Scope hierarchy makes sense (READ < WRITE < DELETE)
+- [ ] Tests verify both with-scope and without-scope cases
+- [ ] 403 and 401 error responses documented
+- [ ] Error messages mention required scope
+- [ ] Token issuer configured in `application.yml`
+- [ ] JWKS endpoint configured for signature verification
+- [ ] Scope claims verified from authenticated token
+- [ ] No manual scope checking in code (use annotation)
+
+---
+
+## When to Ask for Help
+
+- "What scopes should this endpoint require?"
+- "Do I need multiple scopes or is one sufficient?"
+- "How do I handle cross-module authorization?"
+- "Should I create a new scope or reuse an existing one?"
+- "How do I test both authenticated and unauthenticated requests?"

--- a/.claude/skills/backend/spring-testing/SKILL.md
+++ b/.claude/skills/backend/spring-testing/SKILL.md
@@ -1,0 +1,700 @@
+---
+name: spring-testing
+description: Writing integration tests with AbstractIntegrationTest, controller tests with AbstractControllerTest, test base classes, assertions, and Arrange-Act-Assert patterns. Use when writing or updating tests for services, repositories, and REST endpoints.
+---
+
+# Spring Testing
+
+## Test Base Classes
+
+Konfigyr provides two test base classes that handle Spring context, database, and HTTP mocking setup.
+
+### AbstractIntegrationTest
+
+For integration tests with full Spring context and real database:
+
+```java
+// Provides:
+//   - Full Spring Boot application context (@SpringBootTest)
+//   - TestContainers PostgreSQL (real database, runs Liquibase migrations)
+//   - WireMock server (for OAuth JWKS endpoint and external HTTP stubs)
+//   - TestSmtpServer (for email assertions)
+//   - PublishedEventsExtension (for asserting Spring domain events)
+//   - @MockitoSpyBean: features, metadataStore, mailer
+// Use for: NamespaceManagerTest, VaultServiceTest — anything needing real DB
+
+@TestProfile
+@SpringBootTest
+@EnableWireMock
+@TestSmtpServer
+@TestObservations
+@ImportTestcontainers(TestContainers.class)
+@ExtendWith(PublishedEventsExtension.class)
+public abstract class AbstractIntegrationTest {
+
+    @InjectWireMock
+    protected static WireMockServer wiremock;
+
+    @Autowired
+    protected DSLContext dsl;
+
+    @MockitoSpyBean
+    protected Features features;
+
+    @MockitoSpyBean
+    protected Mailer mailer;
+}
+```
+
+**Inheriting from AbstractIntegrationTest:**
+
+```java
+@DisplayName("Namespace Manager")
+class NamespaceManagerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private NamespaceManager manager;
+
+    @Test
+    @DisplayName("should create namespace and publish event")
+    void shouldCreateNamespace(AssertablePublishedEvents events) {
+        // Test code here
+    }
+}
+```
+
+### AbstractControllerTest
+
+For controller/REST endpoint tests with MockMvc:
+
+```java
+// Extends AbstractIntegrationTest
+// Provides:
+//   - MockMvcTester mvc (fluent API for HTTP assertions)
+//   - static authentication(...) helpers to forge JWT tokens
+//   - static forbidden(), unauthorized() ProblemDetail consumers
+//   - static namespaceNotFound(slug), serviceNotFound(slug) consumers
+
+@WebMvcTest(NamespaceController.class)
+public abstract class AbstractControllerTest extends AbstractIntegrationTest {
+
+    protected static MockMvcTester mvc;
+    protected static JsonMapper jsonMapper;
+
+    @BeforeAll
+    protected static void setup(WebApplicationContext context) {
+        mvc = MockMvcTester.create(
+                MockMvcBuilders.webAppContextSetup(context)
+                        .apply(springSecurity())
+                        .build()
+        );
+    }
+}
+```
+
+**Inheriting from AbstractControllerTest:**
+
+```java
+@DisplayName("Namespace Controller")
+@WebMvcTest(NamespaceController.class)
+class NamespaceControllerTest extends AbstractControllerTest {
+
+    @MockBean
+    private NamespaceManager namespaces;
+
+    @Test
+    @DisplayName("should retrieve namespace by slug")
+    void shouldGetNamespace() {
+        // Test code here
+    }
+}
+```
+
+---
+
+## Unit Tests (Domain Layer)
+
+Unit tests don't extend any base class. They test pure domain logic with no database or Spring context.
+
+### Test Domain Objects
+
+```java
+class NamespaceTest {
+
+    @Test
+    @DisplayName("should create namespace using fluent builder")
+    void shouldBuildNamespace() {
+        // Arrange
+        Namespace namespace = Namespace.builder()
+                .id(EntityId.from(1L))
+                .slug("my-namespace")
+                .name("My Namespace")
+                .description("Test namespace")
+                .avatar("https://example.com/avatar.gif")
+                .build();
+
+        // Assert
+        assertThat(namespace)
+                .returns(EntityId.from(1L), Namespace::id)
+                .returns("my-namespace", Namespace::slug)
+                .returns("My Namespace", Namespace::name);
+    }
+
+    @Test
+    @DisplayName("should validate namespace data on build")
+    void shouldValidateBuilder() {
+        // Arrange
+        Namespace.Builder builder = Namespace.builder();
+
+        // Assert - ID required
+        assertThatThrownBy(builder::build)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Namespace entity identifier can not be null");
+
+        // Assert - Slug required
+        assertThatThrownBy(() -> builder.id(EntityId.from(1L)).build())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Namespace slug can not be blank");
+    }
+
+    @Test
+    @DisplayName("should reject invalid slug")
+    void shouldRejectInvalidSlug() {
+        assertThatThrownBy(() -> Namespace.builder()
+                .id(EntityId.from(1L))
+                .slug("")  // Empty slug
+                .name("Invalid")
+                .build())
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}
+```
+
+---
+
+## Integration Tests (Service Layer)
+
+Integration tests extend `AbstractIntegrationTest`. They test service methods with real database.
+
+### Test Service Operations
+
+```java
+@DisplayName("Namespace Manager")
+class NamespaceManagerTest extends AbstractIntegrationTest {
+
+    @Autowired
+    private NamespaceManager manager;
+
+    @Test
+    @DisplayName("should fetch namespace by slug")
+    void shouldFindBySlug() {
+        // Arrange
+        Namespace existing = Namespace.builder()
+                .id(EntityId.from(1L))
+                .slug("existing")
+                .name("Existing")
+                .build();
+
+        // Act
+        Optional<Namespace> found = manager.findBySlug("existing");
+
+        // Assert
+        assertThat(found)
+                .isPresent()
+                .get()
+                .returns("existing", Namespace::slug);
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("should create namespace and publish event")
+    void shouldCreateNamespace(AssertablePublishedEvents events) {
+        // Arrange
+        NamespaceDefinition definition = NamespaceDefinition.builder()
+                .owner(EntityId.from(1L))
+                .slug("new-namespace")
+                .name("New Namespace")
+                .build();
+
+        // Act
+        Namespace created = manager.create(definition);
+
+        // Assert - Domain object
+        assertThat(created)
+                .isNotNull()
+                .returns("new-namespace", Namespace::slug);
+
+        // Assert - Database persistence
+        Namespace stored = dsl.selectFrom(NAMESPACES)
+                .where(NAMESPACES.SLUG.eq("new-namespace"))
+                .fetchOne(record -> /* mapping */);
+
+        assertThat(stored).isNotNull();
+
+        // Assert - Event published
+        events.assertThat()
+                .contains(NamespaceEvent.Created.class)
+                .matching(e -> e.get().slug().equals("new-namespace"));
+    }
+
+    @Test
+    @DisplayName("should throw NamespaceExistsException on duplicate slug")
+    void shouldThrowOnDuplicate() {
+        // Arrange
+        NamespaceDefinition definition = NamespaceDefinition.builder()
+                .owner(EntityId.from(1L))
+                .slug("existing")  // Already exists
+                .name("Duplicate")
+                .build();
+
+        // Assert
+        assertThatThrownBy(() -> manager.create(definition))
+                .isInstanceOf(NamespaceExistsException.class)
+                .hasMessageContaining("existing");
+    }
+
+    @Test
+    @DisplayName("should search namespaces by criteria")
+    void shouldSearchByCriteria() {
+        // Arrange
+        SearchQuery query = SearchQuery.builder()
+                .criteria(SearchQuery.ACCOUNT, EntityId.from(1L))
+                .build();
+
+        // Act
+        Page<Namespace> results = manager.search(query);
+
+        // Assert
+        assertThat(results)
+                .isNotEmpty()
+                .allSatisfy(ns -> assertThat(ns.name()).isNotBlank());
+    }
+}
+```
+
+### Asserting Database State
+
+```java
+@Test
+void shouldPersistToDatabase() {
+    // Act
+    Namespace created = manager.create(definition);
+
+    // Assert - Query database directly using jOOQ
+    long count = dsl.fetchCount(
+            DSL.selectFrom(NAMESPACES)
+                    .where(NAMESPACES.SLUG.eq(created.slug()))
+    );
+
+    assertThat(count).isEqualTo(1);
+
+    // Assert - Fetch and verify
+    Namespace stored = dsl.selectFrom(NAMESPACES)
+            .where(NAMESPACES.ID.eq(created.id().get()))
+            .fetchOne(DefaultNamespaceManager::toNamespace);
+
+    assertThat(stored)
+            .isEqualTo(created);
+}
+```
+
+### Asserting Domain Events
+
+```java
+@Test
+void shouldPublishNamespaceCreatedEvent(AssertablePublishedEvents events) {
+    // Act
+    Namespace created = manager.create(definition);
+
+    // Assert
+    events.assertThat()
+            .contains(NamespaceEvent.Created.class)
+            .matching(event -> {
+                Namespace ns = event.get();
+                return ns.id().equals(created.id())
+                        && ns.slug().equals(created.slug());
+            });
+}
+```
+
+---
+
+## Controller Tests (REST Endpoints)
+
+Controller tests extend `AbstractControllerTest`. They test HTTP behavior: status codes, headers, response bodies, authentication.
+
+### GET Endpoint
+
+```java
+@WebMvcTest(NamespaceController.class)
+class NamespaceControllerTest extends AbstractControllerTest {
+
+    @MockBean
+    private NamespaceManager namespaces;
+
+    @Test
+    @DisplayName("should return namespace when found")
+    void shouldGetNamespace() {
+        // Arrange
+        Namespace konfigyr = Namespace.builder()
+                .id(EntityId.from(1L))
+                .slug("konfigyr")
+                .name("Konfigyr")
+                .build();
+
+        given(namespaces.findBySlug("konfigyr"))
+                .willReturn(Optional.of(konfigyr));
+
+        // Act & Assert
+        mvc.get().uri("/namespaces/{slug}", "konfigyr")
+                .with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+                .exchange()
+                .assertThat()
+                .hasStatusOk()
+                .hasContentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+                .bodyJson()
+                .convertTo(Namespace.class)
+                .returns("konfigyr", Namespace::slug)
+                .returns("Konfigyr", Namespace::name);
+    }
+
+    @Test
+    @DisplayName("should return 404 when namespace not found")
+    void shouldReturn404() {
+        // Arrange
+        given(namespaces.findBySlug("not-found"))
+                .willReturn(Optional.empty());
+
+        // Act & Assert
+        mvc.get().uri("/namespaces/{slug}", "not-found")
+                .with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+                .exchange()
+                .assertThat()
+                .hasStatus(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("should return 403 when scope missing")
+    void shouldReturn403WithoutScope() {
+        // Act & Assert
+        mvc.get().uri("/namespaces/{slug}", "konfigyr")
+                .with(authentication(TestPrincipals.jane()))  // No scope
+                .exchange()
+                .assertThat()
+                .satisfies(forbidden(OAuthScope.READ_NAMESPACES));
+    }
+
+    @Test
+    @DisplayName("should return 401 when unauthenticated")
+    void shouldReturn401Unauthenticated() {
+        // Act & Assert
+        mvc.get().uri("/namespaces/{slug}", "konfigyr")
+                .exchange()  // No authentication
+                .assertThat()
+                .satisfies(unauthorized());
+    }
+}
+```
+
+### POST Endpoint
+
+```java
+@Test
+@Transactional
+@DisplayName("should create namespace and return 201")
+void shouldCreateNamespace() {
+    // Arrange
+    NamespaceDefinition definition = NamespaceDefinition.builder()
+            .owner(EntityId.from(1L))
+            .slug("new-namespace")
+            .name("New Namespace")
+            .build();
+
+    Namespace created = Namespace.builder()
+            .id(EntityId.from(2L))
+            .slug("new-namespace")
+            .name("New Namespace")
+            .build();
+
+    given(namespaces.create(any()))
+            .willReturn(created);
+
+    // Act & Assert
+    mvc.post().uri("/namespaces")
+            .with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(objectMapper.writeValueAsString(definition))
+            .exchange()
+            .assertThat()
+            .hasStatus(HttpStatus.CREATED)
+            .hasHeader("Location", "/namespaces/new-namespace")
+            .bodyJson()
+            .convertTo(Namespace.class)
+            .returns("new-namespace", Namespace::slug);
+}
+
+@Test
+@DisplayName("should return 400 when validation fails")
+void shouldReturn400OnValidationError() {
+    // Arrange
+    String invalidPayload = "{ \"slug\": \"\" }";  // Empty slug
+
+    // Act & Assert
+    mvc.post().uri("/namespaces")
+            .with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+            .contentType(MediaType.APPLICATION_JSON)
+            .content(invalidPayload)
+            .exchange()
+            .assertThat()
+            .hasStatus(HttpStatus.BAD_REQUEST);
+}
+```
+
+### DELETE Endpoint
+
+```java
+@Test
+@DisplayName("should delete namespace and return 204")
+void shouldDeleteNamespace() {
+    // Arrange
+    willDoNothing()
+            .given(namespaces)
+            .delete("konfigyr");
+
+    // Act & Assert
+    mvc.delete().uri("/namespaces/{slug}", "konfigyr")
+            .with(authentication(TestPrincipals.john(), OAuthScope.DELETE_NAMESPACES))
+            .exchange()
+            .assertThat()
+            .hasStatus(HttpStatus.NO_CONTENT)
+            .hasNoContent();
+
+    // Verify delete was called
+    then(namespaces).should().delete("konfigyr");
+}
+```
+
+---
+
+## Test Helpers
+
+### Authentication Helper
+
+```java
+// Create authenticated request with specific scopes
+authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES)
+
+// Create authenticated request with multiple scopes
+authentication(TestPrincipals.jane(), 
+        OAuthScope.READ_NAMESPACES, 
+        OAuthScope.WRITE_NAMESPACES)
+
+// Create unauthenticated request
+// (just don't add .with(authentication(...)))
+```
+
+### Response Assertion Helpers
+
+```java
+// Assert 403 Forbidden (missing scope)
+.satisfies(forbidden(OAuthScope.READ_NAMESPACES))
+
+// Assert 401 Unauthorized
+.satisfies(unauthorized())
+
+// Assert 404 Not Found with specific message
+.satisfies(namespaceNotFound("my-namespace"))
+
+// Custom assertion
+.satisfies(result -> {
+    assertThat(result.getStatus()).isEqualTo(HttpStatus.OK);
+    assertThat(result.getResponse().getContentAsString())
+            .contains("expected content");
+})
+```
+
+---
+
+## Arrange-Act-Assert Pattern
+
+All tests follow AAA structure:
+
+```java
+@Test
+void testBehavior() {
+    // ===== ARRANGE =====
+    // Set up test data, mocks, conditions
+    Namespace existing = Namespace.builder().slug("test").build();
+    given(manager.findBySlug("test")).willReturn(Optional.of(existing));
+
+    // ===== ACT =====
+    // Call the method under test
+    Optional<Namespace> result = manager.findBySlug("test");
+
+    // ===== ASSERT =====
+    // Verify the result matches expectations
+    assertThat(result)
+            .isPresent()
+            .get()
+            .returns("test", Namespace::slug);
+}
+```
+
+---
+
+## Test Naming Convention
+
+| Test Type | Pattern | Example |
+|-----------|---------|---------|
+| Unit (domain) | `shouldX WhenY()` | `shouldRejectEmptySlugWhenBuilding()` |
+| Integration | `shouldXWhenY()` | `shouldCreateNamespaceWhenDefinitionValid()` |
+| Controller | `shouldReturnXWhenY()` | `shouldReturn403WhenScopeMissing()` |
+
+---
+
+## Common Assertions
+
+```java
+// Optional assertions
+assertThat(optional)
+        .isPresent()
+        .get()
+        .returns("value", Object::field);
+
+// Collection assertions
+assertThat(list)
+        .isNotEmpty()
+        .hasSize(3)
+        .allSatisfy(item -> assertThat(item.name()).isNotBlank())
+        .extracting(Item::id)
+        .contains(1L, 2L, 3L);
+
+// Exception assertions
+assertThatThrownBy(() -> manager.create(invalid))
+        .isInstanceOf(NamespaceExistsException.class)
+        .hasMessageContaining("already exists");
+
+// Event assertions
+events.assertThat()
+        .contains(NamespaceEvent.Created.class)
+        .matching(e -> e.get().slug().equals("test"));
+```
+
+---
+
+## Test Data Setup
+
+### Using Test Fixtures
+
+```java
+class NamespaceManagerTest extends AbstractIntegrationTest {
+
+    private Namespace testNamespace;
+
+    @BeforeEach
+    void setUp() {
+        // Insert test data directly
+        testNamespace = Namespace.builder()
+                .id(EntityId.generate())
+                .slug("test-ns")
+                .name("Test Namespace")
+                .build();
+
+        // Persist via manager
+        testNamespace = manager.create(
+                NamespaceDefinition.builder()
+                        .slug("test-ns")
+                        .name("Test Namespace")
+                        .build()
+        );
+    }
+
+    @Test
+    void shouldFindTestNamespace() {
+        Optional<Namespace> found = manager.findBySlug("test-ns");
+        assertThat(found).isPresent();
+    }
+}
+```
+
+### Using @Sql Annotation
+
+```java
+@Test
+@Sql("/test-data/namespaces.sql")
+void shouldQueryExistingData() {
+    // Test code here
+}
+```
+
+---
+
+## Mocking External Services
+
+### WireMock for HTTP Stubs
+
+```java
+@Test
+void shouldCallExternalService() {
+    // Stub external API
+    wiremock.stubFor(get(urlPathEqualTo("/external/api"))
+            .willReturn(ok()
+                    .withHeader("Content-Type", "application/json")
+                    .withBody("{\"status\": \"ok\"}")
+            ));
+
+    // Test code that calls external service
+    String response = externalService.call();
+    assertThat(response).contains("ok");
+}
+```
+
+### MockitoSpyBean for Partial Mocking
+
+```java
+@MockitoSpyBean
+private Features features;
+
+@Test
+void shouldUseFeatureFlag() {
+    // Spy allows real calls, but can verify
+    given(features.isEnabled("flag"))
+            .willReturn(true);
+
+    // Test code
+    boolean enabled = features.isEnabled("flag");
+    assertThat(enabled).isTrue();
+
+    // Verify it was called
+    then(features).should().isEnabled("flag");
+}
+```
+
+---
+
+## Verification Checklist
+
+- [ ] Tests use Arrange-Act-Assert pattern
+- [ ] Test names follow conventions (shouldX / shouldReturnX)
+- [ ] Unit tests have no Spring context
+- [ ] Integration tests use `AbstractIntegrationTest`
+- [ ] Controller tests use `AbstractControllerTest`
+- [ ] All endpoints tested with and without authentication
+- [ ] OAuth2 scope requirements tested (with scope / without scope)
+- [ ] Error cases tested (404, 400, 403, 401)
+- [ ] Database state verified in integration tests
+- [ ] Domain events asserted in event publishers
+- [ ] Mocks verified when behavior should be called
+- [ ] No hardcoded test data (use builders, factories)
+- [ ] `@Transactional` used on tests that modify database
+- [ ] `./gradlew test` passes, no skipped tests
+
+---
+
+## When to Ask for Help
+
+- "How do I test this async operation?"
+- "Should I mock this dependency or use the real one?"
+- "How do I verify a database query was correct?"
+- "What's the best way to set up test data?"
+- "How do I test this cross-module event?"

--- a/.claude/skills/frontend/form-handling/SKILL.md
+++ b/.claude/skills/frontend/form-handling/SKILL.md
@@ -1,0 +1,264 @@
+---
+name: form-handling
+description: TanStack Form setup, form validation with schemas, submission handling, error display, and loading states. Use when building forms for data entry or complex user interactions.
+---
+
+# Form Handling
+
+## Basic Form
+
+```typescript
+import { useForm } from '@tanstack/react-form'
+import { zodValidator } from '@tanstack/zod-form-adapter'
+import { z } from 'zod'
+
+// Define schema
+const createNamespaceSchema = z.object({
+  slug: z.string().min(1, 'Slug required').regex(/^[a-z0-9-]+$/),
+  name: z.string().min(1, 'Name required').max(255),
+  description: z.string().optional(),
+})
+
+type CreateNamespaceInput = z.infer<typeof createNamespaceSchema>
+
+export function CreateNamespaceForm() {
+  const { mutate, isPending } = useCreateNamespace()
+
+  const form = useForm({
+    defaultValues: {
+      slug: '',
+      name: '',
+      description: '',
+    },
+    onSubmit: async ({ value }) => {
+      mutate(value)
+    },
+    validatorAdapter: zodValidator(),
+  })
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault()
+        form.handleSubmit()
+      }}
+    >
+      <form.Field name="slug">
+        {(field) => (
+          <div>
+            <label>Slug</label>
+            <input
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+            {field.state.meta.errors && (
+              <span className="text-destructive">
+                {field.state.meta.errors[0]}
+              </span>
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <form.Field name="name">
+        {(field) => (
+          <div>
+            <label>Name</label>
+            <input
+              value={field.state.value}
+              onBlur={field.handleBlur}
+              onChange={(e) => field.handleChange(e.target.value)}
+            />
+            {field.state.meta.errors && (
+              <span className="text-destructive">
+                {field.state.meta.errors[0]}
+              </span>
+            )}
+          </div>
+        )}
+      </form.Field>
+
+      <button type="submit" disabled={isPending}>
+        {isPending ? 'Creating...' : 'Create'}
+      </button>
+    </form>
+  )
+}
+```
+
+## Field Component Wrapper
+
+```typescript
+interface FieldProps {
+  name: string
+  label: string
+  type?: string
+  required?: boolean
+}
+
+export function TextField({ name, label, type = 'text', required }: FieldProps) {
+  return (
+    <form.Field name={name}>
+      {(field) => (
+        <div className="mb-4">
+          <label htmlFor={name} className="block font-medium">
+            {label} {required && <span className="text-destructive">*</span>}
+          </label>
+          <input
+            id={name}
+            type={type}
+            value={field.state.value}
+            onBlur={field.handleBlur}
+            onChange={(e) => field.handleChange(e.target.value)}
+            className={cn(
+              'border rounded px-3 py-2 w-full',
+              field.state.meta.errors && 'border-destructive',
+            )}
+          />
+          {field.state.meta.errors && (
+            <p className="text-sm text-destructive mt-1">
+              {field.state.meta.errors[0]}
+            </p>
+          )}
+        </div>
+      )}
+    </form.Field>
+  )
+}
+
+// Usage
+<TextField name="slug" label="Slug" required />
+```
+
+## Validation
+
+```typescript
+// Zod schema
+const schema = z.object({
+  email: z.string().email('Invalid email'),
+  password: z.string().min(8, 'Minimum 8 characters'),
+  confirmPassword: z.string(),
+}).refine((d) => d.password === d.confirmPassword, {
+  message: 'Passwords do not match',
+  path: ['confirmPassword'],
+})
+
+// Custom validation
+const form = useForm({
+  validators: {
+    onChange: schema,  // Real-time validation
+    onSubmit: schema,  // Submit-time validation
+  },
+})
+```
+
+## Async Validation
+
+```typescript
+const schema = z.object({
+  slug: z.string()
+    .min(1)
+    .superRefine(async (val, ctx) => {
+      const exists = await checkSlugExists(val)
+      if (exists) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'Slug already taken',
+        })
+      }
+    }),
+})
+```
+
+## Form Handler Integration
+
+```typescript
+// routes/namespace/index-handler.ts
+export const updateNamespaceAction = async ({ request, params }) => {
+  const formData = await request.formData()
+  const name = formData.get('name')
+
+  try {
+    const response = await fetch(
+      `/api/namespaces/${params.namespace}`,
+      {
+        method: 'PATCH',
+        body: JSON.stringify({ name }),
+      },
+    )
+
+    if (!response.ok) {
+      return json({ error: 'Update failed' }, { status: 400 })
+    }
+
+    return json({ success: true })
+  } catch (error) {
+    return json({ error: error.message }, { status: 500 })
+  }
+}
+
+// routes/namespace/index.tsx
+import { Form } from '@tanstack/react-router'
+
+function NamespacePage() {
+  return (
+    <Form action={updateNamespaceAction} method="post">
+      <input type="text" name="name" />
+      <button type="submit">Update</button>
+    </Form>
+  )
+}
+```
+
+## Loading States
+
+```typescript
+<form onSubmit={handleSubmit}>
+  <input
+    disabled={isPending}
+    placeholder="Enter namespace"
+  />
+  
+  <button type="submit" disabled={isPending}>
+    {isPending ? (
+      <>
+        <Spinner className="mr-2" />
+        Creating...
+      </>
+    ) : (
+      'Create'
+    )}
+  </button>
+</form>
+```
+
+## Error Display
+
+```typescript
+function FormError({ error }: { error?: string }) {
+  return error ? (
+    <div className="bg-destructive/10 border border-destructive text-destructive p-3 rounded">
+      {error}
+    </div>
+  ) : null
+}
+
+// Usage
+{form.state.meta.errors && (
+  <FormError error={form.state.meta.errors[0]?.message} />
+)}
+```
+
+## Verification Checklist
+
+- [ ] Schema validation defined (Zod/Yup)
+- [ ] Real-time validation on change
+- [ ] Form submission handling
+- [ ] Error messages displayed
+- [ ] Loading state during submit
+- [ ] Disabled input while pending
+- [ ] Success feedback (toast/redirect)
+- [ ] Async validation when needed
+- [ ] Form reset after success
+- [ ] Accessibility (labels, error announcements)

--- a/.claude/skills/frontend/frontend-testing/SKILL.md
+++ b/.claude/skills/frontend/frontend-testing/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: frontend-testing
+description: Testing React components and hooks with @testing-library, MSW for API mocking, test utilities, and Arrange-Act-Assert pattern. Use when writing tests for components, hooks, or routes.
+---
+
+# Frontend Testing
+
+## Test Structure
+
+Tests mirror `src/` structure under `test/`:
+
+```
+src/hooks/namespace/query.ts → test/hooks/namespace/query.test.ts
+src/components/ui/button.tsx → test/components/ui/button.test.tsx
+```
+
+## MSW (Mock Service Worker)
+
+All HTTP calls intercepted by MSW—no real API calls in tests.
+
+```typescript
+// test/msw/handlers.ts
+import { http, HttpResponse } from 'msw'
+
+export const handlers = [
+  http.get('/api/namespaces/:slug', ({ params }) => {
+    return HttpResponse.json({
+      id: '1',
+      slug: params.slug,
+      name: 'Test Namespace',
+    })
+  }),
+
+  http.post('/api/namespaces', async ({ request }) => {
+    const body = await request.json()
+    return HttpResponse.json(
+      { id: '2', ...body },
+      { status: 201 },
+    )
+  }),
+
+  http.get('/api/namespaces/:slug', () => {
+    return HttpResponse.error()  // Simulate 500
+  }),
+]
+
+// test/setup.ts
+import { setupServer } from 'msw/node'
+beforeAll(() => server.listen())
+afterEach(() => server.resetHandlers())
+afterAll(() => server.close())
+```
+
+## Testing Hooks
+
+```typescript
+// test/hooks/namespace/query.test.ts
+import { renderHook, waitFor } from '@testing-library/react'
+import { createWrapper } from '@konfigyr/test/utils'
+import { getNamespaceQuery } from '@konfigyr/hooks/namespace/query'
+
+test('should fetch namespace by slug', async () => {
+  // Arrange
+  const { result } = renderHook(
+    () => useSuspenseQuery(getNamespaceQuery('test')),
+    { wrapper: createWrapper() },
+  )
+
+  // Act & Assert
+  await waitFor(() => {
+    expect(result.current.data?.slug).toBe('test')
+  })
+})
+
+test('should handle error', async () => {
+  // Arrange
+  server.use(
+    http.get('/api/namespaces/*', () =>
+      HttpResponse.error(),
+    ),
+  )
+
+  // Act & Assert
+  const { result } = renderHook(
+    () => useSuspenseQuery(getNamespaceQuery('test')),
+    { wrapper: createWrapper() },
+  )
+
+  await waitFor(() => {
+    expect(result.current.error).toBeDefined()
+  })
+})
+```
+
+## Testing Components
+
+```typescript
+// test/components/ui/button.test.tsx
+import { render, screen } from '@testing-library/react'
+import { Button } from '@konfigyr/ui/button'
+
+test('should render button with text', () => {
+  render(<Button>Click me</Button>)
+  expect(screen.getByText('Click me')).toBeInTheDocument()
+})
+
+test('should call onClick handler', async () => {
+  const handleClick = vi.fn()
+  const { user } = render(
+    <Button onClick={handleClick}>Submit</Button>
+  )
+
+  await user.click(screen.getByRole('button'))
+  expect(handleClick).toHaveBeenCalled()
+})
+
+test('should render variant styles', () => {
+  render(<Button variant="outline">Outlined</Button>)
+  const button = screen.getByRole('button')
+  expect(button).toHaveClass('border', 'border-input')
+})
+```
+
+## Testing Routes
+
+```typescript
+// test/routes/namespace.test.tsx
+import { render, screen } from '@testing-library/react'
+import { createRouter } from '@konfigyr/test/router'
+
+test('should render namespace page', async () => {
+  // Arrange & Act
+  render(createRouter({ path: '/namespace/test' }))
+
+  // Assert
+  expect(await screen.findByText('Test Namespace')).toBeInTheDocument()
+})
+
+test('should show error when not found', async () => {
+  server.use(
+    http.get('/api/namespaces/missing', () =>
+      HttpResponse.json({ error: 'Not found' }, { status: 404 }),
+    ),
+  )
+
+  render(createRouter({ path: '/namespace/missing' }))
+  expect(await screen.findByText(/not found/i)).toBeInTheDocument()
+})
+```
+
+## Test Utilities
+
+```typescript
+// test/utils.ts
+import { QueryClientProvider } from '@tanstack/react-query'
+import { queryClient } from '@konfigyr/lib/query'
+
+export function createWrapper() {
+  return ({ children }) => (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  )
+}
+
+export function createRouter(options: { path: string }) {
+  return <RouterProvider router={createTestRouter(options.path)} />
+}
+```
+
+## Arrange-Act-Assert Pattern
+
+```typescript
+test('should update namespace name', async () => {
+  // ===== ARRANGE =====
+  const handleClick = vi.fn()
+  render(<Form onSubmit={handleClick} />)
+
+  // ===== ACT =====
+  const input = screen.getByLabelText('Name')
+  await user.type(input, 'New Name')
+  await user.click(screen.getByRole('button', { name: 'Submit' }))
+
+  // ===== ASSERT =====
+  await waitFor(() => {
+    expect(handleClick).toHaveBeenCalledWith({
+      name: 'New Name',
+    })
+  })
+})
+```
+
+## Testing with Server Errors
+
+```typescript
+test('should show error message on API failure', async () => {
+  server.use(
+    http.post('/api/namespaces', () => {
+      return HttpResponse.json(
+        { error: 'Validation failed' },
+        { status: 400 },
+      )
+    }),
+  )
+
+  render(<CreateNamespaceForm />)
+  await user.click(screen.getByRole('button'))
+
+  expect(await screen.findByText('Validation failed')).toBeInTheDocument()
+})
+```
+
+## Run Tests
+
+```bash
+npm run test              # Watch mode
+npm run test:coverage    # Coverage report
+npm run test:ci         # CI mode (once, with lint + type-check)
+```
+
+## Verification Checklist
+
+- [ ] All tests use Arrange-Act-Assert
+- [ ] No real API calls (MSW intercepts all)
+- [ ] Components tested with and without data
+- [ ] Error states tested
+- [ ] Async operations awaited properly
+- [ ] User interactions use `userEvent`
+- [ ] Query results awaited with `waitFor`
+- [ ] Test names describe behavior
+- [ ] No hardcoded test data (use factories)
+- [ ] Coverage > 80%
+

--- a/.claude/skills/frontend/oidc-authentication/SKILL.md
+++ b/.claude/skills/frontend/oidc-authentication/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: oidc-authentication
+description: OIDC authentication flow, session management via encrypted cookies, token lifecycle, useAccount hook, and accessing user data in components. Use when implementing auth features or accessing authenticated user context.
+---
+
+# OIDC Authentication
+
+## Authentication Flow
+
+1. Frontend redirects to Identity Provider (AuthCode + PKCE)
+2. IdP authenticates user
+3. IdP redirects back to `/auth/code?code=...`
+4. Server exchanges code for tokens
+5. Tokens stored in encrypted HTTP-only cookie
+6. Token automatically included in all `/api/*` requests
+
+## Session Management
+
+Handled entirely in `src/middleware/authentication.ts` and `src/lib/authentication.ts`.
+
+**Do not add auth logic in components.** Access user via `useAccount()` hook only.
+
+```typescript
+// Middleware runs on every request (server-side)
+// - Checks session cookie
+// - Refreshes expired tokens
+// - Redirects to IdP if missing
+
+// Tokens never exposed to client code
+// - Only server-side proxy sees them
+// - Components never access `localStorage` or `sessionStorage`
+```
+
+## useAccount Hook
+
+Access current user in any component inside `AccountProvider`:
+
+```typescript
+import { useAccount } from '@konfigyr/components/account'
+
+export function NamespaceCard() {
+  const account = useAccount()  // Throws if outside provider
+  
+  return <div>Welcome, {account.email}</div>
+}
+```
+
+**AccountProvider** wraps authenticated routes (in `_authenticated/route.tsx`):
+
+```typescript
+export const Route = createFileRoute('/_authenticated')({
+  component: AuthenticatedLayout,
+})
+
+function AuthenticatedLayout() {
+  return (
+    <AccountProvider>
+      <Outlet />
+    </AccountProvider>
+  )
+}
+```
+
+## Environment Variables
+
+Required for OIDC setup:
+
+```bash
+# IdP base URL
+KONFIGYR_ID_URL=http://localhost:8081
+
+# OAuth2 client credentials
+KONFIGYR_OAUTH_CLIENT_ID=konfigyr-frontend
+KONFIGYR_OAUTH_CLIENT_SECRET=...
+
+# Session encryption
+KONFIGYR_SESSION_KEY=... (32-byte base64)
+
+# Backend API (server-side proxy)
+KONFIGYR_API_URL=http://localhost:8080
+```
+
+## Token Access
+
+**Never access tokens directly in components:**
+
+```typescript
+// ✗ Wrong: Tokens aren't in window or localStorage
+const token = localStorage.getItem('access_token')  // undefined
+
+// ✓ Correct: Tokens in encrypted cookie, automatically attached
+// All /api/* requests include token in Authorization header
+const { data } = useSuspenseQuery(getNamespaceQuery(slug))
+```
+
+## Handling 401/403
+
+If token expires or scopes invalid:
+
+```typescript
+// ✗ Wrong: Manual error checking
+if (response.status === 401) {
+  localStorage.removeItem('token')
+  window.location.href = '/login'
+}
+
+// ✓ Correct: Middleware redirects automatically
+// If token invalid, request to IdP
+// If no session, redirect to AuthCode flow
+```
+
+## OAuth2 Scopes in Frontend
+
+Scopes determine what API endpoints user can access:
+
+```typescript
+// When requesting data, backend validates scope
+// 403 Forbidden → user lacks required scope
+// 401 Unauthorized → token expired or missing
+
+try {
+  const { data } = useSuspenseQuery(getNamespaceQuery(slug))
+} catch (error) {
+  if (error.status === 403) {
+    return <div>Access denied. Contact admin.</div>
+  }
+}
+```
+
+## Account Data Structure
+
+```typescript
+interface Account {
+  id: string
+  email: string
+  firstName?: string
+  lastName?: string
+  avatarUrl?: string
+  createdAt: Date
+}
+
+// Access in component
+const account = useAccount()
+account.email  // user@example.com
+account.firstName  // John
+```
+
+## Logout
+
+Logout endpoint clears session:
+
+```typescript
+const logout = async () => {
+  await fetch('/api/auth/logout', { method: 'POST' })
+  window.location.href = '/'  // Redirect to login
+}
+```
+
+## Token Refresh
+
+Automatic in middleware (server-side). No client-side token management needed.
+
+```
+Request → Middleware checks expiration
+         → If expired, refresh automatically
+         → Include refreshed token in request
+         → Proceed
+```
+
+## Testing Authentication
+
+```typescript
+import { render } from '@testing-library/react'
+import { createRouter } from '@konfigyr/test/router'
+
+test('should show account email', () => {
+  render(createRouter({ 
+    path: '/_authenticated',
+    authenticated: true,  // Mock authenticated state
+  }))
+  
+  expect(screen.getByText(/user@example.com/)).toBeInTheDocument()
+})
+
+test('should redirect to login when not authenticated', () => {
+  render(createRouter({
+    path: '/_authenticated',
+    authenticated: false,
+  }))
+  
+  expect(window.location.pathname).toBe('/auth/login')
+})
+```
+
+## Verification Checklist
+
+- [ ] useAccount() only used inside AccountProvider
+- [ ] No token access in client code
+- [ ] No localStorage/sessionStorage usage
+- [ ] Environment variables configured
+- [ ] Logout clears session
+- [ ] 401/403 responses handled
+- [ ] Components test with/without auth
+- [ ] No hardcoded user data
+

--- a/.claude/skills/frontend/react-components/SKILL.md
+++ b/.claude/skills/frontend/react-components/SKILL.md
@@ -1,0 +1,213 @@
+---
+name: react-components
+description: Component conventions including named exports, TypeScript interfaces, data fetching via hooks, styling with Tailwind, and using CVA for variants. Use when building new components or updating existing UI.
+---
+
+# React Components
+
+## Component Convention
+
+```typescript
+// components/ui/button.tsx
+
+// 1. Props interface
+interface ButtonProps extends React.ComponentPropsWithoutRef<'button'> {
+  variant?: 'default' | 'outline' | 'ghost'
+  size?: 'sm' | 'md' | 'lg'
+}
+
+// 2. Named export (never export default)
+export function Button({
+  variant = 'default',
+  size = 'md',
+  className,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      data-slot="button"
+      className={cn(
+        'inline-flex items-center justify-center rounded font-medium',
+        variant === 'default' && 'bg-primary text-primary-fg',
+        variant === 'outline' && 'border border-input',
+        size === 'sm' && 'h-8 px-2 text-sm',
+        size === 'md' && 'h-10 px-3',
+        size === 'lg' && 'h-12 px-4',
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+```
+
+## Using CVA (Class Variance Authority)
+
+```typescript
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from './utils'
+
+const cardVariants = cva('rounded-lg border', {
+  variants: {
+    variant: {
+      default: 'bg-card text-card-foreground',
+      elevated: 'shadow-lg',
+    },
+    padding: {
+      sm: 'p-3',
+      md: 'p-6',
+      lg: 'p-8',
+    },
+  },
+  defaultVariants: {
+    variant: 'default',
+    padding: 'md',
+  },
+})
+
+interface CardProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof cardVariants> {}
+
+export function Card({
+  variant,
+  padding,
+  className,
+  ...props
+}: CardProps) {
+  return (
+    <div
+      className={cn(cardVariants({ variant, padding }), className)}
+      {...props}
+    />
+  )
+}
+```
+
+## Data Fetching in Components
+
+```typescript
+// ✓ Correct: Use hooks for data
+function NamespaceCard({ slug }: { slug: string }) {
+  const { data: namespace } = useGetNamespace(slug)
+  return <div>{namespace?.name}</div>
+}
+
+// ✗ Wrong: Direct API call
+function NamespaceCard({ slug }) {
+  const [data, setData] = useState(null)
+  useEffect(() => {
+    // Never do this - use hooks instead
+    fetch(`/api/namespaces/${slug}`).then(r => r.json()).then(setData)
+  }, [slug])
+}
+```
+
+## Styling Rules
+
+- Use Tailwind utilities
+- Use CSS custom properties for colors (`var(--primary)`)
+- Support dark mode with `dark:` prefix
+- Use `cn()` for conditional class merging
+
+```typescript
+export function Component() {
+  return (
+    <div className={cn(
+      // Base styles
+      'flex items-center justify-center p-4',
+      // Conditional
+      isActive && 'bg-primary text-white',
+      // Dark mode
+      'dark:bg-slate-900 dark:text-slate-50',
+      // Responsive
+      'sm:p-2 lg:p-6',
+    )}>
+      Content
+    </div>
+  )
+}
+```
+
+## Component Organization
+
+```
+components/
+├── ui/                    # Reusable primitives
+│   ├── button.tsx
+│   ├── card.tsx
+│   ├── dialog.tsx
+│   └── utils.ts          # cn(), styling helpers
+├── namespace/            # Feature-specific
+│   ├── NamespaceCard.tsx
+│   ├── NamespaceForm.tsx
+│   └── NamespaceList.tsx
+├── vault/
+├── layout/
+└── error/
+```
+
+## TypeScript Props
+
+```typescript
+// With optional props
+interface FormProps {
+  onSubmit: (data: Data) => void | Promise<void>
+  loading?: boolean
+  error?: Error | null
+}
+
+// With children
+interface LayoutProps {
+  children: React.ReactNode
+  title: string
+}
+
+// HTML attributes spread
+interface InputProps
+  extends React.ComponentPropsWithoutRef<'input'> {
+  label?: string
+}
+
+export function Input({ label, ...props }: InputProps) {
+  return (
+    <div>
+      {label && <label>{label}</label>}
+      <input {...props} />
+    </div>
+  )
+}
+```
+
+## data-slot Attribute
+
+Use `data-slot` for styling hooks:
+
+```typescript
+function Card() {
+  return (
+    <div data-slot="card" className="border rounded p-4">
+      <h2 data-slot="card-title" className="font-bold">
+        Title
+      </h2>
+    </div>
+  )
+}
+
+// In global CSS
+[data-slot='card'] { @apply shadow; }
+[data-slot='card-title'] { @apply text-lg; }
+```
+
+## Verification Checklist
+
+- [ ] Named exports only (no default exports)
+- [ ] Props interface defined above component
+- [ ] All data fetching via hooks
+- [ ] Styling uses Tailwind + CSS variables
+- [ ] Dark mode supported (`dark:` classes)
+- [ ] Component is testable (no hardcoded dependencies)
+- [ ] Props TypeScript typed
+- [ ] Responsive design considered
+- [ ] Accessible (semantic HTML, ARIA attributes)
+

--- a/.claude/skills/frontend/tailwind-styling/SKILL.md
+++ b/.claude/skills/frontend/tailwind-styling/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: tailwind-styling
+description: Tailwind CSS conventions, design tokens via CSS custom properties, dark mode support, responsive design, and styling best practices. Use when styling components, updating design tokens, or implementing dark mode.
+---
+
+# Tailwind Styling
+
+## Design Tokens (CSS Variables)
+
+Define all colors and spacing in `src/styles.css`:
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 0 0% 3%;
+    --primary: 0 84% 60%;
+    --primary-foreground: 0 85% 97%;
+    --secondary: 217 33% 17%;
+    --accent: 142 71% 45%;
+    --destructive: 0 84% 60%;
+    --muted: 0 0% 96%;
+    --muted-foreground: 0 0% 45%;
+    --border: 0 0% 89%;
+    --input: 0 0% 89%;
+    --ring: 0 84% 60%;
+    --radius-sm: 0.25rem;
+    --radius-md: 0.375rem;
+    --radius-lg: 0.5rem;
+  }
+
+  .dark {
+    --background: 0 0% 3%;
+    --foreground: 0 0% 98%;
+    --primary: 0 84% 60%;
+    --secondary: 217 100% 87%;
+    --muted: 0 0% 14%;
+    --muted-foreground: 0 0% 63%;
+    --border: 0 0% 14%;
+    --input: 0 0% 20%;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
+  }
+}
+```
+
+## Using Design Tokens
+
+```typescript
+// ✓ Correct: Use token name
+<div className="bg-primary text-primary-foreground" />
+
+// ✗ Wrong: Hardcoded color
+<div className="bg-blue-500 text-white" />
+
+// ✓ Correct: Dark mode
+<div className="bg-primary dark:bg-secondary" />
+```
+
+## Tailwind Config
+
+```javascript
+// tailwind.config.ts
+import type { Config } from 'tailwindcss'
+
+export default {
+  content: ['./src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: 'hsl(var(--primary))',
+        'primary-foreground': 'hsl(var(--primary-foreground))',
+        secondary: 'hsl(var(--secondary))',
+        accent: 'hsl(var(--accent))',
+        muted: 'hsl(var(--muted))',
+        'muted-foreground': 'hsl(var(--muted-foreground))',
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        destructive: 'hsl(var(--destructive))',
+      },
+      borderRadius: {
+        sm: 'var(--radius-sm)',
+        md: 'var(--radius-md)',
+        lg: 'var(--radius-lg)',
+      },
+    },
+  },
+} satisfies Config
+```
+
+## Responsive Design
+
+```typescript
+// Mobile-first approach
+<div className={cn(
+  // Mobile: small padding
+  'p-3',
+  // Tablet and up
+  'sm:p-4',
+  // Desktop and up
+  'md:p-6',
+  'lg:p-8',
+)}>
+  Content
+</div>
+
+// Responsive grid
+<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+  {items.map(item => <Card key={item.id} {...item} />)}
+</div>
+```
+
+## Dark Mode
+
+```typescript
+// ✓ Correct: Explicit dark variants
+<div className={cn(
+  'bg-white text-black',
+  'dark:bg-slate-900 dark:text-white',
+)} />
+
+// Component with dark support
+export function Button() {
+  return (
+    <button className={cn(
+      'bg-primary text-primary-foreground',
+      'dark:bg-primary dark:text-primary-foreground',  // Can be same
+      'hover:opacity-90',
+      'dark:hover:opacity-80',
+    )} />
+  )
+}
+```
+
+## Typography
+
+Font stack in CSS:
+
+```css
+@layer base {
+  body {
+    @apply font-sans;
+  }
+
+  h1, h2, h3 {
+    @apply font-heading;
+  }
+
+  code {
+    @apply font-mono;
+  }
+}
+```
+
+Config:
+
+```javascript
+theme: {
+  extend: {
+    fontFamily: {
+      sans: ['Geist', 'system-ui', 'sans-serif'],
+      heading: ['Rubik', 'sans-serif'],
+      mono: ['JetBrains Mono', 'monospace'],
+    },
+  },
+}
+```
+
+## Focus & Keyboard Navigation
+
+```typescript
+// ✓ Good: Visible focus
+<button className={cn(
+  'px-3 py-2 rounded',
+  'focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2',
+  'dark:focus:ring-offset-slate-950',
+)} />
+
+// ✗ Bad: No focus styling
+<button className="px-3 py-2 rounded" />
+```
+
+## Component Composition
+
+```typescript
+// Compose with cn()
+export function Card({ className, ...props }) {
+  return (
+    <div
+      className={cn(
+        'rounded-lg border bg-card p-6 text-card-foreground',
+        'shadow-sm hover:shadow-md transition-shadow',
+        'dark:border-slate-700',
+        className,  // Allows overrides
+      )}
+      {...props}
+    />
+  )
+}
+```
+
+## Verification Checklist
+
+- [ ] All colors use design tokens (CSS variables)
+- [ ] Dark mode variants present
+- [ ] Responsive design tested (sm, md, lg breakpoints)
+- [ ] Focus states visible for keyboard navigation
+- [ ] No hardcoded colors in component code
+- [ ] Font stack defined
+- [ ] Spacing consistent (use Tailwind scale)
+- [ ] Contrast ratios meet WCAG AA
+- [ ] Print styles considered if needed
+

--- a/.claude/skills/frontend/tanstack-queries/SKILL.md
+++ b/.claude/skills/frontend/tanstack-queries/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: tanstack-queries
+description: TanStack Query patterns for data fetching, mutation hooks, query key structure, cache management, and stale time configuration. Use when working with API data, implementing cache strategies, or managing server state.
+---
+
+# TanStack Query (React Query)
+
+## Query Hooks Pattern
+
+All data fetching goes through hooks. Never call `ky` directly from components.
+
+```typescript
+// hooks/namespace/query.ts
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { request } from '@konfigyr/lib/http'
+
+// Query key constants
+export const namespaceKeys = {
+  all: () => ['namespaces'] as const,
+  lists: () => [...namespaceKeys.all(), 'list'] as const,
+  list: (filters?: Record<string, any>) => [...namespaceKeys.lists(), filters] as const,
+  details: () => [...namespaceKeys.all(), 'detail'] as const,
+  detail: (slug: string) => [...namespaceKeys.details(), slug] as const,
+}
+
+// Query options factory
+export const getNamespaceQuery = (slug: string) =>
+  queryOptions({
+    queryKey: namespaceKeys.detail(slug),
+    queryFn: async ({ signal }) => {
+      const res = await request.get(`api/namespaces/${slug}`, { signal })
+      return res.json<Namespace>()
+    },
+    staleTime: Infinity, // Read-only data
+  })
+
+// Hook for component use
+export const useGetNamespace = (slug: string) =>
+  useQuery(getNamespaceQuery(slug))
+
+// Mutation hook
+export const useUpdateNamespace = () => {
+  const client = useQueryClient()
+  
+  return useMutation({
+    mutationFn: async (def: NamespaceDefinition) => {
+      const res = await request.patch(`api/namespaces/${def.slug}`, {
+        json: def,
+      })
+      return res.json<Namespace>()
+    },
+    onSuccess: (updated) => {
+      // Update cache after successful mutation
+      client.setQueryData(namespaceKeys.detail(updated.slug), updated)
+      // Invalidate list to refetch
+      client.invalidateQueries({ queryKey: namespaceKeys.lists() })
+    },
+  })
+}
+```
+
+## staleTime Configuration
+
+```typescript
+// Read-only data (never changes via mutations)
+staleTime: Infinity
+
+// Data that changes frequently
+staleTime: 0  // Always stale
+
+// Data refreshed occasionally
+staleTime: 5 * 60 * 1000  // 5 minutes
+```
+
+## Using Queries in Components
+
+```typescript
+// Suspense (for prefetched data in loaders)
+const { data: namespace } = useSuspenseQuery(getNamespaceQuery(slug))
+
+// Regular query (client-side fetch)
+const { data, isLoading, error } = useQuery(getNamespaceQuery(slug))
+```
+
+## Mutations with Optimistic Updates
+
+```typescript
+export const useRenameNamespace = () => {
+  const client = useQueryClient()
+  
+  return useMutation({
+    mutationFn: (params: { slug: string; newName: string }) =>
+      request.patch(`api/namespaces/${params.slug}`, {
+        json: { name: params.newName },
+      }).json<Namespace>(),
+    
+    // Optimistic update
+    onMutate: (vars) => {
+      // Cancel in-flight queries
+      client.cancelQueries({ queryKey: namespaceKeys.detail(vars.slug) })
+      
+      // Get previous data
+      const previous = client.getQueryData(namespaceKeys.detail(vars.slug))
+      
+      // Update cache optimistically
+      client.setQueryData(namespaceKeys.detail(vars.slug), (old: Namespace) => ({
+        ...old,
+        name: vars.newName,
+      }))
+      
+      return { previous }
+    },
+    
+    // Rollback on error
+    onError: (err, vars, context) => {
+      if (context?.previous) {
+        client.setQueryData(
+          namespaceKeys.detail(vars.slug),
+          context.previous,
+        )
+      }
+    },
+    
+    // Update on success
+    onSuccess: (updated) => {
+      client.setQueryData(namespaceKeys.detail(updated.slug), updated)
+    },
+  })
+}
+```
+
+## Query Key Best Practices
+
+```typescript
+// Hierarchical structure
+export const userKeys = {
+  all: () => ['users'] as const,
+  lists: () => [...userKeys.all(), 'list'] as const,
+  list: (filters) => [...userKeys.lists(), filters] as const,
+  details: () => [...userKeys.all(), 'detail'] as const,
+  detail: (id) => [...userKeys.details(), id] as const,
+}
+
+// Invalidate related queries
+client.invalidateQueries({ queryKey: userKeys.all() })  // All user queries
+client.invalidateQueries({ queryKey: userKeys.lists() })  // Only list queries
+client.invalidateQueries({ queryKey: userKeys.detail(id) })  // Specific user
+```
+
+## Infinite Queries
+
+```typescript
+export const useNamespacesInfinite = () =>
+  useInfiniteQuery({
+    queryKey: ['namespaces', 'infinite'],
+    queryFn: ({ pageParam = 0 }) =>
+      request.get(`api/namespaces?page=${pageParam}`).json(),
+    getNextPageParam: (lastPage, pages) =>
+      lastPage.hasMore ? pages.length : null,
+  })
+
+// In component
+const { data, fetchNextPage, hasNextPage } = useNamespacesInfinite()
+
+{data?.pages.map((page) =>
+  page.items.map((ns) => <div key={ns.id}>{ns.name}</div>)
+)}
+
+<button onClick={() => fetchNextPage()} disabled={!hasNextPage}>
+  Load More
+</button>
+```
+
+## Verification Checklist
+
+- [ ] All data fetching via hooks (no direct `ky` calls from components)
+- [ ] Query keys hierarchical and consistent
+- [ ] `staleTime` configured appropriately
+- [ ] Mutations invalidate related queries
+- [ ] Optimistic updates on mutations
+- [ ] Error handling in mutations
+- [ ] Loader prefetches with `ensureQueryData`
+- [ ] Components use `useSuspenseQuery` (when prefetched)
+- [ ] Cache invalidation strategy documented
+

--- a/.claude/skills/frontend/tanstack-routing/SKILL.md
+++ b/.claude/skills/frontend/tanstack-routing/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: tanstack-routing
+description: File-based routing with TanStack Router, creating routes, loaders for data prefetching, dynamic segments, and form handlers. Use when adding new pages or modifying navigation structure.
+---
+
+# TanStack Router & File-Based Routing
+
+## Overview
+
+TanStack Start uses file-based routing where folder structure determines URLs.
+
+| File | URL | Purpose |
+|------|-----|---------|
+| `index.tsx` | `/` at that level | Page component |
+| `$param.tsx` | `/:param` | Dynamic segment |
+| `-handler.ts` | Form submission | POST/PATCH/DELETE handlers |
+| `_layout/route.tsx` | Pathless layout | Wraps children, no URL change |
+
+## Example Route Structure
+
+```
+routes/
+├── __root.tsx                    # Root layout + providers
+├── _authenticated/route.tsx      # Pathless: adds AccountProvider
+│   ├── index.tsx                 # /dashboard
+│   └── namespace/
+│       └── $namespace/
+│           ├── index.tsx         # /namespace/:namespace
+│           └── index-handler.ts  # Form actions
+├── auth/code.tsx                 # /auth/code (OAuth callback)
+└── api/$.ts                      # /api/* (proxy)
+```
+
+## Creating a Route
+
+```typescript
+// routes/_authenticated/namespace/$namespace/index.tsx
+import { createFileRoute } from '@tanstack/react-router'
+import { getNamespaceQuery } from '@konfigyr/hooks/namespace/query'
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace',
+)({
+  // Prefetch data server-side (optional)
+  loader: ({ context: { queryClient }, params }) =>
+    queryClient.ensureQueryData(getNamespaceQuery(params.namespace)),
+  
+  component: NamespacePage,
+})
+
+function NamespacePage() {
+  const { namespace } = Route.useParams()
+  // Data already loaded by loader
+  const { data } = useSuspenseQuery(getNamespaceQuery(namespace))
+  
+  return <div>{data.name}</div>
+}
+```
+
+## Form Handlers
+
+```typescript
+// routes/namespace/$namespace/index-handler.ts
+import { json } from '@tanstack/start'
+
+export const updateNamespaceAction = async ({
+  request,
+  params,
+}: {
+  request: Request
+  params: { namespace: string }
+}) => {
+  const formData = await request.formData()
+  const name = formData.get('name') as string
+
+  const response = await fetch(
+    `/api/namespaces/${params.namespace}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify({ name }),
+    },
+  )
+
+  if (!response.ok) {
+    return json({ error: 'Failed' }, { status: response.status })
+  }
+
+  return json({ success: true })
+}
+
+// Usage in component
+import { Form } from '@tanstack/react-router'
+import { updateNamespaceAction } from './index-handler'
+
+<Form action={updateNamespaceAction}>
+  <input name="name" />
+  <button>Update</button>
+</Form>
+```
+
+## Navigation
+
+```typescript
+import { Link, useNavigate } from '@tanstack/react-router'
+
+// Link
+<Link 
+  to="/namespace/$namespace" 
+  params={{ namespace: 'my-org' }}
+>
+  Go to Org
+</Link>
+
+// Programmatic
+const navigate = useNavigate()
+navigate({
+  to: '/namespace/$namespace',
+  params: { namespace: 'my-org' },
+})
+```
+
+## Loaders Best Practices
+
+- Use `ensureQueryData()` to prefetch
+- Loader runs server-side before render
+- Component uses `useSuspenseQuery()` (no loading state needed)
+- Throw errors in loader to trigger error boundary
+
+```typescript
+export const Route = createFileRoute('/_authenticated/namespace/$namespace')({
+  loader: ({ context, params }) => {
+    // Prefetch data
+    return context.queryClient.ensureQueryData(
+      getNamespaceQuery(params.namespace)
+    )
+  },
+  errorComponent: () => <div>Namespace not found</div>,
+  component: NamespacePage,
+})
+```
+
+## Pathless Layouts
+
+Use `_layout/route.tsx` for wrappers that don't affect URL:
+
+```typescript
+// routes/_authenticated/route.tsx
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { AccountProvider } from '@konfigyr/components/account'
+
+export const Route = createFileRoute('/_authenticated')({
+  component: AuthenticatedLayout,
+})
+
+function AuthenticatedLayout() {
+  return (
+    <AccountProvider>
+      <div className="layout">
+        <Navbar />
+        <Outlet /> {/* Renders child routes */}
+        <Footer />
+      </div>
+    </AccountProvider>
+  )
+}
+```
+
+## Verification Checklist
+
+- [ ] Route path matches URL structure
+- [ ] Loader defined if data prefetch needed
+- [ ] Dynamic segments use `$param` naming
+- [ ] Form handlers colocated with routes (-handler.ts)
+- [ ] Components use `useSuspenseQuery` (loader prefetches)
+- [ ] Error boundaries handle missing data
+- [ ] Navigation uses typed `to` and `params`
+- [ ] Pathless layouts use correct naming
+

--- a/.claude/skills/shared/git-practices/SKILL.md
+++ b/.claude/skills/shared/git-practices/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: git-practices
+description: Git commit message conventions, PR structure, code review practices, and when to ask before changing. Use for all version control and collaboration workflow.
+---
+
+# Git Practices
+
+## Commit Messages
+
+**Format:** Clear, imperative, concise
+
+```
+# ✓ Good
+Add namespace quota validation
+Update jOOQ generated code after schema change
+Fix N+1 query in vault list endpoint
+
+# ✗ Bad
+fixed stuff
+WIP
+Update
+changes
+```
+
+**Structure:**
+- **First line:** 50 characters max, imperative mood
+- **Blank line:** Separate from body
+- **Body:** Explain WHY (not what or how)
+- **Closes #123:** Link to issue (if applicable)
+
+**Example:**
+
+```
+Add namespace quota validation
+
+The namespace module now validates that a namespace 
+doesn't exceed the quota set in the feature flag. 
+This prevents runaway consumption in multi-tenant deployments.
+
+Closes #456
+```
+
+## Commit Scope
+
+**One logical change per commit.** Not one change per file, one per line.
+
+```
+# ✓ Good: Logical units
+1st commit: Add namespace quota field to database
+2nd commit: Implement quota validation in NamespaceManager
+3rd commit: Add REST endpoint to update quota
+
+# ✗ Bad: Too many unrelated changes
+1st commit: Add field, validation, endpoint, AND audit logging
+```
+
+## Squashing Commits
+
+Before merging, squash related commits:
+
+```bash
+# Before PR: 5 commits for one feature
+git log --oneline
+abc1234 Fix typo in constant
+abc1235 Rename variable
+abc1236 Add namespace validation
+abc1237 Update tests
+abc1238 Add OpenAPI docs
+
+# After squashing: 1 logical commit
+git rebase -i HEAD~5
+# Mark all but first as 'squash'
+# Result: 1 commit "Add namespace validation"
+```
+
+## Pull Request Structure
+
+### Title
+Clear summary, not a question:
+
+```
+# ✓ Good
+Add namespace quota validation
+Fix N+1 query in vault endpoint
+Update Spring Boot to 3.5.1
+
+# ✗ Bad
+Fixed issue
+Update code
+What about namespaces?
+```
+
+### Description
+
+Template:
+
+```markdown
+## What
+Brief description of the change.
+
+## Why
+Business reason or technical justification. 
+
+## How
+High-level approach (don't explain code).
+
+## Testing
+How was this tested? Which scenarios?
+
+## Checklist
+- [ ] Code compiles without warnings
+- [ ] Tests pass (./gradlew test or npm run test:ci)
+- [ ] No unused imports
+- [ ] Documentation updated (if API changes)
+- [ ] Commit history is clean
+```
+
+### Review Checklist
+
+As **author:**
+- [ ] PR title is clear and descriptive
+- [ ] Description explains the "why"
+- [ ] Changes are logically grouped
+- [ ] All tests pass
+- [ ] No unrelated changes ("cleanup" commits)
+
+As **reviewer:**
+- [ ] Understand the business reason
+- [ ] Code follows project conventions
+- [ ] No hardcoded values
+- [ ] Tests cover happy path + errors
+- [ ] No over-engineering
+- [ ] Performance implications considered
+
+## When to Ask Before Changing
+
+**Always ask upfront; don't implement then ask for permission:**
+
+### Architecture Questions
+- "Should this be a new aggregate or part of existing one?"
+- "Which module should own this logic?"
+- "Is this a breaking change?"
+
+### Design Questions
+- "Should this be an event or a direct service call?"
+- "What's the scope for this endpoint?"
+- "Do we need to add a table or can we reuse existing ones?"
+
+### Code Quality Questions
+- "Should I refactor this module?"
+- "Is this performance critical?"
+- "Should we add a caching layer?"
+
+### Maintenance Questions
+- "Should I update the README?"
+- "Does this need documentation?"
+- "Should we version this endpoint?"
+
+## Merge Strategy
+
+**Squash and merge** for small PRs:
+```bash
+# One commit per feature
+git merge --squash feature/namespace-quota
+git commit -m "Add namespace quota validation"
+```
+
+**Rebase and merge** for clean history:
+```bash
+# Keep all commits if they're already clean
+git rebase main
+git push -f
+# Then merge without squash
+```
+
+**Don't use merge commits:**
+```bash
+# ✗ Avoid
+git merge feature  # Creates merge commit
+```
+
+## Reverting Changes
+
+If you must revert:
+
+```bash
+# Revert a commit (create new commit that undoes it)
+git revert <commit-hash>
+
+# Revert a PR
+git revert -m 1 <merge-commit-hash>
+
+# Don't force push to shared branch:
+git push origin main  # ✓ Safe
+git push -f origin main  # ✗ Never on shared branches
+```
+
+## Branching Convention
+
+```
+feature/namespace-quota              Feature
+bugfix/vault-encryption              Bug fix
+docs/add-architecture-guide          Documentation
+chore/update-spring-boot             Maintenance
+```
+
+## Local Development
+
+```bash
+# Create feature branch
+git checkout -b feature/my-feature
+
+# Make changes, commit
+git add .
+git commit -m "First logical chunk"
+git commit -m "Second logical chunk"
+
+# Before PR: rebase and squash if needed
+git rebase main
+# OR
+git rebase -i HEAD~3  # Squash last 3 commits
+
+# Push
+git push -u origin feature/my-feature
+
+# Create PR in GitHub
+# After review: merge with squash
+```
+
+## Handling Merge Conflicts
+
+```bash
+# Rebase your branch on main
+git fetch origin
+git rebase origin/main
+
+# If conflicts:
+# 1. Edit files to resolve
+# 2. Stage resolved files
+git add <resolved-files>
+
+# 3. Continue rebase
+git rebase --continue
+
+# 4. Force push (safe if feature branch is yours)
+git push -f origin feature/my-feature
+```
+
+## Code Review Comments
+
+**Be kind and constructive:**
+
+```
+# ✓ Good
+This N+1 query could be expensive with large datasets.
+Consider using an EXISTS subquery: [example]
+
+# ✗ Bad
+This is wrong. Use EXISTS.
+```
+
+**Accept suggestions gracefully:**
+```
+# ✓ Good
+You're right, that's cleaner. I'll update.
+
+# ✗ Bad
+That doesn't matter.
+```
+
+## Amending Commits
+
+If you forgot something small:
+
+```bash
+# Make change
+git add .
+
+# Amend last commit (don't create a new one)
+git commit --amend --no-edit
+
+# Force push to your branch
+git push -f origin feature/my-feature
+
+# Don't do this on main or after PR is merged!
+```
+
+## Verification Checklist
+
+- [ ] Commit messages are clear and imperative
+- [ ] PR description explains "why"
+- [ ] One logical change per PR (not everything)
+- [ ] All tests pass before requesting review
+- [ ] No large files or secrets committed
+- [ ] Code follows project conventions
+- [ ] Documentation updated if needed
+- [ ] Commit history is clean (squashed if needed)
+

--- a/.claude/skills/shared/project-overview/SKILL.md
+++ b/.claude/skills/shared/project-overview/SKILL.md
@@ -1,0 +1,327 @@
+---
+name: project-overview
+description: Konfigyr system architecture, business domains, module responsibilities, and design decisions. Use when understanding the system structure or designing new features that span multiple modules.
+---
+
+# Konfigyr Project Overview
+
+## System Architecture
+
+Three independently deployed services:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Frontend (React/TanStack) - konfigyr-frontend          │
+│ - SSR with Nitro                                        │
+│ - OAuth2 Authorization Code + PKCE                      │
+│ - Session in encrypted HTTP-only cookie                 │
+└─────────┬───────────────────────────────────┬───────────┘
+          │                                   │
+    1. Auth Flow                      2. API Calls
+          │                                   │
+┌─────────▼─────────────────┐    ┌──────────▼─────────────┐
+│ Identity Provider         │    │ REST API                │
+│ konfigyr-identity         │    │ konfigyr-api            │
+│ - Spring AuthServer       │    │ - Spring Boot 3.5+      │
+│ - OAuth2/OIDC broker      │    │ - Spring Modulith       │
+│ - JWT issuance (PS256)    │    │ - jOOQ + Liquibase      │
+│ - External IdP federation │    │ - @RequiresScope auth   │
+└──────────────────────────┘    └────────────────────────┘
+                                  │
+                            ┌─────▼──────────────┐
+                            │ PostgreSQL Database │
+                            │ - Liquibase managed │
+                            │ - Encrypted vaults  │
+                            └────────────────────┘
+```
+
+### Identity Provider: Protocol Broker
+
+The IdP is not a plain JWT issuer — it is an **identity broker and protocol translator**. It accepts
+authentication from upstream external providers (GitHub, GitLab, Google, SAML-based enterprise IdPs, or
+customer-managed OIDC providers) and translates those identities into a single, standardized OIDC JWT
+issued by Konfigyr. Application code never needs to handle provider-specific token formats.
+
+Key responsibilities:
+- Delegates authentication to external providers; never stores credentials itself
+- Maps external user identities to local `Account` records
+- Issues PS256/ES256 JWT access tokens and ID tokens
+- Exposes standard OIDC endpoints: JWKS, discovery (`.well-known`), token introspection, and revocation
+
+## Business Domains (Modules)
+
+| Module | Responsibility | Key Entities |
+|--------|---|---|
+| **namespace** | Multi-tenancy | Namespace, Member, Role |
+| **vault** | Config management | Profile, Entry, ChangeRequest, ChangeHistory |
+| **artifactory** | Metadata registry | Artifact, ArtifactVersion, PropertyDescriptor, PropertyOccurrence, ServiceManifest |
+| **kms** | Encryption | KeysetMetadata, KeyVersion |
+| **audit** | Event logging | AuditEvent, AuditLog |
+| **account** | User management | Account (from OAuth) |
+| **feature** | Feature flags | FeatureFlag (per-namespace limits) |
+
+## Key Design Decisions
+
+### 1. Per-Namespace Encryption
+
+- Each namespace owns a `KeysetMetadata` in KMS
+- Vault data encrypted with the namespace's DEK keyset
+- Key compromise in one namespace doesn't expose others
+- Benefits: tenant isolation, regulatory compliance
+
+### 2. JSON Schema for Property Metadata
+
+- Property descriptors stored as JSON Schema (not Java types)
+- Enables language-agnostic validation
+- Rich UI rendering based on schema
+- Version-to-version diff analysis
+
+### 3. Three-Tier Metadata Deduplication
+
+```
+Property Definition (identity: name + typeName → SHA-256)
+    ↓
+Property Occurrence (schema + description + deprecation → SHA-256)
+    ↓
+Version-to-Property Links
+```
+
+Identical schemas across thousands of artifact versions stored once.
+
+### 4. Change Workflow
+
+```
+Create → Submit Change Request → Approve → Apply
+         (optional if PROTECTED)
+```
+
+Profiles can be `UNPROTECTED` (direct apply) or `PROTECTED` (requires approval).
+
+### 5. Namespace OAuth2 Clients
+
+Namespaces can register OAuth2 clients (service tokens) with scoped permissions for CI/CD pipelines,
+Gradle/Maven plugins, and other automated integrations. These clients authenticate against the Identity
+Provider and receive access tokens scoped to specific operations (e.g. `metadata:upload`, `config:read`).
+This is the primary integration mechanism for build-time metadata ingestion.
+
+## Module Dependencies
+
+```
+Frontend
+  ├── Identity Provider (OAuth2 login)
+  └── REST API (all domain operations)
+
+REST API
+  ├── namespace → vault (config belongs to service in namespace)
+  ├── namespace → audit (all changes logged)
+  ├── vault → kms (encrypt vault data)
+  ├── vault → artifactory (get property metadata)
+  ├── artifactory → (read-only)
+  ├── kms → (standalone, no outbound)
+  └── audit → (listens to all events via @TransactionalEventListener)
+
+Identity Provider
+  └── Account provisioning (standalone)
+```
+
+## KMS Domain: Key Hierarchy and Lifecycle
+
+The KMS module is built on the **konfigyr-crypto** library
+(GitHub: https://github.com/konfigyr/konfigyr-crypto), a Spring-compatible abstraction over Google Tink
+that enforces a two-tier key architecture and clean key lifecycle management.
+
+### Two-Tier Key Hierarchy
+
+```
+KEK (Key Encryption Key) — master key, NEVER stored in the database
+  └── wraps ↓
+      DEK (Data Encryption Key) — stored in DB as eDEK (encrypted DEK)
+        └── encrypts ↓
+            vault entries, sensitive fields
+```
+
+- **SaaS deployment**: KEK lives in an external KMS (AWS KMS, GCP KMS)
+- **On-premise deployment**: KEK provided as a Kubernetes Secret
+- **DEKs** are stored in the database only in their encrypted (wrapped) form
+
+### Key Components (konfigyr-crypto)
+
+| Component | Role |
+|-----------|------|
+| `Keyset` | The collection of DEKs performing cryptographic operations; has one primary key for new operations, others for decryption/verification only |
+| `KeysetStore` | Primary interface — creates, rotates, and drives lifecycle transitions |
+| `KeysetFactory` | Bridges the API to an underlying crypto library (Tink, Nimbus JOSE) |
+| `Algorithm` | Immutable value object declaring algorithm identity (e.g. `tink:AES256_GCM`, `jose:ES256`) |
+
+### Key Purposes
+
+Each `KeysetMetadata` is assigned exactly one `KeyPurpose` at creation. Purpose cannot be changed.
+
+| Purpose | Operations | Algorithms |
+|---------|-----------|------------|
+| `ENCRYPT` | `encrypt(plaintext)` / `decrypt(ciphertext)` | AES-GCM (symmetric) |
+| `KEY_ENCAPSULATION` | `wrap(key)` / `unwrap(ciphertext)` | RSA, EC, or ML-KEM (post-quantum) |
+| `SIGN` | `sign(data)` / `verify(signature)` — exposes public key | ECDSA, Ed25519, ML-DSA |
+
+### Key Lifecycle States
+
+```
+ENABLED → DISABLED → PENDING_DESTRUCTION → DESTROYED
+    ↘ COMPROMISED → PENDING_DESTRUCTION → DESTROYED
+```
+
+- `ENABLED` — active; primary key is used for new crypto operations
+- `DISABLED` — inactive; excluded from new operations, still readable for decrypt/verify
+- `COMPROMISED` — emergency state; triggers immediate rotation
+- `PENDING_DESTRUCTION` — grace period before material is wiped (scheduled tasks run hourly by default)
+- `DESTROYED` — material deleted; record retained for audit
+
+### Business Rules (invariants to never violate)
+
+1. **Purpose consistency** — a `KeyVersion` spec must be compatible with the parent keyset's `KeyPurpose`
+2. **Immutability of material** — once generated, key material can never be altered
+3. **Single primary key** — a keyset should have exactly one primary version for crypto operations
+4. **Soft-deletion** — `KeysetMetadata` cannot be destroyed while it has active `KeyVersion` records; versions must be scheduled for destruction first
+
+## Artifactory Domain: SDK and Key Entities
+
+The Artifactory module is backed by the **konfigyr-artifactory** SDK
+(GitHub: https://github.com/konfigyr/konfigyr-artifactory, Maven: `com.konfigyr:konfigyr-artifactory`),
+a lightweight Java library providing the shared abstractions used by the backend, Gradle/Maven plugins,
+and third-party integrations alike.
+
+### Key SDK Entities
+
+| Entity | Description |
+|--------|-------------|
+| `Artifact` | Unique component identified by Maven coordinates (`groupId:artifactId`). Parent of all versions. |
+| `ArtifactVersion` | Immutable snapshot of a specific release. Owns `PropertyOccurrence` links. |
+| `PropertyDescriptor` | Configuration property metadata: name, type, description, default, JSON Schema. |
+| `ArtifactMetadata` | Upload envelope — aggregates all `PropertyDescriptor`s for one artifact version. Uploaded by build plugins via REST. |
+| `Release` | Version change event with lifecycle: `PENDING → RELEASED → FAILED`. |
+| `Manifest` | A Konfigyr service's current metadata state — used to detect property differences across environments. |
+| `ServiceManifest` | Relational link between a namespace-owned service and one or more artifact versions. Enables metadata reuse (shared library configs) across services. |
+
+### Metadata Ingestion Flow
+
+```
+Build (Gradle/Maven plugin)
+  1. Extract spring-configuration-metadata.json from classpath
+  2. Translate property types → JSON Schema
+  3. POST /artifactory/artifacts/{group}/{artifact}/{version}
+     (ArtifactMetadata payload, authenticated as namespace OAuth2 client)
+  ↓
+Artifactory module
+  4. Compute Definition Checksum (name + typeName)
+  5. Compute Occurrence Checksum (schema + description + deprecation)
+  6. Deduplicate: reuse existing PropertyOccurrence if checksum matches
+  7. Create Version-to-Property links
+  8. Update Release status: PENDING → RELEASED
+```
+
+## API Contracts
+
+### Namespace Endpoints
+
+```
+GET    /namespaces/:slug           @RequiresScope(READ_NAMESPACES)
+POST   /namespaces                 @RequiresScope(WRITE_NAMESPACES)
+PATCH  /namespaces/:slug           @RequiresScope(WRITE_NAMESPACES)
+DELETE /namespaces/:slug           @RequiresScope(DELETE_NAMESPACES)
+```
+
+### Vault Endpoints
+
+```
+GET    /namespaces/:ns/vaults      @RequiresScope(READ_VAULT)
+GET    /namespaces/:ns/vaults/:id/profiles/:prof
+POST   /namespaces/:ns/vaults/:id/entries
+PATCH  /namespaces/:ns/vaults/:id/entries/:eid
+```
+
+### Audit Endpoints
+
+```
+GET    /audit                      @RequiresScope(READ_AUDIT)
+GET    /audit/:id                  @RequiresScope(READ_AUDIT)
+```
+
+## Frontend Routes
+
+```
+/                            Dashboard
+/namespace/:slug             Namespace detail
+/namespace/:slug/members     Member management
+/namespace/:slug/services/:svc/profiles/:prof   Vault access
+/auth/code                   OAuth2 callback
+```
+
+## Data Flow Example: Creating a Namespace
+
+```
+Frontend
+  1. User submits form: { slug, name, description }
+  2. POST /namespaces (with @RequiresScope(WRITE_NAMESPACES))
+  ↓
+REST API - namespace module
+  3. Validate input (slug unique, format valid)
+  4. Create Namespace aggregate in database
+  5. Publish NamespaceEvent.Created
+  ↓
+REST API - audit module
+  6. @TransactionalEventListener catches event
+  7. Insert audit record
+  ↓
+REST API - KMS module
+  8. Listener creates KeysetMetadata for new namespace
+  ↓
+Frontend
+  9. Receive 201 Created response
+  10. Redirect to /namespace/:slug
+  11. Load namespace data (already cached server-side from loader)
+```
+
+## Environment-Specific Deployments
+
+### Development
+- Single database (PostgreSQL local or Docker)
+- Single IdP (local Spring AuthServer)
+- Frontend + API + IdP all local
+- KEK typically provided as a local secret
+
+### SaaS (Multi-tenant)
+- Shared database (PostgreSQL managed service)
+- Shared IdP (konfigyr-identity)
+- KEK managed by external KMS (AWS KMS, GCP KMS)
+- CDN for static assets, load-balanced API instances
+
+### On-Premise
+- Isolated database per deployment
+- On-premise IdP (konfigyr-identity)
+- KEK provided as a Kubernetes Secret
+- Behind customer firewall, per-deployment SSL certificates
+
+## Namespace Access Control
+
+Two roles, namespace-scoped:
+
+| Role | Permissions |
+|------|-------------|
+| `ADMIN` | Manage members, billing, services, all configurations |
+| `USER` | Manage configurations and deployments only |
+
+OAuth2 clients registered by a namespace authenticate as that namespace and carry permission scopes
+(`metadata:upload`, `config:read`, etc.) rather than a user role.
+
+## Verification Checklist
+
+- [ ] Understand namespace = tenant boundary
+- [ ] Know which module owns each domain entity
+- [ ] Understand cross-module event flow
+- [ ] Aware of per-namespace encryption (KEK/DEK two-tier model)
+- [ ] Know KMS key purposes and lifecycle states
+- [ ] Know REST API contracts
+- [ ] Understand frontend-to-API communication
+- [ ] Aware of OAuth2 scope hierarchy
+- [ ] Understand IdP as a protocol broker (not just a JWT issuer)
+- [ ] Can trace data through all layers

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,226 @@
+# CLAUDE.md - Konfigyr Development Guidelines
+
+Behavioral guidelines for Claude Code in Konfigyr projects. Extends Andrej Karpathy's methodology.
+
+**Tradeoff:** These guidelines bias toward caution, maintainability, and production-readiness over speed. For trivial tasks, use judgment.
+
+---
+
+## 1. Project Summary
+
+### What is Konfigyr?
+
+Konfigyr is a Spring Boot-native configuration management platform offered as both SaaS and on-premise. The core problem it solves is configuration chaos in teams running microservices: config drift across environments, human errors from manual edits, and lack of auditability or access control over sensitive properties.
+
+Unlike generic secret stores (HashiCorp Vault) or framework-agnostic tools (Infisical), Konfigyr is opinionated about Spring Boot. It reads property metadata generated at build time to power a type-safe UI that validates values before they reach production, surfaces deprecations, and tracks how configuration evolves across artifact versions.
+
+### System Architecture
+
+The system consists of three deployed services that communicate via OAuth2/OIDC:
+
+- **Identity Provider** (`konfigyr-identity`) — Built on Spring Authorization Server. Brokers authentication to external providers (GitHub, GitLab, OIDC), issues PS256/ES256 JWTs, and manages user identity records. Does not store credentials.
+- **REST API** (`konfigyr-api`) — Spring Boot OAuth2 Resource Server. Hosts all domain logic: namespaces, vaults, artifactory, KMS. Protected by JWT scopes enforced via `@RequiresScope`.
+- **Frontend** (`konfigyr-frontend`) — React 19 / TanStack Start app. Authenticates via Authorization Code + PKCE, holds tokens in session, consumes the REST API.
+
+A Gradle/Maven plugin layer handles build-time metadata ingestion: plugins extract `spring-configuration-metadata.json` from applications and push it to the REST API, populating the Artifactory and enabling the type-safe UI.
+
+### Business Domains
+
+| Domain | Module(s) | Responsibility |
+|--------|-----------|----------------|
+| **Namespaces & Accounts** | `account`, `namespace`, `membership` | Multi-tenancy: namespaces are the top-level tenant container. Members have roles (`ADMIN`, `USER`). Services (Spring Boot apps) are owned by namespaces. |
+| **Vault** | `vault` | Per-service configuration: profiles (dev/staging/prod), change sets, change requests with optional approval workflows, and change history. |
+| **Artifactory** | `artifactory` | Metadata registry: indexes artifact versions and their configuration property descriptors (as JSON Schema). Powers type-safe UI, diff/change analysis, and provenance tracking. |
+| **KMS** | `kms` | Per-namespace cryptographic keyset management. Each namespace gets an isolated keyset (backed by Google Tink) used to encrypt vault contents. Supports encrypt, key-encapsulation, and signing purposes. |
+| **Identity** | `konfigyr-identity` module | User account provisioning from external OAuth providers, JWT token customisation, authorization consent. |
+| **Audit** | `audit` | Centralized audit log. Listens to domain events from all other modules via `@TransactionalEventListener` and persists structured records. |
+| **Feature flags** | `feature` | Per-namespace feature limits and toggles (e.g. max member count, max services). |
+
+---
+
+## 2. Karpathy's 4 Core Principles
+
+### 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly
+- If multiple approaches exist, present tradeoffs
+- If uncertain about architecture or requirements, ask before coding
+- If something is unclear, stop and ask for clarification
+
+### 2. Simplicity First
+
+**Minimum code that solves the problem. No speculative features.**
+
+- No features beyond what was asked
+- No abstractions for single-use code
+- No "flexibility" or "configurability" that wasn't requested
+- No error handling for impossible scenarios
+- If you write 200 lines and it could be 50, rewrite it
+
+### 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't refactor unrelated code or reformat files
+- Match existing code style exactly
+- Remove only what YOUR changes made unused
+- Don't delete pre-existing dead code unless asked
+
+**The test:** Every changed line traces directly to the user's request.
+
+### 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+```
+Goal: "Add OAuth scope validation to endpoint"
+↓
+Specific:
+  1. Create validator for required scope → Test: endpoint returns 403 without scope
+  2. Add @RequiresScope annotation → Test: endpoint accepts valid scope
+  3. Update OpenAPI docs → Test: docs reflect new scope requirement
+
+Verification:
+  - Run: ./gradlew test
+  - Check: Auth tests pass
+  - Check: No regressions
+```
+
+---
+
+## 3. Quick Reference: Which Skill to Load
+
+**You're working on backend (Java, Spring Boot)?**
+→ Load backend agent: `/agent backend-engineer`
+
+**You're working on frontend (React, TanStack)?**
+→ Load frontend agent: `/agent frontend-engineer`
+
+**You need project architecture context?**
+→ Load skill: `/skill project-overview`
+
+---
+
+## 4. Backend Modules & Agents
+
+### Agents
+
+**`backend-engineer`** — Orchestrates backend development
+- Loads: Spring Modulith + DDD, jOOQ queries, Liquibase migrations, OAuth2 security, Spring testing, entity modeling, cross-module events
+- Use when: Adding features to `konfigyr-api`, creating new modules, writing domain logic
+
+### Backend Skills
+
+| Skill | When to Use |
+|-------|-----------|
+| `spring-modulith-ddd` | Creating a new module, defining aggregates, service interfaces |
+| `jooq-queries` | Writing database queries, understanding generated code |
+| `liquibase-migrations` | Modifying database schema, running migrations |
+| `spring-security-oauth2` | Protecting endpoints with `@RequiresScope`, auth flows |
+| `spring-testing` | Writing integration tests, unit tests, controller tests |
+| `entity-modeling` | Designing domain objects, value objects, aggregates |
+| `cross-module-events` | Publishing/listening to domain events between modules |
+
+---
+
+## 5. Frontend Routes & Agents
+
+### Agents
+
+**`frontend-engineer`** — Orchestrates frontend development
+- Loads: TanStack routing, TanStack queries, React components, Tailwind styling, OIDC authentication, frontend testing, form handling
+- Use when: Adding pages/features to `konfigyr-frontend`, fixing UI bugs, improving performance
+
+### Frontend Skills
+
+| Skill | When to Use |
+|-------|-----------|
+| `tanstack-routing` | Creating new routes, understanding file-based routing, loaders |
+| `tanstack-queries` | Fetching/mutating data, cache invalidation, query keys |
+| `react-components` | Building new components, component conventions |
+| `tailwind-styling` | Styling components, adding new design tokens |
+| `oidc-authentication` | Session management, token handling, auth flows |
+| `frontend-testing` | Testing components, hooks, routes with MSW |
+| `form-handling` | Building forms with TanStack Form |
+
+---
+
+## 6. Shared Principles
+
+### No Context Pollution
+
+- **Backend work:** Frontend skills stay unloaded (no React, TanStack clutter)
+- **Frontend work:** Backend skills stay unloaded (no Spring, jOOQ clutter)
+- Each skill is self-contained and loads only what's needed
+
+### Verification Checklist (All Work)
+
+- [ ] Code compiles/builds without warnings
+- [ ] All tests pass (`./gradlew test` for backend, `npm run test:ci` for frontend)
+- [ ] No unused imports or variables
+- [ ] No hardcoded values (use configuration)
+- [ ] Git history is clean (logical commits)
+- [ ] Existing functionality not broken
+- [ ] Code is simpler than when I started
+- [ ] I can explain the change in one sentence
+
+### Git & Change Management
+
+**Commit Messages:**
+- Clear, imperative: "Add namespace quota validation"
+- One logical change per commit
+
+**Pull Requests:**
+- Title summarizes change
+- Description explains WHY
+- Link to issues/tickets
+
+**When to Ask Before Changing:**
+- Anything affecting public APIs
+- Database schema changes
+- Dependency upgrades
+- Configuration defaults
+- Architectural decisions
+
+---
+
+## 7. Skill Maintenance
+
+When making changes that affect documented architecture, update the relevant skill file as part of the same task — not as a separate follow-up.
+
+| If you change...                                                 | Update this skill |
+|------------------------------------------------------------------|------------------|
+| Auth flow, JWT claims, `OAuthScope`, `@RequiresScope`, token types | `spring-security-oauth2` |
+| KMS key purposes, lifecycle states, konfigyr-crypto usage        | `project-overview` |
+| Artifactory domain entities, ingestion flow, SDK types           | `project-overview` |
+| IdP broker behaviour, OIDC endpoints, JWS algorithm              | `project-overview`, `oidc-authentication`, `spring-security-oauth2` |
+| New module, aggregate, or cross-module event                     | `project-overview`, `spring-modulith-ddd` |
+| Database schema, Liquibase patterns                              | `liquibase-migrations` |
+| API endpoint contracts or scopes                                 | `project-overview`, `spring-security-oauth2` |
+| Frontend routes or loaders                                       | `project-overview`, `tanstack-routing` |
+| Domain entity design, value objects, aggregates                  | `entity-modeling` |
+| Namespace roles, membership model                                | `project-overview` |
+
+---
+
+## 8. Getting Started
+
+**First time here?**
+
+1. Read this file (you're done!)
+2. Load the appropriate agent:
+    - Backend: `Load agent: backend-engineer`
+    - Frontend: `Load agent: frontend-engineer`
+3. Each agent will guide you through the relevant skills
+
+**Want to understand the whole system?**
+→ Load `/skill project-overview` for architecture deep-dive
+
+---
+
+**Default Behavior:** When in doubt, ask. Better a clarifying question than an unnecessary rewrite.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,141 @@
-# konfigyr-project ![example workflow](https://github.com/konfigyr/konfigyr-project/actions/workflows/ci.yml/badge.svg) [![codecov](https://codecov.io/gh/konfigyr/konfigyr-project/graph/badge.svg?token=81ATZF33YH)](https://codecov.io/gh/konfigyr/konfigyr-project)
+# Konfigyr ![CI](https://github.com/konfigyr/konfigyr-project/actions/workflows/ci.yml/badge.svg) [![codecov](https://codecov.io/gh/konfigyr/konfigyr-project/graph/badge.svg?token=81ATZF33YH)](https://codecov.io/gh/konfigyr/konfigyr-project)
+
+Konfigyr is a Spring Boot-native configuration management platform available as both SaaS and on-premise. It solves the configuration chaos that comes with running microservices at scale: config drift across environments, human errors from manual edits, and no auditability or access control over sensitive properties.
+
+Unlike generic secret stores (HashiCorp Vault) or framework-agnostic tools (Infisical), Konfigyr is opinionated about Spring Boot. It reads property metadata generated at build time to power a type-safe UI that validates values before they reach production, surfaces deprecations, and tracks how configuration evolves across artifact versions.
+
+## Architecture
+
+Three independently deployed services communicate via OAuth2/OIDC:
+
+```
+┌──────────────────────────────────────────────────────────┐
+│  Frontend  ·  konfigyr-frontend                         │
+│  React 19 / TanStack Start · OAuth2 Code + PKCE         │
+└────────┬─────────────────────────────────┬──────────────┘
+         │ auth                             │ API calls
+┌────────▼──────────────┐     ┌────────────▼─────────────┐
+│  Identity Provider    │     │  REST API                │
+│  konfigyr-identity    │     │  konfigyr-api            │
+│  Spring Auth Server   │     │  Spring Boot + Modulith  │
+│  PS256/ES256 JWTs     │     │  jOOQ + Liquibase        │
+│  External IdP broker  │     │  @RequiresScope auth     │
+└───────────────────────┘     └──────────────────────────┘
+                                         │
+                               ┌─────────▼──────────┐
+                               │  PostgreSQL         │
+                               │  Liquibase managed  │
+                               └────────────────────┘
+```
+
+The Identity Provider acts as an **identity broker**: it accepts logins from external providers (GitHub, GitLab, Google, SAML enterprise IdPs) and translates them into standardised Konfigyr JWTs. The REST API only trusts tokens from konfigyr-identity — no multi-issuer configuration needed.
+
+A Gradle/Maven plugin layer handles build-time metadata ingestion: plugins extract `spring-configuration-metadata.json` from Spring Boot applications and push it to the REST API, populating the Artifactory and enabling the type-safe UI.
+
+## Modules
+
+| Module | Description |
+|--------|-------------|
+| `konfigyr-api` | Core REST API — all business domains: namespaces, vault, artifactory, KMS, audit |
+| `konfigyr-identity` | Identity Provider — Spring Authorization Server, external IdP federation, JWT issuance |
+| `konfigyr-frontend` | React 19 / TanStack Start frontend application |
+| `konfigyr-core` | Shared domain primitives — `EntityId`, `OAuthScope`, shared value objects |
+| `konfigyr-data` | Shared database infrastructure — jOOQ configuration, Liquibase base migrations |
+| `konfigyr-mail` | Email integration — SMTP transport, Thymeleaf templates |
+| `konfigyr-test` | Shared test utilities — `TestPrincipals`, test containers, mock factories |
+| `konfigyr-jooq-extensions` | Custom jOOQ type bindings and converters |
+
+### Business Domains (inside `konfigyr-api`)
+
+| Domain | Responsibility |
+|--------|----------------|
+| `namespace` | Multi-tenancy — namespaces are the top-level tenant container; members have `ADMIN` or `USER` roles |
+| `vault` | Per-service configuration — profiles, entries, change requests with optional approval workflow, change history |
+| `artifactory` | Metadata registry — artifact versions, property descriptors as JSON Schema, provenance tracking |
+| `kms` | Per-namespace encryption — keyset lifecycle backed by [konfigyr-crypto](https://github.com/konfigyr/konfigyr-crypto) |
+| `audit` | Centralised audit log — listens to all domain events via `@TransactionalEventListener` |
+| `account` | User account management — provisioned from external OAuth providers |
+| `feature` | Per-namespace feature flags and limits |
+| `membership` | Standalone membership subdomain — member invitations, role management |
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Language | Java 25 |
+| Backend framework | Spring Boot 4.0.6 |
+| Module architecture | Spring Modulith 2.0.6 |
+| Database | PostgreSQL 18 (jOOQ + Liquibase) |
+| Auth server | Spring Authorization Server |
+| Frontend | React 19, TanStack Start (SSR), Tailwind CSS |
+| Build | Gradle (Groovy DSL) |
+| Crypto | [konfigyr-crypto](https://github.com/konfigyr/konfigyr-crypto) (Google Tink + BouncyCastle) |
+| Artifactory SDK | [konfigyr-artifactory](https://github.com/konfigyr/konfigyr-artifactory) |
+
+## Getting Started
+
+### Prerequisites
+
+- Java 25+
+- Node.js (see `konfigyr-frontend/.nvmrc`)
+- Docker (for local services)
+
+### Start local services
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+This starts:
+- **PostgreSQL 18** on `localhost:5432` (`konfigyr-database` / `konfigyr-database`)
+- **smtp4dev** on `localhost:8880` (SMTP UI) / `localhost:2525` (SMTP)
+- **Keycloak 26** on `localhost:8881` (external IdP for local development)
+
+### Build and test
+
+```bash
+# Full build with tests
+./gradlew build
+
+# Backend tests only
+./gradlew test
+
+# Generate jOOQ sources (required after schema changes)
+./gradlew generateJooq
+
+# Frontend
+cd konfigyr-frontend
+npm install
+npm run dev
+```
+
+### Run the applications
+
+```bash
+# Identity Provider
+./gradlew :konfigyr-identity:bootRun
+
+# REST API
+./gradlew :konfigyr-api:bootRun
+
+# Frontend (dev server with HMR)
+cd konfigyr-frontend && npm run dev
+```
+
+## Configuration
+
+Each service is configured via `application.yml` and environment variables. Key properties:
+
+| Property | Description |
+|----------|-------------|
+| `spring.datasource.url` | PostgreSQL connection URL |
+| `spring.security.oauth2.resourceserver.jwt.issuer-uri` | konfigyr-identity URL (for REST API) |
+| `konfigyr.identity.issuer` | Public URL of the Identity Provider |
+
+## Contributing
+
+1. Fork the repository
+2. Create a feature branch: `git checkout -b feat/your-feature`
+3. Follow the conventions in [CLAUDE.md](CLAUDE.md)
+4. Run `./gradlew build` and ensure all checks pass
+5. Open a pull request with a clear description of the change and why

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/provenance/DefaultProvenanceEvaluator.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/provenance/DefaultProvenanceEvaluator.java
@@ -62,7 +62,7 @@ import static com.konfigyr.data.tables.ArtifactVersionProperties.ARTIFACT_VERSIO
  */
 @Slf4j
 @RequiredArgsConstructor
-public class DefaultProvenanceEvaluator implements ProvenanceEvaluator {
+class DefaultProvenanceEvaluator implements ProvenanceEvaluator {
 
 	private static final List<SelectField<?>> SELECTABLE_PROVENANCE_FIELDS = List.of(
 			PROPERTY_DEFINITIONS.CHECKSUM,

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
@@ -37,7 +37,7 @@ import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
 
 @Slf4j
 @RequiredArgsConstructor
-public class DefaultServices implements Services {
+class DefaultServices implements Services {
 
 	private static final Name SERVICE_ARTIFACTS_ALIAS = DSL.name("artifacts");
 

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/Profile.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/Profile.java
@@ -2,6 +2,7 @@ package com.konfigyr.vault;
 
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.Service;
+import com.konfigyr.support.Slug;
 import org.jmolecules.ddd.annotation.Association;
 import org.jmolecules.ddd.annotation.Entity;
 import org.jmolecules.ddd.annotation.Identity;
@@ -264,10 +265,14 @@ public record Profile(
 		public Profile build() {
 			Assert.notNull(id, "Profile entity identifier can not be null");
 			Assert.notNull(service, "Profile service identifier can not be null");
-			Assert.hasText(slug, "Profile slug can not be blank");
 			Assert.hasText(name, "Profile name can not be blank");
 			Assert.notNull(policy, "Profile policy can not be null");
 			Assert.isTrue(position > 0, "Profile position must be greater than zero");
+
+			if (slug == null) {
+				slug = Slug.slugify(name).get();
+			}
+
 			return new Profile(id, service, slug, name, policy, description, position, createdAt, updatedAt);
 		}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/Profile.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/Profile.java
@@ -2,11 +2,12 @@ package com.konfigyr.vault;
 
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.Service;
-import lombok.Builder;
 import org.jmolecules.ddd.annotation.Association;
 import org.jmolecules.ddd.annotation.Entity;
 import org.jmolecules.ddd.annotation.Identity;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -22,7 +23,7 @@ import java.time.OffsetDateTime;
  * Users can choose which {@link ProfilePolicy} their {@link Profile}s should use depending on their internal
  * process and security policies. Protected profiles require that {@code ChangeSet}s must go through a review
  * and an approval process, represented by the {@code ChangeRequest}, before changes can be applied.
- * Unprotected {@link Profile}s allow users to apply tiehr {@code ChangeSet}s directly without going
+ * Unprotected {@link Profile}s allow users to apply their {@code ChangeSet}s directly without going
  * through a review process.
  * <p>
  * When working with {@link Profile}s, it is important to understand the following principles:
@@ -75,24 +76,201 @@ import java.time.OffsetDateTime;
  * @see ProfilePolicy
  */
 @Entity
-@Builder
 public record Profile(
 		@Identity EntityId id,
 		@Association(aggregateType = Service.class) EntityId service,
 		String slug,
 		String name,
 		ProfilePolicy policy,
-		String description,
+		@Nullable String description,
 		int position,
-		OffsetDateTime createdAt,
-		OffsetDateTime updatedAt
+		@Nullable OffsetDateTime createdAt,
+		@Nullable OffsetDateTime updatedAt
 ) implements Comparable<Profile>, Serializable {
 
 	@Serial
 	private static final long serialVersionUID = 2657983964397225835L;
 
+	/**
+	 * Creates a new {@link Builder fluent profile builder} instance used to create the {@link Profile}.
+	 *
+	 * @return profile builder, never {@literal null}
+	 */
+	@NonNull
+	public static Builder builder() {
+		return new Builder();
+	}
+
 	@Override
 	public int compareTo(@NonNull Profile o) {
 		return Integer.compare(position, o.position);
 	}
+
+	/**
+	 * Fluent builder type used to create a {@link Profile}.
+	 */
+	public static final class Builder {
+
+		private EntityId id;
+		private EntityId service;
+		private String slug;
+		private String name;
+		private ProfilePolicy policy;
+		private String description;
+		private int position = 1;
+		private OffsetDateTime createdAt;
+		private OffsetDateTime updatedAt;
+
+		private Builder() {
+		}
+
+		/**
+		 * Specify the {@link EntityId} of this {@link Profile}.
+		 *
+		 * @param id profile entity identifier, can't be {@literal null}
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder id(@NonNull EntityId id) {
+			this.id = id;
+			return this;
+		}
+
+		/**
+		 * Specify the internal {@link EntityId} of this {@link Profile}.
+		 *
+		 * @param id internal profile entity identifier
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder id(long id) {
+			return id(EntityId.from(id));
+		}
+
+		/**
+		 * Specify the {@link EntityId} of the {@link Service} this {@link Profile} belongs to.
+		 *
+		 * @param service service entity identifier, can't be {@literal null}
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder service(@NonNull EntityId service) {
+			this.service = service;
+			return this;
+		}
+
+		/**
+		 * Specify the internal {@link EntityId} of the {@link Service} this {@link Profile} belongs to.
+		 *
+		 * @param service internal service entity identifier
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder service(long service) {
+			return service(EntityId.from(service));
+		}
+
+		/**
+		 * Specify the slug that uniquely identifies this {@link Profile} within its {@link Service}.
+		 *
+		 * @param slug profile slug, can't be {@literal null}
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder slug(@NonNull String slug) {
+			this.slug = slug;
+			return this;
+		}
+
+		/**
+		 * Specify the human-readable name of this {@link Profile}.
+		 *
+		 * @param name profile name, can't be {@literal null}
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder name(@NonNull String name) {
+			this.name = name;
+			return this;
+		}
+
+		/**
+		 * Specify the {@link ProfilePolicy} of this {@link Profile}.
+		 *
+		 * @param policy profile access policy, can't be {@literal null}
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder policy(@NonNull ProfilePolicy policy) {
+			this.policy = policy;
+			return this;
+		}
+
+		/**
+		 * Describe this {@link Profile}.
+		 *
+		 * @param description profile description, can be {@literal null}
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder description(@Nullable String description) {
+			this.description = description;
+			return this;
+		}
+
+		/**
+		 * Specify the display order of this {@link Profile} within the UI.
+		 *
+		 * @param position display position, must be greater than zero
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder position(int position) {
+			this.position = position;
+			return this;
+		}
+
+		/**
+		 * Specify when this {@link Profile} was created.
+		 *
+		 * @param createdAt created date, can be {@literal null}
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder createdAt(@Nullable OffsetDateTime createdAt) {
+			this.createdAt = createdAt;
+			return this;
+		}
+
+		/**
+		 * Specify when this {@link Profile} was last updated.
+		 *
+		 * @param updatedAt updated date, can be {@literal null}
+		 * @return profile builder
+		 */
+		@NonNull
+		public Builder updatedAt(@Nullable OffsetDateTime updatedAt) {
+			this.updatedAt = updatedAt;
+			return this;
+		}
+
+		/**
+		 * Creates a new instance of the {@link Profile} using the values defined in the builder.
+		 *
+		 * @return profile instance, never {@literal null}
+		 * @throws IllegalArgumentException when required fields are missing or invalid
+		 */
+		@NonNull
+		public Profile build() {
+			Assert.notNull(id, "Profile entity identifier can not be null");
+			Assert.notNull(service, "Profile service identifier can not be null");
+			Assert.hasText(slug, "Profile slug can not be blank");
+			Assert.hasText(name, "Profile name can not be blank");
+			Assert.notNull(policy, "Profile policy can not be null");
+			Assert.isTrue(position > 0, "Profile position must be greater than zero");
+			return new Profile(id, service, slug, name, policy, description, position, createdAt, updatedAt);
+		}
+
+	}
+
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/controller/VaultController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/controller/VaultController.java
@@ -25,7 +25,7 @@ import java.util.Set;
 
 @RestController
 @RequestMapping("/namespaces/{namespace}/services/{service}")
-public class VaultController extends AbstractVaultController {
+class VaultController extends AbstractVaultController {
 
 	private final VaultAccessor accessor;
 	private final VaultChronicle chronicle;

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/controller/VaultEnvironmentController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/controller/VaultEnvironmentController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequestMapping("/configs")
-public class VaultEnvironmentController extends AbstractVaultController {
+class VaultEnvironmentController extends AbstractVaultController {
 
 	private final ConfigurationEnvironmentLocator locator;
 

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/state/GitStateRepositoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/state/GitStateRepositoryTest.java
@@ -3,7 +3,6 @@ package com.konfigyr.vault.state;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.Service;
 import com.konfigyr.security.AuthenticatedPrincipal;
-import com.konfigyr.support.Slug;
 import com.konfigyr.vault.Profile;
 import com.konfigyr.vault.ProfilePolicy;
 import com.konfigyr.vault.Properties;
@@ -30,15 +29,15 @@ import static org.mockito.Mockito.*;
 
 class GitStateRepositoryTest {
 
-	Path root;
-	GitStateRepository repository;
-
-	final Service service = Service.builder()
+	static final Service service = Service.builder()
 			.id(123567L)
 			.namespace(1L)
 			.slug("test-service")
 			.name("test service")
 			.build();
+
+	Path root;
+	GitStateRepository repository;
 
 	@BeforeEach
 	void setup(@TempDir(cleanup = CleanupMode.ALWAYS) Path parent) {
@@ -403,7 +402,7 @@ class GitStateRepositoryTest {
 	static Profile createProfile(long id, String name, ProfilePolicy policy) {
 		return Profile.builder()
 				.id(EntityId.from(id))
-				.slug(Slug.slugify(name).get())
+				.service(service.id())
 				.name(name)
 				.policy(policy)
 				.build();

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AccountIdentity.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AccountIdentity.java
@@ -39,7 +39,7 @@ import java.util.Objects;
 @NullMarked
 @AggregateRoot
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class AccountIdentity implements UserDetails, AuthenticatedPrincipal, Identifiable<EntityId>, Serializable {
+public final class AccountIdentity implements UserDetails, AuthenticatedPrincipal, Identifiable<EntityId>, Serializable {
 
 	@Serial
 	private static final long serialVersionUID = -4208974779066630762L;
@@ -175,8 +175,12 @@ public class AccountIdentity implements UserDetails, AuthenticatedPrincipal, Ide
 
 	@Override
 	public boolean equals(@Nullable Object o) {
-		if (this == o) return true;
-		if (!(o instanceof AccountIdentity that)) return false;
+		if (this == o) {
+			return true;
+		}
+		if (!(o instanceof AccountIdentity that)) {
+			return false;
+		}
 		return Objects.equals(id, that.id);
 	}
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AccountIdentity.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AccountIdentity.java
@@ -4,23 +4,24 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.support.Avatar;
-import lombok.Builder;
-import lombok.Value;
 import org.jmolecules.ddd.annotation.AggregateRoot;
 import org.jmolecules.ddd.annotation.Identity;
 import org.jmolecules.ddd.types.Identifiable;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.Assert;
 
 import java.io.Serial;
 import java.io.Serializable;
 import java.util.Collection;
+import java.util.Objects;
 
 /**
- * Class that represents the {@link org.springframework.security.core.AuthenticatedPrincipal}
- * that retrieves the security attributes from the stored user accounts.
+ * Class that represents the {@link AuthenticatedPrincipal} that retrieves the security attributes
+ * from the stored user accounts.
  * <p>
  * It is recommended that every {@link org.springframework.security.core.Authentication} type
  * that is created by Spring Security should contain either {@link AccountIdentity} or
@@ -35,8 +36,6 @@ import java.util.Collection;
  * @see UserDetails
  * @see AccountIdentityUser
  **/
-@Value
-@Builder
 @NullMarked
 @AggregateRoot
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -47,36 +46,41 @@ public class AccountIdentity implements UserDetails, AuthenticatedPrincipal, Ide
 
 	private static final String EMPTY_PASSWORD = "";
 
+	private final EntityId id;
+	private final AccountIdentityStatus status;
+	private final String email;
+	private final String displayName;
+	private final Avatar avatar;
+	private final Collection<? extends GrantedAuthority> authorities;
+
+	private AccountIdentity(
+			EntityId id,
+			AccountIdentityStatus status,
+			String email,
+			String displayName,
+			Avatar avatar,
+			Collection<? extends GrantedAuthority> authorities
+	) {
+		this.id = id;
+		this.status = status;
+		this.email = email;
+		this.displayName = displayName;
+		this.avatar = avatar;
+		this.authorities = authorities;
+	}
+
 	/**
-	 * Entity identifier of the user account behind this {@link AccountIdentity}.
+	 * Creates a new {@link Builder fluent account identity builder} instance used to create
+	 * the {@link AccountIdentity}.
+	 *
+	 * @return account identity builder, never {@literal null}
 	 */
-	EntityId id;
+	public static Builder builder() {
+		return new Builder();
+	}
 
 	/**
-	 * The current status of the account that is used to check if this {@link AccountIdentity} can be used.
-	 */
-	AccountIdentityStatus status;
-
-	/**
-	 * E-Mail address of the {@link AccountIdentity}.
-	 */
-	String email;
-
-	/**
-	 * Display name, or an email address, of this {@link AccountIdentity}.
-	 */
-	String displayName;
-
-	/**
-	 * Avatar that points to the profile picture of this {@link AccountIdentity}.
-	 */
-	Avatar avatar;
-
-	Collection<? extends GrantedAuthority> authorities;
-
-	/**
-	 * Returns an {@link EntityId} of the {@link AccountIdentity} that would be used as the
-	 * {@link org.springframework.security.core.AuthenticatedPrincipal}.
+	 * Returns the {@link EntityId} of the user account behind this {@link AccountIdentity}.
 	 *
 	 * @return account entity identifier, never {@literal null}
 	 */
@@ -86,8 +90,44 @@ public class AccountIdentity implements UserDetails, AuthenticatedPrincipal, Ide
 	}
 
 	/**
-	 * Returns the serialized external form the {@link EntityId} of the {@link AccountIdentity} as the
-	 * name of the {@link org.springframework.security.core.AuthenticatedPrincipal}.
+	 * Returns the current status of this {@link AccountIdentity}.
+	 *
+	 * @return account identity status, never {@literal null}
+	 */
+	public AccountIdentityStatus getStatus() {
+		return status;
+	}
+
+	/**
+	 * Returns the e-mail address of this {@link AccountIdentity}.
+	 *
+	 * @return e-mail address, never {@literal null}
+	 */
+	public String getEmail() {
+		return email;
+	}
+
+	/**
+	 * Returns the display name, or an email address, of this {@link AccountIdentity}.
+	 *
+	 * @return display name, never {@literal null}
+	 */
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	/**
+	 * Returns the {@link Avatar} that points to the profile picture of this {@link AccountIdentity}.
+	 *
+	 * @return account avatar, never {@literal null}
+	 */
+	public Avatar getAvatar() {
+		return avatar;
+	}
+
+	/**
+	 * Returns the serialized external form of the {@link EntityId} of the {@link AccountIdentity}
+	 * as the name of the {@link AuthenticatedPrincipal}.
 	 *
 	 * @return the authenticated principal name, never {@literal null}
 	 */
@@ -100,6 +140,11 @@ public class AccountIdentity implements UserDetails, AuthenticatedPrincipal, Ide
 	@JsonIgnore
 	public String getUsername() {
 		return getName();
+	}
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return authorities;
 	}
 
 	@Override
@@ -129,8 +174,119 @@ public class AccountIdentity implements UserDetails, AuthenticatedPrincipal, Ide
 	}
 
 	@Override
+	public boolean equals(@Nullable Object o) {
+		if (this == o) return true;
+		if (!(o instanceof AccountIdentity that)) return false;
+		return Objects.equals(id, that.id);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(id);
+	}
+
+	@Override
 	public String toString() {
 		return "AccountIdentity(id=" + id + ", status=" + status + ")";
+	}
+
+	/**
+	 * Fluent builder type used to create an {@link AccountIdentity}.
+	 */
+	public static final class Builder {
+
+		private @Nullable EntityId id;
+		private @Nullable AccountIdentityStatus status;
+		private @Nullable String email;
+		private @Nullable String displayName;
+		private @Nullable Avatar avatar;
+		private @Nullable Collection<? extends GrantedAuthority> authorities;
+
+		private Builder() {
+		}
+
+		/**
+		 * Specify the {@link EntityId} of the user account behind this {@link AccountIdentity}.
+		 *
+		 * @param id account entity identifier, can't be {@literal null}
+		 * @return account identity builder
+		 */
+		public Builder id(EntityId id) {
+			this.id = id;
+			return this;
+		}
+
+		/**
+		 * Specify the current {@link AccountIdentityStatus} of this {@link AccountIdentity}.
+		 *
+		 * @param status account identity status, can't be {@literal null}
+		 * @return account identity builder
+		 */
+		public Builder status(AccountIdentityStatus status) {
+			this.status = status;
+			return this;
+		}
+
+		/**
+		 * Specify the e-mail address of this {@link AccountIdentity}.
+		 *
+		 * @param email e-mail address, can't be {@literal null}
+		 * @return account identity builder
+		 */
+		public Builder email(String email) {
+			this.email = email;
+			return this;
+		}
+
+		/**
+		 * Specify the display name of this {@link AccountIdentity}.
+		 *
+		 * @param displayName display name, can't be {@literal null}
+		 * @return account identity builder
+		 */
+		public Builder displayName(String displayName) {
+			this.displayName = displayName;
+			return this;
+		}
+
+		/**
+		 * Specify the {@link Avatar} of this {@link AccountIdentity}.
+		 *
+		 * @param avatar account avatar, can't be {@literal null}
+		 * @return account identity builder
+		 */
+		public Builder avatar(Avatar avatar) {
+			this.avatar = avatar;
+			return this;
+		}
+
+		/**
+		 * Specify the {@link GrantedAuthority authorities} granted to this {@link AccountIdentity}.
+		 *
+		 * @param authorities granted authorities, can't be {@literal null}
+		 * @return account identity builder
+		 */
+		public Builder authorities(Collection<? extends GrantedAuthority> authorities) {
+			this.authorities = authorities;
+			return this;
+		}
+
+		/**
+		 * Creates a new instance of the {@link AccountIdentity} using the values defined in the builder.
+		 *
+		 * @return account identity instance, never {@literal null}
+		 * @throws IllegalArgumentException when required fields are missing or invalid
+		 */
+		public AccountIdentity build() {
+			Assert.notNull(id, "Account entity identifier can not be null");
+			Assert.notNull(status, "Account identity status can not be null");
+			Assert.hasText(email, "Account e-mail address can not be blank");
+			Assert.hasText(displayName, "Account display name can not be blank");
+			Assert.notNull(avatar, "Account avatar can not be null");
+			Assert.notNull(authorities, "Account granted authorities can not be null");
+			return new AccountIdentity(id, status, email, displayName, avatar, authorities);
+		}
+
 	}
 
 }

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AccountIdentity.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AccountIdentity.java
@@ -13,6 +13,8 @@ import org.springframework.security.core.AuthenticatedPrincipal;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.util.Assert;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonPOJOBuilder;
 
 import java.io.Serial;
 import java.io.Serializable;
@@ -39,6 +41,7 @@ import java.util.Objects;
 @NullMarked
 @AggregateRoot
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(builder = AccountIdentity.Builder.class)
 public final class AccountIdentity implements UserDetails, AuthenticatedPrincipal, Identifiable<EntityId>, Serializable {
 
 	@Serial
@@ -197,6 +200,7 @@ public final class AccountIdentity implements UserDetails, AuthenticatedPrincipa
 	/**
 	 * Fluent builder type used to create an {@link AccountIdentity}.
 	 */
+	@JsonPOJOBuilder(withPrefix = "")
 	public static final class Builder {
 
 		private @Nullable EntityId id;

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
@@ -89,7 +89,7 @@ class DefaultAuthorizationService implements AuthorizationService {
 			StringUtils::collectionToCommaDelimitedString
 	);
 
-	public DefaultAuthorizationService(
+	DefaultAuthorizationService(
 			DSLContext context, ApplicationEventPublisher publisher, ObjectMapper mapper,
 			KeysetOperations operations, RegisteredClientRepository repository
 	) {

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/DefaultAuthorizationService.java
@@ -56,7 +56,7 @@ import static com.konfigyr.data.tables.OauthAuthorizationsConsents.OAUTH_AUTHORI
  */
 @Slf4j
 @SuppressWarnings("rawtypes")
-public class DefaultAuthorizationService implements AuthorizationService {
+class DefaultAuthorizationService implements AuthorizationService {
 
 	static final OAuth2TokenType AUTHORIZATION_STATE_TOKEN_TYPE = new OAuth2TokenType(OAuth2ParameterNames.STATE);
 	static final OAuth2TokenType AUTHORIZATION_CODE_TOKEN_TYPE = new OAuth2TokenType(OAuth2ParameterNames.CODE);


### PR DESCRIPTION
### Summary

- Adds `.claude/agents/` with two orchestrating agents (backend-engineer, frontend-engineer) that load only the context relevant to the task at hand
- Adds `.claude/skills/` with 16 domain-scoped skill files across backend (Spring Modulith, jOOQ, Liquibase, OAuth2, testing, entity modeling, cross-module events), frontend (TanStack routing/queries, React, Tailwind, OIDC auth, testing, forms), and shared (project overview, git practices)
- Adds `CLAUDE.md` at the repo root with Karpathy's 4 core principles, agent/skill quick-reference, and a Skill Maintenance table that maps project changes to the skills that must be kept in sync

### Why

Claude Code's default behaviour loads all context indiscriminately. This system gives it precise, domain-scoped knowledge: a backend task loads no React context, a frontend task loads no Spring context. The skill files also encode project-specific conventions (PS256 JWTs, `@RequiresScope`, `SearchQuery` patterns, KEK/DEK hierarchy, etc.) that would otherwise have to be re-explained every session.

