### PR TITLE
Trusted Issuer Registry with Nimbus JWK source caching

### DIFF
--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ApplicationsControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ApplicationsControllerTest.java
@@ -664,7 +664,10 @@ public class ApplicationsControllerTest extends AbstractControllerTest {
 						.hasTitle("Client secret is not supported")
 						.hasDetailContaining("Client secret reset is not available for %s applications.", NamespaceClientType.AGENT.displayName())
 				))
-				.satisfies(hasFailedWithException(NamespaceApplicationTypeException.class));
+				.satisfies(hasFailedWithException(NamespaceApplicationTypeException.class, ex -> ex
+				.extracting(NamespaceApplicationTypeException::getErrorCode)
+				.isEqualTo(NamespaceApplicationTypeException.ErrorCode.SECRET_NOT_SUPPORTED)
+		));
 	}
 
 	@Test

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationConfiguration.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationConfiguration.java
@@ -11,9 +11,6 @@ import com.konfigyr.identity.authorization.client.CachingRegisteredClientReposit
 import com.konfigyr.identity.authorization.client.DelegatingRegisteredClientRepository;
 import com.konfigyr.identity.authorization.client.KonfigyrRegisteredClientRepository;
 import com.konfigyr.identity.authorization.client.RegisteredNamespaceClientRepository;
-import com.konfigyr.identity.authorization.issuer.CompositeTrustedIssuerRepository;
-import com.konfigyr.identity.authorization.issuer.TrustedIssuerRepository;
-import com.konfigyr.identity.authorization.issuer.WellKnownTrustedIssuers;
 import com.konfigyr.identity.authorization.jwk.KeysetSource;
 import com.konfigyr.identity.authorization.jwk.SigningJwkSelector;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
@@ -125,13 +122,6 @@ public class AuthorizationConfiguration implements InitializingBean {
 						.stream()
 						.filter(StringUtils::hasText)
 						.toList()
-		);
-	}
-
-	@Bean
-	TrustedIssuerRepository trustedIssuerRepository() {
-		return new CompositeTrustedIssuerRepository(
-				WellKnownTrustedIssuers.getInstance()
 		);
 	}
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationProperties.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationProperties.java
@@ -94,6 +94,13 @@ public class AuthorizationProperties {
 	private CacheProperties.Caffeine cache = new CacheProperties.Caffeine();
 
 	/**
+	 * Configuration for the trusted issuer registry that resolves and caches the JWK
+	 * sources used to verify JWT subject tokens during OAuth 2.0 Token Exchange.
+	 */
+	@NestedConfigurationProperty
+	private TrustedIssuersProperties trustedIssuers = new TrustedIssuersProperties();
+
+	/**
 	 * Token settings overrides for a specific namespace client type. Fields left unset fall
 	 * back to the global token settings defined in the enclosing authorization properties.
 	 * Platform-level constraints such as refresh token rotation policy are always enforced
@@ -119,6 +126,29 @@ public class AuthorizationProperties {
 		 */
 		@DurationUnit(ChronoUnit.MINUTES)
 		Duration refreshTokenTimeToLive;
+
+	}
+
+	/**
+	 * Configuration properties for the trusted issuer registry cache. Controls how long
+	 * inactive JWK source entries are retained and the maximum number of issuers held
+	 * concurrently. Use a Caffeine specification string to configure both constraints,
+	 * for example: {@code "maximumSize=1000,expireAfterAccess=7d"}.
+	 */
+	@Data
+	public static class TrustedIssuersProperties {
+
+		/**
+		 * Caffeine cache specification for the JWK source cache. Controls the maximum
+		 * number of trusted issuers and the inactivity TTL after which an entry is evicted
+		 * and its JWK source session torn down. The entry is rebuilt transparently on the
+		 * next token exchange request for that issuer.
+		 * <p>
+		 * It is recommended to set a long inactivity TTL relative to the expected interval
+		 * between token exchange requests, for example: {@code "maximumSize=1000,expireAfterAccess=7d"}.
+		 */
+		@NestedConfigurationProperty
+		private CacheProperties.Caffeine cache = new CacheProperties.Caffeine();
 
 	}
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/CompositeTrustedIssuerRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/CompositeTrustedIssuerRepository.java
@@ -18,7 +18,7 @@ import java.util.List;
  */
 @NullMarked
 @RequiredArgsConstructor
-public final class CompositeTrustedIssuerRepository implements TrustedIssuerRepository {
+final class CompositeTrustedIssuerRepository implements TrustedIssuerRepository {
 
 	private final Iterable<TrustedIssuerRepository> repositories;
 
@@ -27,14 +27,14 @@ public final class CompositeTrustedIssuerRepository implements TrustedIssuerRepo
 	 *
 	 * @param repositories ordered repositories to delegate to
 	 */
-	public CompositeTrustedIssuerRepository(TrustedIssuerRepository... repositories) {
+	CompositeTrustedIssuerRepository(TrustedIssuerRepository... repositories) {
 		this(List.of(repositories));
 	}
 
 	@Override
-	public @Nullable TrustedIssuer lookup(EntityId namespace, String issuerUri) {
+	public @Nullable TrustedIssuerRegistration lookup(EntityId namespace, String issuerUri) {
 		for (TrustedIssuerRepository repository : repositories) {
-			final TrustedIssuer issuer = repository.lookup(namespace, issuerUri);
+			final TrustedIssuerRegistration issuer = repository.lookup(namespace, issuerUri);
 
 			if (issuer != null) {
 				return issuer;

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/NimbusTrustedIssuerRegistry.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/NimbusTrustedIssuerRegistry.java
@@ -1,0 +1,333 @@
+package com.konfigyr.identity.authorization.issuer;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import com.konfigyr.entity.EntityId;
+import com.nimbusds.jose.jwk.source.JWKSource;
+import com.nimbusds.jose.jwk.source.JWKSourceBuilder;
+import com.nimbusds.jose.proc.SecurityContext;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.RequestEntity;
+import org.springframework.security.oauth2.core.*;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationServerMetadataClaimNames;
+import org.springframework.util.Assert;
+import org.springframework.util.CollectionUtils;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Nimbus-backed {@link TrustedIssuerRegistry} that resolves and verifies JWT subject
+ * tokens using a two-level caching strategy to minimize remote JWKS fetches while
+ * keeping signing keys up to date.
+ *
+ * <h2>Caching layers</h2>
+ * <p>
+ * <b>Outer Caffeine cache</b>: one live {@link JWKSource} per
+ * {@link TrustedIssuerRegistration#id()}, held for a configurable inactivity TTL
+ * (default: 7 days). A cache miss triggers JWKS URI resolution and constructs a new
+ * {@link JWKSource} via {@link JWKSourceBuilder}. When an entry is evicted,
+ * {@link JWKSourceCloser} calls {@link java.io.Closeable#close()} on the source,
+ * releasing any thread pools or connections held by the Nimbus chain.
+ * <p>
+ * <b>Nimbus-internal cache</b>: the {@link JWKSource} produced by
+ * {@link JWKSourceBuilder} keeps the parsed JWK set in memory with a short TTL
+ * (default: 5 minutes). On expiry, it triggers a background key refresh so that callers
+ * are never blocked waiting for the network. Rate-limiting ensures at most one refresh
+ * request per second to the remote JWKS endpoint; the built-in retry handles transient
+ * network failures transparently.
+ * <p>
+ * <b>OIDC discovery</b>: for registrations without an explicit
+ * {@link TrustedIssuerRegistration#jwksUri()}, a single HTTP call to the issuer's
+ * {@code /.well-known/openid-configuration} resolves the JWKS URI. Because this happens
+ * only on an outer-cache miss, the round trip is amortized over the full outer TTL;
+ * at most once per issuer per eviction cycle.
+ *
+ * <h2>Request timeline example</h2>
+ * <pre>
+ * t=0s    get(namespace, issuerUri) called
+ *           Caffeine MISS → discoverJwkSetUri, buildSource [OIDC discovery HTTP call
+ *                           only if jwksUri is null], JWKSource stored in Caffeine
+ *
+ * t=0s    trustedIssuer.verify(token) called
+ *           Nimbus MISS → fetches JWKS endpoint [HTTP], parses and caches JWK set
+ *           Signature, iss, exp and aud claims validated → JWT returned
+ *
+ * t=30s   get(namespace, issuerUri) called
+ *           Caffeine HIT → same JWKSource returned, no HTTP call
+ *         trustedIssuer.verify(token) called
+ *           Nimbus HIT → no HTTP call, claims validated → JWT returned
+ *
+ * t=5min  Nimbus internal cache expires
+ *           Next verify() submits a background key refresh [HTTP]
+ *           Caller is not blocked — stale keys serve requests until refresh completes
+ *
+ * t=7days Caffeine entry evicted (inactivity TTL exceeded)
+ *           JWKSourceCloser.close() called → Nimbus session torn down
+ *
+ * t=7days get(namespace, issuerUri) called
+ *           Caffeine MISS → new JWKSource built, JWKS re-fetched on next verify()
+ * </pre>
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@Slf4j
+@NullMarked
+final class NimbusTrustedIssuerRegistry implements TrustedIssuerRegistry, MeterBinder {
+
+	private static final String ERROR_URI = "https://datatracker.ietf.org/doc/html/rfc6749#section-5.2";
+	private static final ParameterizedTypeReference<Map<String, Object>> MAP_TYPE =
+			new ParameterizedTypeReference<>() { /* noop */ };
+
+	private final TrustedIssuerRepository repository;
+	private final RestOperations operations;
+	private final Cache<String, JWKSource<SecurityContext>> cache;
+
+	/**
+	 * Creates a new registry with the given Caffeine configuration specification.
+	 *
+	 * @param repository    the repository used to look up trusted issuer registrations
+	 * @param operations    the HTTP client used for OIDC discovery when no explicit JWKS URI is configured
+	 * @param specification Caffeine cache specification controlling the size and expiry of the JWK source
+	 *                      cache, e.g. {@code "maximumSize=1000,expireAfterAccess=7d"}
+	 */
+	NimbusTrustedIssuerRegistry(
+			TrustedIssuerRepository repository,
+			RestOperations operations,
+			String specification
+	) {
+		this.repository = repository;
+		this.operations = operations;
+		this.cache = Caffeine.from(specification)
+				.removalListener(new JWKSourceCloser())
+				.recordStats()
+				.build();
+	}
+
+	/**
+	 * Looks up the {@link TrustedIssuerRegistration} for the given namespace and issuer URI,
+	 * builds or retrieves a cached {@link JWKSource} for that registration, and returns a
+	 * {@link TrustedIssuer} ready to verify subject tokens.
+	 *
+	 * @param namespace the namespace on whose behalf the lookup is performed
+	 * @param issuerUri the OIDC issuer URI to resolve
+	 * @return a {@link TrustedIssuer} backed by a live JWK source, never {@code null}
+	 * @throws OAuth2AuthenticationException with {@code invalid_client} if no trusted issuer
+	 *         is registered for the given namespace and issuer URI combination
+	 */
+	@Override
+	public TrustedIssuer get(EntityId namespace, String issuerUri) {
+		final TrustedIssuerRegistration issuer = repository.lookup(namespace, issuerUri);
+
+		if (issuer == null) {
+			throw new OAuth2AuthenticationException(new OAuth2Error(
+					OAuth2ErrorCodes.INVALID_CLIENT,
+					"Can't find any trusted issuer for this OAuth2 Client that matches this issuer URI: %s".formatted(issuerUri),
+					ERROR_URI
+			));
+		}
+
+		if (log.isDebugEnabled()) {
+			log.debug("Resolving trusted issuer for: [issuer_id={}, issuer_url={}]", issuer.id(), issuer.issuerUri());
+		}
+
+		final JWKSource<SecurityContext> source = cache.get(issuer.id(), ignore -> buildSource(issuer));
+		return new TrustedIssuer(issuer, buildDecoder(issuer, source));
+	}
+
+	/**
+	 * Binds JWK source cache metrics to the given {@link MeterRegistry} under the name
+	 * {@code identity.trusted-issuers}, exposing hit rate, load count, and eviction
+	 * statistics.
+	 *
+	 * @param meterRegistry the registry to bind metrics to
+	 */
+	@Override
+	public void bindTo(MeterRegistry meterRegistry) {
+		CaffeineCacheMetrics.monitor(meterRegistry, cache, "identity.trusted-issuers");
+	}
+
+	private JWKSource<SecurityContext> buildSource(TrustedIssuerRegistration issuer) {
+		final String keysetUri = discoverJwkSetUri(issuer);
+
+		final URL url;
+
+		try {
+			url = URI.create(keysetUri).toURL();
+		} catch (MalformedURLException ex) {
+			throw new OAuth2AuthenticationException(new OAuth2Error(
+					OAuth2ErrorCodes.INVALID_CLIENT,
+					"Failed to parse JWKS URI of '%s' for Issuer: %s".formatted(keysetUri, issuer.issuerUri()),
+					ERROR_URI
+			), ex);
+		}
+
+		if (log.isDebugEnabled()) {
+			log.debug("Creating new JWK Source for: [issuer={}, jwks_uri={}]", issuer.issuerUri(), keysetUri);
+		}
+
+		return JWKSourceBuilder.create(url)
+				.cache(true)
+				.rateLimited(true)
+				.retrying(true)
+				.build();
+	}
+
+	private String discoverJwkSetUri(TrustedIssuerRegistration issuer) {
+		if (StringUtils.hasText(issuer.jwksUri())) {
+			return issuer.jwksUri();
+		}
+
+		if (StringUtils.hasText(issuer.issuerUri())) {
+			return discoverJwkSetUri(issuer.issuerUri());
+		}
+
+		throw new OAuth2AuthenticationException(new OAuth2Error(
+				OAuth2ErrorCodes.INVALID_CLIENT,
+				"No JWKS URI or issuer URI found",
+				ERROR_URI
+		));
+	}
+
+	private String discoverJwkSetUri(String issuerUri) {
+		final UriComponents endpoint = generateOidcDiscoveryUri(issuerUri);
+		final RequestEntity<Void> request = RequestEntity.get(endpoint.toUri())
+				.build();
+
+		if (log.isDebugEnabled()) {
+			log.debug("Attempting to discover JWKS URI for: [issuer={}, discovery_uri={}]", issuerUri, endpoint);
+		}
+
+		final Map<String, Object> config;
+
+		try {
+			config = operations.exchange(request, MAP_TYPE).getBody();
+		} catch (Exception ex) {
+			throw new OAuth2AuthenticationException(new OAuth2Error(
+					OAuth2ErrorCodes.INVALID_CLIENT,
+					"Failed to fetch OIDC discovery document from: " + endpoint,
+					ERROR_URI
+			), ex);
+		}
+
+		if (CollectionUtils.isEmpty(config)) {
+			throw new OAuth2AuthenticationException(new OAuth2Error(
+					OAuth2ErrorCodes.INVALID_CLIENT,
+					"No OIDC discovery document found at: " + endpoint,
+					ERROR_URI
+			));
+		}
+
+		if (log.isDebugEnabled()) {
+			log.debug("Discovered OIDC discovery document for '{}' issuer: {}", issuerUri, config);
+		}
+
+		final Object value = config.get(OAuth2AuthorizationServerMetadataClaimNames.JWKS_URI);
+
+		if (value instanceof String uri && StringUtils.hasText(uri)) {
+			return uri;
+		}
+
+		throw new OAuth2AuthenticationException(new OAuth2Error(
+				OAuth2ErrorCodes.INVALID_CLIENT,
+				"No 'jwks_uri' claim found in OIDC discovery document at: " + endpoint,
+				ERROR_URI
+		));
+	}
+
+	private static JwtDecoder buildDecoder(TrustedIssuerRegistration issuer, JWKSource<SecurityContext> source) {
+		final NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSource(source).build();
+
+		final List<OAuth2TokenValidator<Jwt>> validators = new ArrayList<>();
+		validators.add(JwtValidators.createDefaultWithIssuer(issuer.issuerUri()));
+
+		if (!CollectionUtils.isEmpty(issuer.allowedAudiences())) {
+			validators.add(new AnyAudienceValidator(issuer.allowedAudiences()));
+		}
+
+		decoder.setJwtValidator(new DelegatingOAuth2TokenValidator<>(validators));
+		return decoder;
+	}
+
+	/**
+	 * Returns the underlying JWK source cache. Exposed for testing.
+	 *
+	 * @return the JWK source cache
+	 */
+	Cache<String, JWKSource<SecurityContext>> sourceCache() {
+		return cache;
+	}
+
+	private static UriComponents generateOidcDiscoveryUri(String issuer) {
+		final UriComponents uri = UriComponentsBuilder.fromUriString(issuer).build();
+
+		return UriComponentsBuilder.newInstance().uriComponents(uri)
+				.replacePath(uri.getPath())
+				.pathSegment(".well-known", "openid-configuration")
+				.build();
+	}
+
+	/**
+	 * {@link OAuth2TokenValidator} that passes if the JWT {@code aud} claim contains
+	 * at least one value from the configured set of allowed audiences.
+	 */
+	private static final class AnyAudienceValidator implements OAuth2TokenValidator<Jwt> {
+
+		private final JwtClaimValidator<Collection<String>> validator;
+
+		private AnyAudienceValidator(Collection<String> audiences) {
+			Assert.notNull(audiences, "audiences cannot be null");
+			this.validator = new JwtClaimValidator<>(JwtClaimNames.AUD,
+					values -> audiences.stream().anyMatch(values::contains));
+		}
+
+		@Override
+		public OAuth2TokenValidatorResult validate(Jwt token) {
+			return this.validator.validate(token);
+		}
+
+	}
+
+	/**
+	 * Caffeine {@link RemovalListener} that calls {@link Closeable#close()} on evicted
+	 * {@link JWKSource} instances, releasing any thread pools or connections held by
+	 * the Nimbus key-set source chain.
+	 */
+	private static final class JWKSourceCloser implements RemovalListener<String, JWKSource<SecurityContext>> {
+
+		@Override
+		public void onRemoval(@Nullable String issuer, @Nullable JWKSource<SecurityContext> source, RemovalCause cause) {
+			log.debug("Attempting to close the evicted JWK source for issuer: {}", issuer);
+
+			if (source instanceof Closeable closeable) {
+				try {
+					closeable.close();
+				} catch (IOException ex) {
+					log.warn("Failed to close JWK source for issuer: {}", issuer, ex);
+				}
+			}
+		}
+	}
+
+}

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuer.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuer.java
@@ -1,49 +1,72 @@
 package com.konfigyr.identity.authorization.issuer;
 
+import lombok.EqualsAndHashCode;
+import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
-import org.springframework.util.Assert;
-
-import java.io.Serial;
-import java.io.Serializable;
-import java.util.Set;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.jwt.JwtClaimAccessor;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
 
 /**
- * Immutable value object describing an external OIDC identity provider that this
- * authorization server trusts as a source of subject tokens during token exchange.
+ * Represents a trusted external OIDC identity provider and serves as the verification
+ * entry point for JWT subject tokens during an OAuth 2.0 Token Exchange (RFC 8693).
  * <p>
- * A trusted issuer records everything the authorization server needs to validate an
- * inbound JWT without going through the full OIDC login flow: where to fetch the
- * signing keys, and which audience values are acceptable. It is intentionally
- * decoupled from any particular use-case (Pipeline Integration, Service Accounts,
- * future workload-identity flows) so that the same registry can serve multiple grant
- * types as the platform evolves.
+ * In the workload identity token exchange flow a client presents a JWT issued by an
+ * external provider (such as GitHub Actions or GitLab) as the {@code subject_token}.
+ * This class validates that token, verifying its signature against the issuer's public
+ * keys, asserting the {@code iss} and timestamp claims, and optionally enforcing
+ * {@code aud} constraints, before the authorization server issues a scoped Konfigyr
+ * access token in exchange.
+ * <p>
+ * A {@link TrustedIssuer} combines the static configuration in a
+ * {@link TrustedIssuerRegistration} with a pre-configured verifier backed by the
+ * issuer's live JWK source. Instances are produced by {@link TrustedIssuerRegistry}
+ * and are not constructed directly. Equality and hash code are based solely on the
+ * underlying {@link TrustedIssuerRegistration}.
  *
- * @param issuerUri the OIDC issuer URI; must match the {@code iss} claim of subject
- *                  tokens issued by this provider
- * @param name human-readable display name, used in audit logs and the management UI
- * @param jwksUri explicit JWKS endpoint URI; when {@code null} the authorization server
- *                resolves the endpoint via OIDC discovery ({@code /.well-known/openid-configuration})
- * @param allowedAudiences set of accepted {@code aud} claim values; an empty set
- *                          disables audience validation for this issuer
  * @author Vladimir Spasic
  * @since 1.0.0
+ * @see TrustedIssuerRegistry
+ * @see TrustedIssuerRegistration
  */
 @NullMarked
-public record TrustedIssuer(
-		String issuerUri,
-		String name,
-		@Nullable String jwksUri,
-		Set<String> allowedAudiences
-) implements Serializable {
+@RequiredArgsConstructor
+@EqualsAndHashCode(of = "registration")
+public final class TrustedIssuer {
 
-	@Serial
-	private static final long serialVersionUID = 102723649959045957L;
+	private final TrustedIssuerRegistration registration;
+	private final JwtDecoder delegate;
 
-	public TrustedIssuer {
-		Assert.hasText(issuerUri, "Trusted issuer URI must not be blank");
-		Assert.hasText(name, "Trusted issuer name must not be blank");
-		allowedAudiences = Set.copyOf(allowedAudiences);
+	/**
+	 * Returns the stored registration data for this issuer.
+	 *
+	 * @return the {@link TrustedIssuerRegistration}, never {@code null}
+	 */
+	public TrustedIssuerRegistration registration() {
+		return registration;
 	}
 
+	/**
+	 * Decodes and validates the given compact JWT string, applying the issuer timestamp
+	 * and audience constraints configured in the {@link TrustedIssuerRegistration}.
+	 *
+	 * @param token the compact JWT string to verify
+	 * @return the validated JWT claims
+	 * @throws AuthenticationException if the token is malformed, expired, or fails
+	 *         issuer or audience validation
+	 */
+	public JwtClaimAccessor verify(String token) throws AuthenticationException {
+		return delegate.decode(token);
+	}
+
+	@Override
+	public String toString() {
+		return new ToStringBuilder(this, ToStringStyle.SIMPLE_STYLE)
+				.append("id", registration.id())
+				.append("name", registration.name())
+				.append("issuer", registration.issuerUri())
+				.toString();
+	}
 }

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerConfiguration.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerConfiguration.java
@@ -1,0 +1,47 @@
+package com.konfigyr.identity.authorization.issuer;
+
+import com.konfigyr.identity.authorization.AuthorizationProperties;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.Assert;
+
+/**
+ * Spring configuration that registers the trusted issuer infrastructure beans. All
+ * implementation classes in this package are package-private; this configuration is
+ * the single place that creates and wires them.
+ * <p>
+ * The two beans registered here are:
+ * <ul>
+ *   <li>{@link TrustedIssuerRepository} — a {@link CompositeTrustedIssuerRepository}
+ *       pre-seeded with the {@link WellKnownTrustedIssuers} static registry. Additional
+ *       {@link TrustedIssuerRepository} implementations registered as beans elsewhere in
+ *       the application context are composed into the same composite automatically.</li>
+ *   <li>{@link TrustedIssuerRegistry} — a {@link NimbusTrustedIssuerRegistry} backed by a
+ *       Caffeine cache whose size and TTL are controlled via
+ *       {@code konfigyr.identity.authorization.trusted-issuers.cache.spec}.</li>
+ * </ul>
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@Configuration(proxyBeanMethods = false)
+class TrustedIssuerConfiguration {
+
+	@Bean
+	TrustedIssuerRepository trustedIssuerRepository() {
+		return new CompositeTrustedIssuerRepository(WellKnownTrustedIssuers.getInstance());
+	}
+
+	@Bean
+	NimbusTrustedIssuerRegistry trustedIssuerRegistry(
+			TrustedIssuerRepository trustedIssuerRepository,
+			RestTemplateBuilder restTemplateBuilder,
+			AuthorizationProperties properties
+	) {
+		final String spec = properties.getTrustedIssuers().getCache().getSpec();
+		Assert.hasText(spec, "Trusted issuer cache specification must not be blank");
+		return new NimbusTrustedIssuerRegistry(trustedIssuerRepository, restTemplateBuilder.build(), spec);
+	}
+
+}

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerRegistration.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerRegistration.java
@@ -1,0 +1,182 @@
+package com.konfigyr.identity.authorization.issuer;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Immutable value object describing an external OIDC identity provider that this
+ * authorization server trusts as a source of subject tokens during token exchange.
+ * <p>
+ * Use {@link #withId(String)} to construct a new registration or {@link #from(TrustedIssuerRegistration)}
+ * to produce a modified copy of an existing one.
+ *
+ * @param id unique identifier for this issuer registration
+ * @param issuerUri the OIDC issuer URI; must match the {@code iss} claim of subject
+ *                  tokens issued by this provider
+ * @param name human-readable display name, used in audit logs and the management UI
+ * @param jwksUri explicit JWKS endpoint URI; when {@code null} the authorization server
+ *                resolves the endpoint via OIDC discovery ({@code /.well-known/openid-configuration})
+ * @param allowedAudiences set of accepted {@code aud} claim values; an empty set
+ *                          disables audience validation for this issuer
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@NullMarked
+public record TrustedIssuerRegistration(
+		String id,
+		String issuerUri,
+		String name,
+		@Nullable String jwksUri,
+		Set<String> allowedAudiences
+) implements Serializable {
+
+	@Serial
+	private static final long serialVersionUID = 102723649959045957L;
+
+	public TrustedIssuerRegistration {
+		Assert.hasText(id, "Trusted issuer registration identifier must not be blank");
+		Assert.hasText(issuerUri, "Trusted issuer URI must not be blank");
+		Assert.hasText(name, "Trusted issuer name must not be blank");
+		allowedAudiences = Set.copyOf(allowedAudiences);
+	}
+
+	/**
+	 * Creates a new {@link Builder} initialized with the given registration identifier.
+	 *
+	 * @param id the unique identifier for the registration, e.g. {@code "github-actions"}
+	 * @return a new {@link Builder}
+	 */
+	public static Builder withId(String id) {
+		return new Builder(id);
+	}
+
+	/**
+	 * Creates a new {@link Builder} pre-populated from an existing registration. Useful
+	 * for producing a modified copy without altering the original.
+	 *
+	 * @param registration the registration to copy from, must not be {@code null}
+	 * @return a new {@link Builder} pre-populated with all fields from {@code registration}
+	 */
+	public static Builder from(TrustedIssuerRegistration registration) {
+		Assert.notNull(registration, "TrustedIssuerRegistration must not be null");
+		return new Builder(registration.id())
+				.issuerUri(registration.issuerUri())
+				.name(registration.name())
+				.jwksUri(registration.jwksUri())
+				.allowedAudiences(registration.allowedAudiences());
+	}
+
+	/**
+	 * Builder for {@link TrustedIssuerRegistration}.
+	 * <p>
+	 * Create an instance via {@link TrustedIssuerRegistration#withId(String)} for a new
+	 * registration or via {@link TrustedIssuerRegistration#from(TrustedIssuerRegistration)}
+	 * to produce a modified copy of an existing one.
+	 */
+	public static final class Builder {
+
+		private final String id;
+		@Nullable private String issuerUri;
+		@Nullable private String name;
+		@Nullable private String jwksUri;
+		private final Set<String> allowedAudiences = new HashSet<>();
+
+		private Builder(String id) {
+			Assert.hasText(id, "Trusted issuer registration identifier must not be blank");
+			this.id = id;
+		}
+
+		/**
+		 * Sets the OIDC issuer URI. Must match the {@code iss} claim of tokens issued
+		 * by this provider.
+		 *
+		 * @param issuerUri the issuer URI, must not be blank
+		 * @return this builder
+		 */
+		public Builder issuerUri(String issuerUri) {
+			this.issuerUri = issuerUri;
+			return this;
+		}
+
+		/**
+		 * Sets the human-readable display name for this registration.
+		 *
+		 * @param name the display name, must not be blank
+		 * @return this builder
+		 */
+		public Builder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		/**
+		 * Sets the explicit JWKS endpoint URI. When not set or set to {@code null}, the
+		 * endpoint is resolved via OIDC discovery at runtime.
+		 *
+		 * @param jwksUri the JWKS endpoint URI, or {@code null} to rely on discovery
+		 * @return this builder
+		 */
+		public Builder jwksUri(@Nullable String jwksUri) {
+			this.jwksUri = jwksUri;
+			return this;
+		}
+
+		/**
+		 * Adds a single accepted {@code aud} claim value. May be called multiple times
+		 * to accumulate more than one audience.
+		 *
+		 * @param audience the audience value to be accepted
+		 * @return this builder
+		 */
+		public Builder allowedAudience(@Nullable String audience) {
+			if (StringUtils.hasText(audience)) {
+				this.allowedAudiences.add(audience);
+			}
+			return this;
+		}
+
+		/**
+		 * Adds all the given {@code aud} claim values to the accepted set.
+		 *
+		 * @param audiences the audience values to accept
+		 * @return this builder
+		 */
+		public Builder allowedAudiences(String @Nullable... audiences) {
+			return audiences == null ? this : allowedAudiences(Arrays.asList(audiences));
+		}
+
+		/**
+		 * Adds all the given {@code aud} claim values to the accepted set.
+		 *
+		 * @param audiences the audience values to accept
+		 * @return this builder
+		 */
+		public Builder allowedAudiences(@Nullable Collection<String> audiences) {
+			if (audiences != null) {
+				audiences.forEach(this::allowedAudience);
+			}
+			return this;
+		}
+
+		/**
+		 * Builds and returns the {@link TrustedIssuerRegistration}.
+		 *
+		 * @return the registration
+		 * @throws IllegalArgumentException if {@code issuerUri} or {@code name} are not set or blank
+		 */
+		public TrustedIssuerRegistration build() {
+			return new TrustedIssuerRegistration(id, issuerUri, name, jwksUri, allowedAudiences);
+		}
+
+	}
+
+}

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerRegistry.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerRegistry.java
@@ -1,0 +1,49 @@
+package com.konfigyr.identity.authorization.issuer;
+
+import com.konfigyr.entity.EntityId;
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Strategy interface that resolves a {@link TrustedIssuer} capable of verifying JWT
+ * subject tokens during an OAuth 2.0 Token Exchange (RFC 8693).
+ * <p>
+ * A trusted issuer represents an external OIDC identity provider whose JWTs this
+ * authorization server accepts as the {@code subject_token} in a token exchange request.
+ * Before a workload application can exchange an external token for a Konfigyr access
+ * token, the registry must confirm that the token's {@code iss} claim identifies a
+ * provider that the namespace has explicitly trusted.
+ * <p>
+ * The resolved {@link TrustedIssuer} verifies the subject token by:
+ * <ul>
+ *   <li>validating the JWT signature against the issuer's public signing keys, fetched
+ *       from the JWKS endpoint declared in the {@link TrustedIssuerRegistration}</li>
+ *   <li>asserting that the {@code iss} claim matches the registered issuer URI</li>
+ *   <li>asserting that the token has not expired ({@code exp} / {@code nbf})</li>
+ *   <li>when the {@link TrustedIssuerRegistration} declares allowed audiences, asserting
+ *       that at least one appears in the token's {@code aud} claim</li>
+ * </ul>
+ * Implementations must throw
+ * {@link org.springframework.security.oauth2.core.OAuth2AuthenticationException} with
+ * error code {@code invalid_client} when no registration is found for the given namespace
+ * and issuer URI, so that the caller can treat an unresolved issuer as an authentication
+ * failure.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@NullMarked
+@FunctionalInterface
+public interface TrustedIssuerRegistry {
+
+	/**
+	 * Resolves the {@link TrustedIssuer} for the given namespace and issuer URI.
+	 *
+	 * @param namespace the namespace on whose behalf the lookup is performed
+	 * @param issuerUri the OIDC issuer URI identifying the external identity provider
+	 * @return a {@link TrustedIssuer} ready to verify subject tokens, never {@code null}
+	 * @throws org.springframework.security.oauth2.core.OAuth2AuthenticationException with
+	 *         {@code invalid_client} if no trusted issuer is registered for the combination
+	 */
+	TrustedIssuer get(EntityId namespace, String issuerUri);
+
+}

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerRepository.java
@@ -5,7 +5,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 /**
- * Strategy interface for resolving a {@link TrustedIssuer} given a namespace and an
+ * Strategy interface for resolving a {@link TrustedIssuerRegistration} given a namespace and an
  * issuer URI.
  * <p>
  * Implementations may back the registry with static well-known issuers, a database
@@ -28,15 +28,15 @@ import org.jspecify.annotations.Nullable;
 public interface TrustedIssuerRepository {
 
 	/**
-	 * Looks up the {@link TrustedIssuer} for the given namespace and issuer URI.
+	 * Looks up the {@link TrustedIssuerRegistration} for the given namespace and issuer URI.
 	 *
 	 * @param namespace the namespace on whose behalf the lookup is performed
 	 * @param issuerUri the OIDC issuer URI to resolve, taken from the workload
 	 *                  application's client settings
-	 * @return the matching {@link TrustedIssuer}, or {@code null} if this repository
+	 * @return the matching {@link TrustedIssuerRegistration}, or {@code null} if this repository
 	 *         has no entry for the given combination
 	 */
 	@Nullable
-	TrustedIssuer lookup(EntityId namespace, String issuerUri);
+	TrustedIssuerRegistration lookup(EntityId namespace, String issuerUri);
 
 }

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/WellKnownTrustedIssuers.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/WellKnownTrustedIssuers.java
@@ -6,7 +6,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.util.function.SingletonSupplier;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -34,7 +33,7 @@ import java.util.stream.Stream;
  * @since 1.0.0
  */
 @NullMarked
-public final class WellKnownTrustedIssuers implements TrustedIssuerRepository {
+final class WellKnownTrustedIssuers implements TrustedIssuerRepository {
 
 	private static final Supplier<TrustedIssuerRepository> INSTANCE = SingletonSupplier.of(WellKnownTrustedIssuers::new);
 
@@ -43,27 +42,36 @@ public final class WellKnownTrustedIssuers implements TrustedIssuerRepository {
 	 *
 	 * @return the singleton repository
 	 */
-	public static TrustedIssuerRepository getInstance() {
+	static TrustedIssuerRepository getInstance() {
 		return INSTANCE.get();
 	}
 
-	private final Map<String, TrustedIssuer> issuers;
+	private final Map<String, TrustedIssuerRegistration> issuers;
 
 	private WellKnownTrustedIssuers() {
 		this.issuers = Stream.of(
-				new TrustedIssuer("https://token.actions.githubusercontent.com", "GitHub Actions", null, Set.of()),
-				new TrustedIssuer("https://gitlab.com", "GitLab", null, Set.of())
-		).collect(Collectors.toUnmodifiableMap(TrustedIssuer::issuerUri, Function.identity()));
+				TrustedIssuerRegistration.withId("github-actions")
+						.name("GitHub Actions")
+						.issuerUri("https://token.actions.githubusercontent.com")
+						.build(),
+				TrustedIssuerRegistration.withId("gitlab")
+						.name("GitLab")
+						.issuerUri("https://gitlab.com")
+						.build()
+		).collect(Collectors.toUnmodifiableMap(
+				TrustedIssuerRegistration::issuerUri,
+				Function.identity()
+		));
 	}
 
 	/**
-	 * Returns the well-known {@link TrustedIssuer} for the given issuer URI, or
+	 * Returns the well-known {@link TrustedIssuerRegistration} for the given issuer URI, or
 	 * {@code null} if the URI does not match any of the built-in entries. The namespace
 	 * parameter is ignored because these issuers are globally trusted regardless of
 	 * which namespace is requesting the lookup.
 	 */
 	@Override
-	public @Nullable TrustedIssuer lookup(EntityId namespace, String issuerUri) {
+	public @Nullable TrustedIssuerRegistration lookup(EntityId namespace, String issuerUri) {
 		return issuers.get(issuerUri);
 	}
 

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/workload/WorkloadTokenExchangeAuthenticationConfigurer.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/workload/WorkloadTokenExchangeAuthenticationConfigurer.java
@@ -1,6 +1,6 @@
 package com.konfigyr.identity.authorization.workload;
 
-import com.konfigyr.identity.authorization.issuer.TrustedIssuerRepository;
+import com.konfigyr.identity.authorization.issuer.TrustedIssuerRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -56,7 +56,7 @@ public final class WorkloadTokenExchangeAuthenticationConfigurer
 
 		builder.authenticationProvider(
 				postProcess(new WorkloadTokenExchangeAuthenticationProvider(
-						getSharedObject(builder, TrustedIssuerRepository.class),
+						getSharedObject(builder, TrustedIssuerRegistry.class),
 						getSharedObject(builder, OAuth2AuthorizationService.class),
 						getSharedObject(builder, OAuth2TokenGenerator.class)
 				))

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/workload/WorkloadTokenExchangeAuthenticationProvider.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/workload/WorkloadTokenExchangeAuthenticationProvider.java
@@ -3,6 +3,7 @@ package com.konfigyr.identity.authorization.workload;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.identity.authorization.NamespaceClientSettingNames;
 import com.konfigyr.identity.authorization.issuer.TrustedIssuer;
+import com.konfigyr.identity.authorization.issuer.TrustedIssuerRegistry;
 import com.konfigyr.identity.authorization.issuer.TrustedIssuerRepository;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.NullMarked;
@@ -54,16 +55,16 @@ class WorkloadTokenExchangeAuthenticationProvider implements AuthenticationProvi
 	private static final String ID_TOKEN_TYPE_URI = "urn:ietf:params:oauth:token-type:id_token";
 	private static final Set<String> SUPPORTED_TOKEN_TYPES = Set.of(JWT_TOKEN_TYPE_URI, ID_TOKEN_TYPE_URI);
 
-	private final TrustedIssuerRepository trustedIssuerRepository;
+	private final TrustedIssuerRegistry trustedIssuerRegistry;
 	private final OAuth2AuthorizationService authorizationService;
 	private final OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator;
 
 	WorkloadTokenExchangeAuthenticationProvider(
-			TrustedIssuerRepository trustedIssuerRepository,
+			TrustedIssuerRegistry trustedIssuerRegistry,
 			OAuth2AuthorizationService authorizationService,
 			OAuth2TokenGenerator<? extends OAuth2Token> tokenGenerator
 	) {
-		this.trustedIssuerRepository = trustedIssuerRepository;
+		this.trustedIssuerRegistry = trustedIssuerRegistry;
 		this.authorizationService = authorizationService;
 		this.tokenGenerator = tokenGenerator;
 	}
@@ -94,15 +95,7 @@ class WorkloadTokenExchangeAuthenticationProvider implements AuthenticationProvi
 					registeredClient.getClientId(), trustedIssuer);
 		}
 
-		final Jwt subjectJwt = decodeSubjectToken(trustedIssuer, tokenExchange);
-
-		if (!hasAllowedAudience(trustedIssuer, subjectJwt)) {
-			throw new OAuth2AuthenticationException(new OAuth2Error(
-					OAuth2ErrorCodes.INVALID_REQUEST,
-					"Subject token audience does not match any of the required audiences",
-					ERROR_URI
-			));
-		}
+		final JwtClaimAccessor subjectJwt = decodeSubjectToken(trustedIssuer, tokenExchange);
 
 		if (!hasMatchingSubject(registeredClient, subjectJwt)) {
 			throw new OAuth2AuthenticationException(new OAuth2Error(
@@ -195,30 +188,19 @@ class WorkloadTokenExchangeAuthenticationProvider implements AuthenticationProvi
 			));
 		}
 
-		final TrustedIssuer trustedIssuer = trustedIssuerRepository.lookup(namespace, issuerUri);
-
-		if (trustedIssuer == null) {
-			throw new OAuth2AuthenticationException(new OAuth2Error(
-					OAuth2ErrorCodes.INVALID_CLIENT,
-					"Can't find any trusted issuer for this OAuth2 Client that matches this issuer URI: %s".formatted(issuerUri),
-					ERROR_URI
-			));
-		}
-
-		return trustedIssuer;
+		return trustedIssuerRegistry.get(namespace, issuerUri);
 	}
 
-	private static Jwt decodeSubjectToken(TrustedIssuer issuer, OAuth2TokenExchangeAuthenticationToken exchange) {
-		final JwtDecoder decoder;
-
-		if (StringUtils.hasText(issuer.jwksUri())) {
-			decoder = NimbusJwtDecoder.withJwkSetUri(issuer.jwksUri()).build();
-		} else {
-			decoder = JwtDecoders.fromIssuerLocation(issuer.issuerUri());
-		}
-
+	private static JwtClaimAccessor decodeSubjectToken(TrustedIssuer issuer, OAuth2TokenExchangeAuthenticationToken exchange) {
 		try {
-			return decoder.decode(exchange.getSubjectToken());
+			return issuer.verify(exchange.getSubjectToken());
+		} catch (JwtValidationException ex) {
+			final OAuth2Error error = ex.getErrors().iterator().next();
+			throw new OAuth2AuthenticationException(new OAuth2Error(
+					OAuth2ErrorCodes.INVALID_REQUEST,
+					"Invalid subject_token: " + error.getDescription(),
+					error.getUri()
+			), ex);
 		} catch (JwtException ex) {
 			throw new OAuth2AuthenticationException(new OAuth2Error(
 					OAuth2ErrorCodes.INVALID_REQUEST,
@@ -228,21 +210,7 @@ class WorkloadTokenExchangeAuthenticationProvider implements AuthenticationProvi
 		}
 	}
 
-	private static boolean hasAllowedAudience(TrustedIssuer issuer, Jwt jwt) {
-		if (CollectionUtils.isEmpty(issuer.allowedAudiences())) {
-			return true;
-		}
-
-		final List<String> audience = jwt.getAudience();
-
-		if (CollectionUtils.isEmpty(audience)) {
-			return false;
-		}
-
-		return issuer.allowedAudiences().stream().anyMatch(audience::contains);
-	}
-
-	private static boolean hasMatchingSubject(RegisteredClient registeredClient, Jwt jwt) {
+	private static boolean hasMatchingSubject(RegisteredClient registeredClient, JwtClaimAccessor jwt) {
 		final String subjectPattern = registeredClient.getClientSettings().getSetting(
 				NamespaceClientSettingNames.WORKLOAD_SUBJECT_PATTERN
 		);

--- a/konfigyr-identity/src/main/resources/application.yml
+++ b/konfigyr-identity/src/main/resources/application.yml
@@ -47,6 +47,9 @@ konfigyr:
         access-token-time-to-live: 15m
         refresh-token-time-to-live: 7d
         id-token-signature-algorithm: PS256
+      trusted-issuers:
+        cache:
+          spec: expireAfterAccess=7d,maximumSize=100
       namespace-token-settings:
         agent:
           access-token-time-to-live: 1h

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/AuthorizationServerIntegrationTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/AuthorizationServerIntegrationTest.java
@@ -8,7 +8,7 @@ import com.konfigyr.identity.authentication.AccountIdentityService;
 import com.konfigyr.identity.authentication.rememberme.AccountRememberMeServices;
 import com.konfigyr.identity.authorization.AuthorizationFailureHandler;
 import com.konfigyr.identity.authorization.AuthorizationServerScopes;
-import com.konfigyr.identity.authorization.issuer.TrustedIssuer;
+import com.konfigyr.identity.authorization.issuer.TrustedIssuerRegistration;
 import com.konfigyr.identity.authorization.jwk.KeysetSource;
 import com.nimbusds.jwt.JWTClaimsSet;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -50,7 +50,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -332,6 +331,8 @@ class AuthorizationServerIntegrationTest extends AbstractControllerIntegrationTe
 		result.assertThat()
 				.apply(log())
 				.satisfies(assertRedirect(uri -> assertThat(uri)
+						.hasScheme("http")
+						.hasHost("localhost")
 						.hasPath("/callback")
 						.hasParameter(OAuth2ParameterNames.STATE, "state")
 						.hasParameter(OAuth2ParameterNames.CODE)
@@ -739,8 +740,11 @@ class AuthorizationServerIntegrationTest extends AbstractControllerIntegrationTe
 
 		// The spy is configured to return a TrustedIssuer whose `jwksUri` points to WireMock,
 		// so token validation never makes real network calls to external OIDC providers.
-		final var trustedIssuer = new TrustedIssuer(configuredIssuerUri, "Stubbed issuer", workloadIdentityStubs.keysetUri(), Set.of());
-		doReturn(trustedIssuer).when(trustedIssuerRepository).lookup(EntityId.from(2), configuredIssuerUri);
+		doReturn(TrustedIssuerRegistration.withId(configuredIssuerUri)
+				.name("Stubbed issuer")
+				.issuerUri(workloadIdentityStubs.issuerUri())
+				.jwksUri(workloadIdentityStubs.keysetUri())
+				.build()).when(trustedIssuerRepository).lookup(EntityId.from(2), configuredIssuerUri);
 
 		// Subject must satisfy the regex subjectPattern "repo:konfigyr/*:ref:refs/heads/main"
 		// configured on the workload test client: "/*" matches zero or more trailing slashes,

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/WorkloadIdentityStubs.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/WorkloadIdentityStubs.java
@@ -12,6 +12,8 @@ import com.nimbusds.jose.jwk.RSAKey;
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
 import com.nimbusds.jwt.JWTClaimsSet;
 import com.nimbusds.jwt.SignedJWT;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationServerMetadataClaimNames;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -83,7 +85,10 @@ final public class WorkloadIdentityStubs {
 
 	public String issue(JWTClaimsSet.Builder claims) {
 		final var jwt = new SignedJWT(
-				new JWSHeader.Builder(JWSAlgorithm.RS256).keyID(key.getKeyID()).build(),
+				new JWSHeader.Builder(JWSAlgorithm.RS256)
+						.keyID(key.getKeyID())
+						.x509CertChain(key.getX509CertChain())
+						.build(),
 				claims.issuer(issuerUri()).build()
 		);
 
@@ -103,13 +108,12 @@ final public class WorkloadIdentityStubs {
 	}
 
 	private StubMapping createStubMappingFor(String path, String response) {
-		final var url = UriComponentsBuilder.fromPath("/")
-				.path(issuer.getPath())
-				.pathSegment(path)
-				.toUriString();
-
-		return WireMock.get(WireMock.urlPathEqualTo(url))
-				.willReturn(WireMock.aResponse().withStatus(200).withBody(response))
+		return WireMock.get(WireMock.urlPathEqualTo("/" + issuer.getPath() + "/" + path))
+				.willReturn(WireMock.aResponse()
+						.withStatus(200)
+						.withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+						.withBody(response)
+				)
 				.build();
 	}
 

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/CompositeTrustedIssuerRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/CompositeTrustedIssuerRepositoryTest.java
@@ -8,7 +8,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
@@ -21,7 +20,10 @@ class CompositeTrustedIssuerRepositoryTest {
 	static final EntityId NAMESPACE = EntityId.from(5L);
 	static final String ISSUER_URI = "https://token.test.example.com";
 
-	static final TrustedIssuer TRUSTED_ISSUER = new TrustedIssuer(ISSUER_URI, "Test", null, Set.of());
+	static final TrustedIssuerRegistration TRUSTED_ISSUER = TrustedIssuerRegistration.withId("test-issuer")
+			.name("Test issuer")
+			.issuerUri(ISSUER_URI)
+			.build();
 
 	@Mock
 	TrustedIssuerRepository first;

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/NimbusTrustedIssuerRegistryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/NimbusTrustedIssuerRegistryTest.java
@@ -54,7 +54,7 @@ class NimbusTrustedIssuerRegistryTest {
 		wiremock.addStubMapping(stubs.createMetadataStub());
 		wiremock.addStubMapping(stubs.createKeysetStub());
 
-		registry = new NimbusTrustedIssuerRegistry(repository, new RestTemplate(),"expireAfterWrite=1h");
+		registry = new NimbusTrustedIssuerRegistry(repository, new RestTemplate(), "expireAfterWrite=1h");
 	}
 
 	@Test

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/NimbusTrustedIssuerRegistryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/NimbusTrustedIssuerRegistryTest.java
@@ -1,0 +1,238 @@
+package com.konfigyr.identity.authorization.issuer;
+
+import com.github.benmanes.caffeine.cache.stats.CacheStats;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.identity.WorkloadIdentityStubs;
+import com.nimbusds.jwt.JWTClaimsSet;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.Closeable;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.doReturn;
+
+@ExtendWith(MockitoExtension.class)
+class NimbusTrustedIssuerRegistryTest {
+
+	@RegisterExtension
+	static WireMockExtension wiremock = WireMockExtension.newInstance()
+			.options(WireMockConfiguration.wireMockConfig().dynamicPort())
+			.configureStaticDsl(true)
+			.build();
+
+	static final EntityId NAMESPACE = EntityId.from(1L);
+
+	@Mock
+	TrustedIssuerRepository repository;
+
+	WorkloadIdentityStubs stubs;
+	NimbusTrustedIssuerRegistry registry;
+
+	@BeforeEach
+	void setup() {
+		stubs = new WorkloadIdentityStubs(wiremock.baseUrl(), "test-oidc-issuer");
+		wiremock.addStubMapping(stubs.createMetadataStub());
+		wiremock.addStubMapping(stubs.createKeysetStub());
+
+		registry = new NimbusTrustedIssuerRegistry(repository, new RestTemplate(),"expireAfterWrite=1h");
+	}
+
+	@Test
+	@DisplayName("should return TrustedIssuer containing the resolved registration")
+	void returnsIssuerWithMatchingRegistration() {
+		final var registration = registration(stubs.keysetUri());
+		doReturn(registration).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		final var issuer = registry.get(NAMESPACE, stubs.issuerUri());
+
+		assertThat(issuer)
+				.isNotNull()
+				.returns(registration, TrustedIssuer::registration);
+	}
+
+	@Test
+	@DisplayName("should verify a valid JWT when an explicit JWKS URI is configured")
+	void verifiesValidTokenWithExplicitJwksUri() {
+		doReturn(registration(stubs.keysetUri())).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		final var claims = registry.get(NAMESPACE, stubs.issuerUri())
+				.verify(signToken("repo:acme/api:ref:refs/heads/main", Instant.now().plusSeconds(300)));
+
+		assertThat(claims.getSubject()).isEqualTo("repo:acme/api:ref:refs/heads/main");
+	}
+
+	@Test
+	@DisplayName("should resolve the JWKS URI via OIDC discovery when not explicitly configured")
+	void resolvesJwksUriViaOidcDiscovery() {
+		doReturn(registration(null)).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		final var claims = registry.get(NAMESPACE, stubs.issuerUri())
+				.verify(signToken("repo:acme/api:ref:refs/heads/main", Instant.now().plusSeconds(300)));
+
+		assertThat(claims.getSubject()).isEqualTo("repo:acme/api:ref:refs/heads/main");
+	}
+
+	@Test
+	@DisplayName("should reuse the cached JWK source across multiple calls for the same issuer")
+	void cachesJwkSourceAcrossCalls() {
+		doReturn(registration(stubs.keysetUri())).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		assertThatNoException().isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri()));
+		assertThatNoException().isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri()));
+
+		assertThat(registry.sourceCache().stats())
+				.returns(1L, CacheStats::loadCount)
+				.returns(1L, CacheStats::hitCount);
+	}
+
+	@Test
+	@DisplayName("should throw invalid_client when no trusted issuer is registered for the namespace and issuer URI")
+	void throwsWhenIssuerNotFound() {
+		doReturn(null).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		assertThatExceptionOfType(OAuth2AuthenticationException.class)
+				.isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri()))
+				.extracting(OAuth2AuthenticationException::getError, InstanceOfAssertFactories.type(OAuth2Error.class))
+				.returns(OAuth2ErrorCodes.INVALID_CLIENT, OAuth2Error::getErrorCode)
+				.returns(
+						"Can't find any trusted issuer for this OAuth2 Client that matches this issuer URI: %s".formatted(stubs.issuerUri()),
+						OAuth2Error::getDescription
+				);
+	}
+
+	@Test
+	@DisplayName("should throw invalid_client when the OIDC discovery endpoint is unavailable")
+	void throwsWhenDiscoveryEndpointUnavailable() {
+		wiremock.stubFor(get(urlPathEqualTo(URI.create(stubs.metadataUri()).getPath()))
+				.willReturn(serverError()));
+
+		doReturn(registration(null)).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		assertThatExceptionOfType(OAuth2AuthenticationException.class)
+				.isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri()))
+				.extracting(OAuth2AuthenticationException::getError, InstanceOfAssertFactories.type(OAuth2Error.class))
+				.returns(OAuth2ErrorCodes.INVALID_CLIENT, OAuth2Error::getErrorCode);
+	}
+
+	@Test
+	@DisplayName("should throw when the JWKS endpoint returns an error response during token verification")
+	void throwsWhenJwksEndpointFails() {
+		wiremock.stubFor(get(urlPathEqualTo(URI.create(stubs.keysetUri()).getPath()))
+				.willReturn(serverError()));
+
+		doReturn(registration(stubs.keysetUri())).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		assertThatExceptionOfType(JwtException.class)
+				.isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri())
+						.verify(signToken("repo:acme/api:ref:refs/heads/main", Instant.now().plusSeconds(300))));
+	}
+
+	@Test
+	@DisplayName("should reject a JWT whose audience does not match any configured allowed audience")
+	void rejectsTokenWithMismatchedAudience() {
+		doReturn(registration(stubs.keysetUri(), "konfigyr-api")).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		assertThatExceptionOfType(JwtException.class)
+				.isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri())
+						.verify(signToken("repo:acme/api:ref:refs/heads/main", Instant.now().plusSeconds(300), "wrong-audience")));
+	}
+
+	@Test
+	@DisplayName("should accept a JWT whose audience matches at least one of the configured allowed audiences")
+	void acceptsTokenWithMatchingAudience() {
+		doReturn(registration(stubs.keysetUri(), "konfigyr-api", "konfigyr-frontend"))
+				.when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		assertThatNoException()
+				.isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri())
+						.verify(signToken("repo:acme/api:ref:refs/heads/main", Instant.now().plusSeconds(300), "konfigyr-api")));
+	}
+
+	@Test
+	@DisplayName("should reject a JWT whose issuer claim does not match the registered issuer URI")
+	void rejectsTokenWithWrongIssuer() {
+		doReturn(registration(stubs.keysetUri())).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		final var tokenFromOtherIssuer = new WorkloadIdentityStubs(wiremock.baseUrl(), "other-issuer")
+				.issue(new JWTClaimsSet.Builder()
+						.subject("repo:acme/api:ref:refs/heads/main")
+						.expirationTime(Date.from(Instant.now().plusSeconds(300))));
+
+		assertThatExceptionOfType(JwtException.class)
+				.isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri()).verify(tokenFromOtherIssuer));
+	}
+
+	@Test
+	@DisplayName("should close the evicted JWK source and rebuild it on the next request")
+	void closesJwkSourceOnEvictionAndRebuildsOnNextRequest() {
+		final var registration = registration(stubs.keysetUri());
+		doReturn(registration).when(repository).lookup(NAMESPACE, stubs.issuerUri());
+
+		assertThatNoException().isThrownBy(() -> registry.get(NAMESPACE, stubs.issuerUri()));
+
+		final var source = registry.sourceCache().getIfPresent(registration.id());
+		assertThat(source).isNotNull().isInstanceOf(Closeable.class);
+
+		// invalidate() schedules the removal; cleanUp() flushes it and fires JWKSourceCloser
+		registry.sourceCache().invalidate(registration.id());
+		registry.sourceCache().cleanUp();
+
+		assertThat(registry.sourceCache().getIfPresent(registration.id())).isNull();
+
+		registry.get(NAMESPACE, stubs.issuerUri());
+		assertThat(registry.sourceCache().stats())
+				.returns(2L, CacheStats::loadCount);
+	}
+
+	@Test
+	@DisplayName("should bind JWK source cache metrics to the provided meter registry")
+	void bindsCacheMetrics() {
+		final var meterRegistry = new SimpleMeterRegistry();
+
+		registry.bindTo(meterRegistry);
+
+		assertThat(meterRegistry.find("cache.gets").meters()).isNotEmpty();
+	}
+
+	private TrustedIssuerRegistration registration(String jwksUri, String... audiences) {
+		return TrustedIssuerRegistration.withId("test-issuer")
+				.issuerUri(stubs.issuerUri())
+				.name("Test Issuer")
+				.jwksUri(jwksUri)
+				.allowedAudiences(audiences)
+				.build();
+	}
+
+	private String signToken(String subject, Instant expiry, String... audiences) {
+		final var claims = new JWTClaimsSet.Builder()
+				.subject(subject)
+				.expirationTime(Date.from(expiry));
+
+		if (audiences.length > 0) {
+			claims.audience(List.of(audiences));
+		}
+
+		return stubs.issue(claims);
+	}
+
+}

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/WellKnownTrustedIssuersTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/WellKnownTrustedIssuersTest.java
@@ -34,9 +34,9 @@ class WellKnownTrustedIssuersTest {
 
 		assertThat(issuer)
 				.isNotNull()
-				.returns("https://token.actions.githubusercontent.com", TrustedIssuer::issuerUri)
-				.returns("GitHub Actions", TrustedIssuer::name)
-				.returns(null, TrustedIssuer::jwksUri)
+				.returns("https://token.actions.githubusercontent.com", TrustedIssuerRegistration::issuerUri)
+				.returns("GitHub Actions", TrustedIssuerRegistration::name)
+				.returns(null, TrustedIssuerRegistration::jwksUri)
 				.satisfies(it -> assertThat(it.allowedAudiences()).isEmpty());
 	}
 
@@ -47,9 +47,9 @@ class WellKnownTrustedIssuersTest {
 
 		assertThat(issuer)
 				.isNotNull()
-				.returns("https://gitlab.com", TrustedIssuer::issuerUri)
-				.returns("GitLab", TrustedIssuer::name)
-				.returns(null, TrustedIssuer::jwksUri)
+				.returns("https://gitlab.com", TrustedIssuerRegistration::issuerUri)
+				.returns("GitLab", TrustedIssuerRegistration::name)
+				.returns(null, TrustedIssuerRegistration::jwksUri)
 				.satisfies(it -> assertThat(it.allowedAudiences()).isEmpty());
 	}
 

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/workload/WorkloadTokenExchangeAuthenticationProviderTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/workload/WorkloadTokenExchangeAuthenticationProviderTest.java
@@ -1,14 +1,11 @@
 package com.konfigyr.identity.authorization.workload;
 
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
-import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.konfigyr.entity.EntityId;
-import com.konfigyr.identity.WorkloadIdentityStubs;
 import com.konfigyr.identity.authorization.NamespaceClientSettingNames;
 import com.konfigyr.identity.authorization.issuer.TrustedIssuer;
-import com.konfigyr.identity.authorization.issuer.TrustedIssuerRepository;
+import com.konfigyr.identity.authorization.issuer.TrustedIssuerRegistration;
+import com.konfigyr.identity.authorization.issuer.TrustedIssuerRegistry;
 import com.konfigyr.test.OAuth2AccessTokens;
-import com.nimbusds.jwt.JWTClaimsSet;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.AfterEach;
@@ -16,12 +13,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.core.*;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.jwt.*;
 import org.springframework.security.oauth2.server.authorization.OAuth2Authorization;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.security.oauth2.server.authorization.authentication.OAuth2AccessTokenAuthenticationToken;
@@ -35,8 +32,6 @@ import org.springframework.security.oauth2.server.authorization.settings.ClientS
 import org.springframework.security.oauth2.server.authorization.token.OAuth2TokenGenerator;
 
 import java.time.Duration;
-import java.time.Instant;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -49,20 +44,21 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 class WorkloadTokenExchangeAuthenticationProviderTest {
 
-	@RegisterExtension
-	static WireMockExtension wiremock = WireMockExtension.newInstance()
-			.options(WireMockConfiguration.wireMockConfig().dynamicPort())
-			.configureStaticDsl(true)
-			.build();
-
 	static final String SUBJECT = "repo:acme/api:ref:refs/heads/main";
+	static final String ISSUER_URI = "https://token.actions.githubusercontent.com";
 	static final EntityId NAMESPACE = EntityId.from(7L);
 
 	static final String JWT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt";
 	static final String ACCESS_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:access_token";
 
 	@Mock
-	TrustedIssuerRepository trustedIssuerRepository;
+	TrustedIssuerRegistry registry;
+
+	@Mock
+	JwtDecoder jwtDecoder;
+
+	@Mock(strictness = Mock.Strictness.LENIENT)
+	Jwt jwt;
 
 	@Mock
 	OAuth2AuthorizationService authorizationService;
@@ -73,26 +69,23 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	@Mock(strictness = Mock.Strictness.LENIENT)
 	AuthorizationServerContext authorizationServerContext;
 
-	WorkloadIdentityStubs identityStubs;
 	WorkloadTokenExchangeAuthenticationProvider provider;
 
 	@BeforeEach
 	void setup() {
 		provider = new WorkloadTokenExchangeAuthenticationProvider(
-				trustedIssuerRepository, authorizationService, tokenGenerator);
+				registry, authorizationService, tokenGenerator);
+
+		doReturn(SUBJECT).when(jwt).getSubject();
 
 		final var settings = AuthorizationServerSettings.builder()
-				.issuer(wiremock.baseUrl())
+				.issuer("https://auth.konfigyr.com")
 				.build();
 
-		doReturn(wiremock.baseUrl()).when(authorizationServerContext).getIssuer();
+		doReturn("https://auth.konfigyr.com").when(authorizationServerContext).getIssuer();
 		doReturn(settings).when(authorizationServerContext).getAuthorizationServerSettings();
 
 		AuthorizationServerContextHolder.setContext(authorizationServerContext);
-
-		identityStubs = new WorkloadIdentityStubs(wiremock.baseUrl(), "test-workload-identity-server");
-		wiremock.addStubMapping(identityStubs.createMetadataStub());
-		wiremock.addStubMapping(identityStubs.createKeysetStub());
 	}
 
 	@AfterEach
@@ -110,14 +103,14 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	@Test
 	@DisplayName("should throw invalid_request for unsupported subject_token_type")
 	void throwsForUnsupportedSubjectTokenType() {
-		final var client = workloadClient(identityStubs.issuerUri(), null);
+		final var client = workloadClient(null);
 		final var exchange = tokenExchange(client, "any-token", ACCESS_TOKEN_TYPE);
 
 		assertOAuthError(exchange, OAuth2ErrorCodes.INVALID_REQUEST)
 				.extracting(OAuth2Error::getDescription, InstanceOfAssertFactories.STRING)
 				.isEqualTo("Unsupported subject_token_type: %s", ACCESS_TOKEN_TYPE);
 
-		verify(trustedIssuerRepository, never()).lookup(any(), any());
+		verify(registry, never()).get(any(), any());
 	}
 
 	@Test
@@ -125,7 +118,7 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	void throwsWhenNamespaceMissing() {
 		final var client = createClient(
 				ClientSettings.builder()
-						.setting(NamespaceClientSettingNames.WORKLOAD_ISSUER_URI, identityStubs.issuerUri())
+						.setting(NamespaceClientSettingNames.WORKLOAD_ISSUER_URI, ISSUER_URI)
 						.build()
 		);
 
@@ -149,29 +142,33 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 		assertOAuthError(exchange, OAuth2ErrorCodes.INVALID_CLIENT)
 				.returns("Trusted issuer is not specified for this OAuth2 Client", OAuth2Error::getDescription);
 
-		verify(trustedIssuerRepository, never()).lookup(any(), any());
+		verify(registry, never()).get(any(), any());
 	}
 
 	@Test
-	@DisplayName("should throw invalid_client when issuer is not in the trusted repository")
+	@DisplayName("should throw invalid_client when issuer is not in the trusted registry")
 	void throwsWhenIssuerNotTrusted() {
-		doReturn(null).when(trustedIssuerRepository).lookup(NAMESPACE, identityStubs.issuerUri());
+		doThrow(new OAuth2AuthenticationException(new OAuth2Error(
+				OAuth2ErrorCodes.INVALID_CLIENT,
+				"Can't find any trusted issuer for this OAuth2 Client that matches this issuer URI: " + ISSUER_URI,
+				null
+		))).when(registry).get(NAMESPACE, ISSUER_URI);
 
-		final var exchange = tokenExchange(workloadClient(identityStubs.issuerUri(), null), "any-token", JWT_TOKEN_TYPE);
+		final var exchange = tokenExchange(workloadClient(null), "any-token", JWT_TOKEN_TYPE);
 
 		assertOAuthError(exchange, OAuth2ErrorCodes.INVALID_CLIENT)
 				.extracting(OAuth2Error::getDescription, InstanceOfAssertFactories.STRING)
-				.isEqualTo("Can't find any trusted issuer for this OAuth2 Client that matches this issuer URI: %s", identityStubs.issuerUri());
+				.isEqualTo("Can't find any trusted issuer for this OAuth2 Client that matches this issuer URI: %s", ISSUER_URI);
 	}
 
 	@Test
 	@DisplayName("should throw invalid_request for a malformed subject_token that cannot be parsed as JWT")
 	void throwsForMalformedSubjectToken() {
-		doReturn(trustedIssuer(null)).when(trustedIssuerRepository).lookup(NAMESPACE, identityStubs.issuerUri());
+		doReturn(trustedIssuer()).when(registry).get(NAMESPACE, ISSUER_URI);
+		doThrow(new JwtException("Malformed token")).when(jwtDecoder).decode("not-a-jwt");
 
-		final var exchange = tokenExchange(workloadClient(identityStubs.issuerUri(), null), "not-a-jwt", JWT_TOKEN_TYPE);
+		final var exchange = tokenExchange(workloadClient(null), "not-a-jwt", JWT_TOKEN_TYPE);
 
-		// Decode fails at JWT parsing before any JWKS fetch
 		assertOAuthError(exchange, OAuth2ErrorCodes.INVALID_REQUEST)
 				.extracting(OAuth2Error::getDescription, InstanceOfAssertFactories.STRING)
 				.contains("Invalid subject_token", "Malformed token");
@@ -182,14 +179,17 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	@Test
 	@DisplayName("should throw invalid_request when subject_token audience does not match trusted issuer")
 	void throwsForAudienceMismatch() {
-		// Trusted issuer requires "konfigyr-api" audience but token has a different one
-		doReturn(trustedIssuer(Set.of("konfigyr-api"))).when(trustedIssuerRepository).lookup(NAMESPACE, identityStubs.issuerUri());
+		doReturn(trustedIssuer()).when(registry).get(NAMESPACE, ISSUER_URI);
 
-		final var token = signToken(SUBJECT, Instant.now().plusSeconds(300), "wrong-audience");
-		final var exchange = tokenExchange(workloadClient(identityStubs.issuerUri(), null), token, JWT_TOKEN_TYPE);
+		final var audError = new OAuth2Error("invalid_token", "The aud claim is not valid", null);
+		doThrow(new JwtValidationException("Validation failed", List.of(audError)))
+				.when(jwtDecoder).decode(any());
+
+		final var exchange = tokenExchange(workloadClient(null), "any-token", JWT_TOKEN_TYPE);
 
 		assertOAuthError(exchange, OAuth2ErrorCodes.INVALID_REQUEST)
-				.returns("Subject token audience does not match any of the required audiences", OAuth2Error::getDescription);
+				.extracting(OAuth2Error::getDescription, InstanceOfAssertFactories.STRING)
+				.contains("Invalid subject_token: The aud claim is not valid");
 
 		verify(authorizationService, never()).save(any());
 	}
@@ -197,11 +197,11 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	@Test
 	@DisplayName("should throw invalid_request when subject_token sub claim does not match the configured pattern")
 	void throwsForSubjectPatternMismatch() {
-		doReturn(trustedIssuer(null)).when(trustedIssuerRepository).lookup(NAMESPACE, identityStubs.issuerUri());
+		doReturn(trustedIssuer()).when(registry).get(NAMESPACE, ISSUER_URI);
+		doReturn(jwt).when(jwtDecoder).decode(any());
+		doReturn("repo:other/repo:ref:refs/heads/main").when(jwt).getSubject();
 
-		// Client requires sub to match "repo:acme/*" but the token has a different subject
-		final var token = signToken("repo:other/repo:ref:refs/heads/main", Instant.now().plusSeconds(300));
-		final var exchange = tokenExchange(workloadClient(identityStubs.issuerUri(), "repo:acme/.*"), token, JWT_TOKEN_TYPE);
+		final var exchange = tokenExchange(workloadClient("repo:acme/.*"), "any-token", JWT_TOKEN_TYPE);
 
 		assertOAuthError(exchange, OAuth2ErrorCodes.INVALID_REQUEST)
 				.returns("Subject token sub claim does not match the required pattern", OAuth2Error::getDescription);
@@ -212,11 +212,11 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	@Test
 	@DisplayName("should throw server_error when the token generator returns null")
 	void throwsWhenTokenGeneratorReturnsNull() {
-		doReturn(trustedIssuer(null)).when(trustedIssuerRepository).lookup(NAMESPACE, identityStubs.issuerUri());
+		doReturn(trustedIssuer()).when(registry).get(NAMESPACE, ISSUER_URI);
+		doReturn(jwt).when(jwtDecoder).decode(any());
 		doReturn(null).when(tokenGenerator).generate(any());
 
-		final var token = signToken(SUBJECT, Instant.now().plusSeconds(300));
-		final var exchange = tokenExchange(workloadClient(identityStubs.issuerUri(), null), token, JWT_TOKEN_TYPE);
+		final var exchange = tokenExchange(workloadClient(null), "any-token", JWT_TOKEN_TYPE);
 
 		assertOAuthError(exchange, OAuth2ErrorCodes.SERVER_ERROR)
 				.returns("Unexpected error occurred while generating the access token", OAuth2Error::getDescription);
@@ -227,12 +227,11 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	@Test
 	@DisplayName("should issue access token with requested scopes on successful exchange")
 	void issuesAccessTokenWithRequestedScopes() {
-		doReturn(trustedIssuer(null)).when(trustedIssuerRepository).lookup(NAMESPACE, identityStubs.issuerUri());
+		doReturn(trustedIssuer()).when(registry).get(NAMESPACE, ISSUER_URI);
+		doReturn(jwt).when(jwtDecoder).decode(any());
 		doReturn(mockAccessToken("namespaces")).when(tokenGenerator).generate(any());
 
-		final var token = signToken(SUBJECT, Instant.now().plusSeconds(300));
-		final var exchange = tokenExchange(workloadClient(identityStubs.issuerUri(), null), token, JWT_TOKEN_TYPE, "namespaces");
-
+		final var exchange = tokenExchange(workloadClient(null), "any-token", JWT_TOKEN_TYPE, "namespaces");
 		final var result = provider.authenticate(exchange);
 
 		assertThat(result)
@@ -258,25 +257,23 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	@Test
 	@DisplayName("should fall back to all client scopes when none are requested in the exchange")
 	void usesClientScopesWhenNoneRequested() {
-		doReturn(trustedIssuer(null)).when(trustedIssuerRepository).lookup(NAMESPACE, identityStubs.issuerUri());
+		doReturn(trustedIssuer()).when(registry).get(NAMESPACE, ISSUER_URI);
+		doReturn(jwt).when(jwtDecoder).decode(any());
 		doReturn(mockAccessToken("namespaces", "namespaces:read")).when(tokenGenerator).generate(any());
 
-		final var token = signToken(SUBJECT, Instant.now().plusSeconds(300));
-
-		// Client has two scopes; exchange requests none — should use both
 		final var client = RegisteredClient.withId("multi-scope")
 				.clientId("kfg-multi-scope")
 				.clientAuthenticationMethod(ClientAuthenticationMethod.NONE)
 				.authorizationGrantType(AuthorizationGrantType.TOKEN_EXCHANGE)
 				.clientSettings(ClientSettings.builder()
 						.setting(NamespaceClientSettingNames.NAMESPACE, NAMESPACE)
-						.setting(NamespaceClientSettingNames.WORKLOAD_ISSUER_URI, identityStubs.issuerUri())
+						.setting(NamespaceClientSettingNames.WORKLOAD_ISSUER_URI, ISSUER_URI)
 						.build())
 				.scope("namespaces")
 				.scope("namespaces:read")
 				.build();
 
-		final var exchange = tokenExchange(client, token, JWT_TOKEN_TYPE);
+		final var exchange = tokenExchange(client, "any-token", JWT_TOKEN_TYPE);
 		final var result = (OAuth2AccessTokenAuthenticationToken) provider.authenticate(exchange);
 
 		assertThat(result.getAccessToken().getScopes())
@@ -286,10 +283,10 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 	@Test
 	@DisplayName("should throw invalid_scope when requested scope is not registered on the client")
 	void throwsForUnregisteredScope() {
-		doReturn(trustedIssuer(null)).when(trustedIssuerRepository).lookup(NAMESPACE, identityStubs.issuerUri());
+		doReturn(trustedIssuer()).when(registry).get(NAMESPACE, ISSUER_URI);
+		doReturn(jwt).when(jwtDecoder).decode(any());
 
-		final var token = signToken(SUBJECT, Instant.now().plusSeconds(300));
-		final var exchange = tokenExchange(workloadClient(identityStubs.issuerUri(), null), token, JWT_TOKEN_TYPE, "vaults:write");
+		final var exchange = tokenExchange(workloadClient(null), "any-token", JWT_TOKEN_TYPE, "vaults:write");
 
 		assertOAuthError(exchange, OAuth2ErrorCodes.INVALID_SCOPE)
 				.returns(null, OAuth2Error::getDescription);
@@ -304,26 +301,18 @@ class WorkloadTokenExchangeAuthenticationProviderTest {
 				.returns(expectedErrorCode, OAuth2Error::getErrorCode);
 	}
 
-	private TrustedIssuer trustedIssuer(Set<String> allowedAudiences) {
-		return new TrustedIssuer(identityStubs.issuerUri(), "Test Issuer", identityStubs.keysetUri(), allowedAudiences != null ? allowedAudiences : Set.of());
+	private TrustedIssuer trustedIssuer() {
+		final var registration = TrustedIssuerRegistration.withId("test-issuer")
+				.issuerUri(ISSUER_URI)
+				.name("Test Issuer")
+				.build();
+		return new TrustedIssuer(registration, jwtDecoder);
 	}
 
-	private String signToken(String subject, Instant expiry, String... audiences) {
-		final var claims = new JWTClaimsSet.Builder()
-				.subject(subject)
-				.expirationTime(Date.from(expiry));
-
-		if (audiences.length > 0) {
-			claims.audience(List.of(audiences));
-		}
-
-		return identityStubs.issue(claims);
-	}
-
-	private static RegisteredClient workloadClient(String issuerUri, String subjectPattern) {
+	private static RegisteredClient workloadClient(String subjectPattern) {
 		final var settings = ClientSettings.builder()
 				.setting(NamespaceClientSettingNames.NAMESPACE, NAMESPACE)
-				.setting(NamespaceClientSettingNames.WORKLOAD_ISSUER_URI, issuerUri);
+				.setting(NamespaceClientSettingNames.WORKLOAD_ISSUER_URI, ISSUER_URI);
 
 		if (subjectPattern != null) {
 			settings.setting(NamespaceClientSettingNames.WORKLOAD_SUBJECT_PATTERN, subjectPattern);


### PR DESCRIPTION
## Summary

   - Introduces `TrustedIssuerRegistry` / `NimbusTrustedIssuerRegistry`: resolves and caches one Nimbus `JWKSource` per issuer via Caffeine, eliminating per-request decoder construction and JWKS fetches in the workload identity token exchange flow.
   - Renames `TrustedIssuer` → `TrustedIssuerRegistration` (data record + builder) and introduces a new `TrustedIssuer` runtime wrapper that combines the registration with a pre-configured `JwtDecoder` (issuer, timestamp, and audience validators).
   - Adds `TrustedIssuerConfiguration` (package-private) to wire the registry and composite repository; `NimbusTrustedIssuerRegistry`, `CompositeTrustedIssuerRepository`, and `WellKnownTrustedIssuers` are now package-private, reducing the public API surface.
   - `WorkloadTokenExchangeAuthenticationProvider` delegates subject-token verification to `TrustedIssuerRegistry`; the provider test is refactored into a pure unit test using a mock registry.
   - New `NimbusTrustedIssuerRegistryTest` covers caching, OIDC discovery, audience validation, JWKS failure, issuer mismatch, eviction cleanup, and Micrometer metrics binding via WireMock.

   ## Caching behaviour

   Two-level strategy:

   | Layer | Key | TTL | What it caches |
   |---|---|---|---|
   | Outer Caffeine cache | `TrustedIssuerRegistration.id()` | Configurable (default `expireAfterAccess=7d`) | One `JWKSource` per issuer — eviction calls `close()` |
   | Nimbus-internal cache | Inside `JWKSource` | ~5 min | Parsed JWK set; background refresh, rate-limiting, retry |

   ## Configuration

   ```yaml
   konfigyr:
     identity:
       authorization:
         trusted-issuers:
           cache:
             spec: expireAfterAccess=7d,maximumSize=100
   ```
