### PR TITLE
Namespace-scoped Trusted Issuer Registry

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -243,6 +243,44 @@ class AuditEventListener {
 		);
 	}
 
+	// ── Namespace trusted issuer events ─────────────────────────────────────────────────
+
+	@TransactionalEventListener(id = "audit.trusted-issuer-created", classes = NamespaceEvent.TrustedIssuerCreated.class)
+	void on(NamespaceEvent.TrustedIssuerCreated event) {
+		insert(event, builder -> builder
+				.namespace(event.id())
+				.entityType("namespace-trusted-issuer")
+				.entityId(event.issuer().id())
+				.eventType("namespace.trusted-issuer-created")
+				.details("name", event.issuer().name())
+				.details("issuerUri", event.issuer().issuerUri())
+		);
+	}
+
+	@TransactionalEventListener(id = "audit.trusted-issuer-updated", classes = NamespaceEvent.TrustedIssuerUpdated.class)
+	void on(NamespaceEvent.TrustedIssuerUpdated event) {
+		insert(event, builder -> builder
+				.namespace(event.id())
+				.entityType("namespace-trusted-issuer")
+				.entityId(event.issuer().id())
+				.eventType("namespace.trusted-issuer-updated")
+				.details("name", event.issuer().name())
+				.details("issuerUri", event.issuer().issuerUri())
+		);
+	}
+
+	@TransactionalEventListener(id = "audit.trusted-issuer-removed", classes = NamespaceEvent.TrustedIssuerRemoved.class)
+	void on(NamespaceEvent.TrustedIssuerRemoved event) {
+		insert(event, builder -> builder
+				.namespace(event.id())
+				.entityType("namespace-trusted-issuer")
+				.entityId(event.issuer().id())
+				.eventType("namespace.trusted-issuer-removed")
+				.details("name", event.issuer().name())
+				.details("issuerUri", event.issuer().issuerUri())
+		);
+	}
+
 	// ── Service events ──────────────────────────────────────────────────────
 
 	@TransactionalEventListener(id = "audit.service-created", classes = ServiceEvent.Created.class)

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultNamespaceManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultNamespaceManager.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 
 import static com.konfigyr.data.tables.Accounts.ACCOUNTS;
 import static com.konfigyr.data.tables.NamespaceMembers.NAMESPACE_MEMBERS;
+import static com.konfigyr.data.tables.NamespaceTrustedIssuers.NAMESPACE_TRUSTED_ISSUERS;
 import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
 import static com.konfigyr.data.tables.OauthApplications.OAUTH_APPLICATIONS;
 
@@ -61,6 +62,12 @@ class DefaultNamespaceManager implements NamespaceManager {
 			.defaultSortField(OAUTH_APPLICATIONS.UPDATED_AT.desc())
 			.sortField("name", OAUTH_APPLICATIONS.NAME)
 			.sortField("date", OAUTH_APPLICATIONS.UPDATED_AT)
+			.build();
+
+	static final PageableExecutor trustedIssuersExecutor = PageableExecutor.builder()
+			.defaultSortField(NAMESPACE_TRUSTED_ISSUERS.UPDATED_AT.desc())
+			.sortField("name", NAMESPACE_TRUSTED_ISSUERS.NAME)
+			.sortField("date", NAMESPACE_TRUSTED_ISSUERS.UPDATED_AT)
 			.build();
 
 	private final DSLContext context;
@@ -413,6 +420,159 @@ class DefaultNamespaceManager implements NamespaceManager {
 				.execute();
 
 		publisher.publishEvent(new NamespaceEvent.ApplicationRemoved(namespace, application));
+	}
+
+	@NonNull
+	@Override
+	@Transactional(readOnly = true, label = "namespace-find-trusted-issuers")
+	public Page<@NonNull NamespaceTrustedIssuer> findTrustedIssuers(@NonNull Namespace namespace, @NonNull SearchQuery query) {
+		final List<Condition> conditions = new ArrayList<>();
+		conditions.add(NAMESPACE_TRUSTED_ISSUERS.NAMESPACE_ID.eq(namespace.id().get()));
+
+		query.criteria(NamespaceTrustedIssuer.ACTIVE_CRITERIA).ifPresent(active ->
+				conditions.add(NAMESPACE_TRUSTED_ISSUERS.IS_ACTIVE.eq(active))
+		);
+
+		query.term().map(term -> "%" + term + "%").ifPresent(term -> conditions.add(DSL.or(
+				NAMESPACE_TRUSTED_ISSUERS.ISSUER_URI.likeIgnoreCase(term),
+				NAMESPACE_TRUSTED_ISSUERS.NAME.likeIgnoreCase(term),
+				NAMESPACE_TRUSTED_ISSUERS.DESCRIPTION.likeIgnoreCase(term)
+		)));
+
+		return trustedIssuersExecutor.execute(
+				createTrustedIssuersQuery(DSL.and(conditions)),
+				this::toTrustedIssuer,
+				query.pageable(),
+				() -> context.fetchCount(createTrustedIssuersQuery(DSL.and(conditions)))
+		);
+	}
+
+	@NonNull
+	@Override
+	@Transactional(readOnly = true, label = "namespace-get-trusted-issuer")
+	public Optional<NamespaceTrustedIssuer> getTrustedIssuer(@NonNull Namespace namespace, @NonNull EntityId id) {
+		return createTrustedIssuersQuery(DSL.and(
+				NAMESPACE_TRUSTED_ISSUERS.NAMESPACE_ID.eq(namespace.id().get()),
+				NAMESPACE_TRUSTED_ISSUERS.ID.eq(id.get())
+		)).fetchOptional(this::toTrustedIssuer);
+	}
+
+	@NonNull
+	@Override
+	@Transactional(label = "namespace-create-trusted-issuer")
+	public NamespaceTrustedIssuer createTrustedIssuer(
+			@NonNull Namespace namespace,
+			@NonNull NamespaceTrustedIssuerDefinition definition
+	) {
+		if (log.isDebugEnabled()) {
+			log.debug("Attempting to create namespace trusted issuer from: {}", definition);
+		}
+
+		final NamespaceTrustedIssuer issuer;
+
+		try {
+			issuer = context.insertInto(NAMESPACE_TRUSTED_ISSUERS)
+					.set(
+							SettableRecord.of(context, NAMESPACE_TRUSTED_ISSUERS)
+									.set(NAMESPACE_TRUSTED_ISSUERS.ID, EntityId.generate().map(EntityId::get))
+									.set(NAMESPACE_TRUSTED_ISSUERS.NAMESPACE_ID, namespace.id().get())
+									.set(NAMESPACE_TRUSTED_ISSUERS.NAME, definition.name())
+									.set(NAMESPACE_TRUSTED_ISSUERS.DESCRIPTION, definition.description())
+									.set(NAMESPACE_TRUSTED_ISSUERS.ISSUER_URI, definition.issuerUri())
+									.set(NAMESPACE_TRUSTED_ISSUERS.JWKS_URI, definition.jwksUri())
+									.set(NAMESPACE_TRUSTED_ISSUERS.IS_ACTIVE, true)
+									.set(NAMESPACE_TRUSTED_ISSUERS.ALLOWED_AUDIENCES, definition.allowedAudiences(), converters.stringList())
+									.set(NAMESPACE_TRUSTED_ISSUERS.CUSTOM_CLAIMS, definition.customClaims(), converters.stringMap())
+									.set(NAMESPACE_TRUSTED_ISSUERS.CREATED_AT, OffsetDateTime.now())
+									.set(NAMESPACE_TRUSTED_ISSUERS.UPDATED_AT, OffsetDateTime.now())
+									.get()
+					)
+					.returning(NAMESPACE_TRUSTED_ISSUERS.fields())
+					.fetchOne(this::toTrustedIssuer);
+		} catch (DataIntegrityViolationException ex) {
+			throw new NamespaceNotFoundException(namespace.id());
+		}
+
+		if (issuer == null) {
+			throw new IllegalStateException("Failed to create trusted issuer");
+		}
+
+		publisher.publishEvent(new NamespaceEvent.TrustedIssuerCreated(namespace, issuer));
+
+		return issuer;
+	}
+
+	@NonNull
+	@Override
+	@Transactional(label = "namespace-update-trusted-issuer")
+	public NamespaceTrustedIssuer updateTrustedIssuer(
+			@NonNull Namespace namespace,
+			@NonNull EntityId id,
+			@NonNull NamespaceTrustedIssuerDefinition definition
+	) {
+		if (log.isDebugEnabled()) {
+			log.debug("Attempting to update namespace trusted issuer with: [id={}, definition={}]", id, definition);
+		}
+
+		final NamespaceTrustedIssuer issuer = context.update(NAMESPACE_TRUSTED_ISSUERS)
+				.set(NAMESPACE_TRUSTED_ISSUERS.NAME, definition.name())
+				.set(NAMESPACE_TRUSTED_ISSUERS.DESCRIPTION, definition.description())
+				.set(NAMESPACE_TRUSTED_ISSUERS.ISSUER_URI, definition.issuerUri())
+				.set(NAMESPACE_TRUSTED_ISSUERS.JWKS_URI, definition.jwksUri())
+				.set(NAMESPACE_TRUSTED_ISSUERS.ALLOWED_AUDIENCES, converters.stringList().to(definition.allowedAudiences()))
+				.set(NAMESPACE_TRUSTED_ISSUERS.CUSTOM_CLAIMS, converters.stringMap().to(definition.customClaims()))
+				.set(NAMESPACE_TRUSTED_ISSUERS.UPDATED_AT, OffsetDateTime.now())
+				.where(DSL.and(
+						NAMESPACE_TRUSTED_ISSUERS.ID.eq(id.get()),
+						NAMESPACE_TRUSTED_ISSUERS.NAMESPACE_ID.eq(namespace.id().get())
+				))
+				.returning(NAMESPACE_TRUSTED_ISSUERS.fields())
+				.fetchOne(this::toTrustedIssuer);
+
+		if (issuer == null) {
+			throw new NamespaceTrustedIssuerNotFoundException(id);
+		}
+
+		publisher.publishEvent(new NamespaceEvent.TrustedIssuerUpdated(namespace, issuer));
+
+		return issuer;
+	}
+
+	@Override
+	@Transactional(label = "namespace-remove-trusted-issuer")
+	public void removeTrustedIssuer(@NonNull Namespace namespace, @NonNull EntityId id) {
+		final NamespaceTrustedIssuer issuer = getTrustedIssuer(namespace, id)
+				.orElseThrow(() -> new NamespaceTrustedIssuerNotFoundException(id));
+
+		context.deleteFrom(NAMESPACE_TRUSTED_ISSUERS)
+				.where(NAMESPACE_TRUSTED_ISSUERS.ID.eq(issuer.id().get()))
+				.execute();
+
+		publisher.publishEvent(new NamespaceEvent.TrustedIssuerRemoved(namespace, issuer));
+	}
+
+	@NonNull
+	private SelectConditionStep<? extends Record> createTrustedIssuersQuery(@NonNull Condition condition) {
+		return context.select(NAMESPACE_TRUSTED_ISSUERS.fields())
+				.from(NAMESPACE_TRUSTED_ISSUERS)
+				.where(condition);
+	}
+
+	@NonNull
+	private NamespaceTrustedIssuer toTrustedIssuer(@NonNull Record record) {
+		return NamespaceTrustedIssuer.builder()
+				.id(record.get(NAMESPACE_TRUSTED_ISSUERS.ID))
+				.namespace(record.get(NAMESPACE_TRUSTED_ISSUERS.NAMESPACE_ID))
+				.name(record.get(NAMESPACE_TRUSTED_ISSUERS.NAME))
+				.description(record.get(NAMESPACE_TRUSTED_ISSUERS.DESCRIPTION))
+				.issuerUri(record.get(NAMESPACE_TRUSTED_ISSUERS.ISSUER_URI))
+				.jwksUri(record.get(NAMESPACE_TRUSTED_ISSUERS.JWKS_URI))
+				.active(record.get(NAMESPACE_TRUSTED_ISSUERS.IS_ACTIVE))
+				.allowedAudiences(record.get(NAMESPACE_TRUSTED_ISSUERS.ALLOWED_AUDIENCES, converters.stringList()))
+				.customClaims(record.get(NAMESPACE_TRUSTED_ISSUERS.CUSTOM_CLAIMS, converters.stringMap()))
+				.createdAt(record.get(NAMESPACE_TRUSTED_ISSUERS.CREATED_AT))
+				.updatedAt(record.get(NAMESPACE_TRUSTED_ISSUERS.UPDATED_AT))
+				.build();
 	}
 
 	@NonNull

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceConverters.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceConverters.java
@@ -9,12 +9,17 @@ import org.jooq.JSONB;
 import org.jspecify.annotations.NullMarked;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.util.List;
+import java.util.Map;
+
 @NullMarked
 final class NamespaceConverters {
 
 	private final Converter<JSONB, NamespaceApplicationSettings> settingsConverter;
 	private final Converter<String, NamespaceClientType> clientTypeConverter;
 	private final Converter<String, NamespaceClientId> clientIdConverter;
+	private final Converter<JSONB, List<String>> stringListConverter;
+	private final Converter<JSONB, Map<String, String>> stringMapConverter;
 
 	NamespaceConverters(JsonMapper mapper) {
 		this.settingsConverter = JsonbConverter.create(mapper, NamespaceApplicationSettings.class);
@@ -24,6 +29,10 @@ final class NamespaceConverters {
 		this.clientIdConverter = Converter.of(
 				String.class, NamespaceClientId.class, NamespaceClientId::parse, NamespaceClientId::get
 		);
+		this.stringListConverter = JsonbConverter.create(mapper,
+				mapper.getTypeFactory().constructCollectionType(List.class, String.class));
+		this.stringMapConverter = JsonbConverter.create(mapper,
+				mapper.getTypeFactory().constructMapType(Map.class, String.class, String.class));
 	}
 
 	Converter<String, NamespaceClientId> clientId() {
@@ -36,6 +45,14 @@ final class NamespaceConverters {
 
 	Converter<JSONB, NamespaceApplicationSettings> settings() {
 		return settingsConverter;
+	}
+
+	Converter<JSONB, List<String>> stringList() {
+		return stringListConverter;
+	}
+
+	Converter<JSONB, Map<String, String>> stringMap() {
+		return stringMapConverter;
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceEvent.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceEvent.java
@@ -16,8 +16,12 @@ import java.util.function.Supplier;
  * @since 1.0.0
  **/
 public abstract sealed class NamespaceEvent extends EntityEvent implements Supplier<Namespace>
-		permits NamespaceEvent.Created, NamespaceEvent.Renamed, NamespaceEvent.Deleted,
-			NamespaceEvent.ApplicationEvent, NamespaceEvent.MembershipEvent {
+		permits NamespaceEvent.Created,
+		NamespaceEvent.Renamed,
+		NamespaceEvent.Deleted,
+		NamespaceEvent.ApplicationEvent,
+		NamespaceEvent.MembershipEvent,
+		NamespaceEvent.TrustedIssuerEvent {
 
 	/**
 	 * The namespace that is the subject of the event.
@@ -323,6 +327,87 @@ public abstract sealed class NamespaceEvent extends EntityEvent implements Suppl
 		 */
 		public ApplicationRemoved(Namespace namespace, NamespaceApplication application) {
 			super(namespace, application);
+		}
+	}
+
+	/**
+	 * Abstract event for all {@link NamespaceTrustedIssuer} changes within a {@link Namespace}.
+	 */
+	public static abstract sealed class TrustedIssuerEvent extends NamespaceEvent
+			permits TrustedIssuerCreated, TrustedIssuerUpdated, TrustedIssuerRemoved {
+
+		private final NamespaceTrustedIssuer issuer;
+
+		protected TrustedIssuerEvent(Namespace namespace, NamespaceTrustedIssuer issuer) {
+			super(namespace);
+			Assert.notNull(issuer, "NamespaceTrustedIssuer can not be null");
+			this.issuer = issuer;
+		}
+
+		/**
+		 * The {@link NamespaceTrustedIssuer} that was the subject of this event.
+		 *
+		 * @return the trusted issuer, never {@literal null}
+		 */
+		@NonNull
+		public NamespaceTrustedIssuer issuer() {
+			return issuer;
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + "[id=" + id + ", issuer=" + issuer.id() + ", timestamp=" + timestamp + ']';
+		}
+	}
+
+	/**
+	 * Event published when a new {@link NamespaceTrustedIssuer} is registered for a {@link Namespace}.
+	 */
+	@DomainEvent(name = "trusted-issuer-created", namespace = "namespaces")
+	public static final class TrustedIssuerCreated extends TrustedIssuerEvent {
+
+		/**
+		 * Creates a new trusted issuer created event for the namespace and the issuer that was added.
+		 *
+		 * @param namespace the namespace to which the issuer was added
+		 * @param issuer the created trusted issuer
+		 */
+		public TrustedIssuerCreated(Namespace namespace, NamespaceTrustedIssuer issuer) {
+			super(namespace, issuer);
+		}
+	}
+
+	/**
+	 * Event published when a {@link NamespaceTrustedIssuer} is updated within a {@link Namespace}.
+	 */
+	@DomainEvent(name = "trusted-issuer-updated", namespace = "namespaces")
+	public static final class TrustedIssuerUpdated extends TrustedIssuerEvent {
+
+		/**
+		 * Creates a new trusted issuer updated event for the namespace and the issuer that was modified.
+		 *
+		 * @param namespace the namespace that owns the updated issuer
+		 * @param issuer the updated trusted issuer
+		 */
+		public TrustedIssuerUpdated(Namespace namespace, NamespaceTrustedIssuer issuer) {
+			super(namespace, issuer);
+		}
+	}
+
+	/**
+	 * Event published when a {@link NamespaceTrustedIssuer} is removed from a {@link Namespace}.
+	 */
+	@DomainEvent(name = "trusted-issuer-removed", namespace = "namespaces")
+	public static final class TrustedIssuerRemoved extends TrustedIssuerEvent {
+
+		/**
+		 * Creates a new trusted issuer removed event for the namespace and the issuer that was removed.
+		 *
+		 * @param namespace the namespace from which the issuer was removed
+		 * @param issuer the removed trusted issuer
+		 */
+		public TrustedIssuerRemoved(Namespace namespace, NamespaceTrustedIssuer issuer) {
+			super(namespace, issuer);
 		}
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceManager.java
@@ -161,4 +161,56 @@ public interface NamespaceManager {
 	@DomainEventPublisher(publishes = "namespaces.application-removed")
 	void removeApplication(Namespace namespace, EntityId application);
 
+	/**
+	 * Retrieves a page of {@link NamespaceTrustedIssuer trusted issuers} for the given {@link Namespace}
+	 * that match the criteria specified by the {@link SearchQuery}.
+	 *
+	 * @param namespace namespace whose trusted issuers to search, can't be {@literal null}
+	 * @param query search query to be executed, can't be {@literal null}
+	 * @return trusted issuers page, never {@literal null}
+	 */
+	Page<NamespaceTrustedIssuer> findTrustedIssuers(Namespace namespace, SearchQuery query);
+
+	/**
+	 * Retrieves the {@link NamespaceTrustedIssuer} with the given entity identifier scoped to the
+	 * given {@link Namespace}.
+	 *
+	 * @param namespace namespace that owns the trusted issuer, can't be {@literal null}
+	 * @param id entity identifier of the trusted issuer, can't be {@literal null}
+	 * @return the matching trusted issuer or an empty {@link Optional}, never {@literal null}
+	 */
+	Optional<NamespaceTrustedIssuer> getTrustedIssuer(Namespace namespace, EntityId id);
+
+	/**
+	 * Creates a new {@link NamespaceTrustedIssuer} for the given {@link Namespace}.
+	 *
+	 * @param namespace namespace for which the issuer is created, can't be {@literal null}
+	 * @param definition definition used to create the trusted issuer, can't be {@literal null}
+	 * @return created trusted issuer, never {@literal null}
+	 */
+	@DomainEventPublisher(publishes = "namespaces.trusted-issuer-created")
+	NamespaceTrustedIssuer createTrustedIssuer(Namespace namespace, NamespaceTrustedIssuerDefinition definition);
+
+	/**
+	 * Updates the {@link NamespaceTrustedIssuer} with the given entity identifier in the {@link Namespace}.
+	 *
+	 * @param namespace namespace for which the issuer is updated, can't be {@literal null}
+	 * @param id entity identifier of the trusted issuer to be updated, can't be {@literal null}
+	 * @param definition the new definition to be applied, can't be {@literal null}
+	 * @return updated trusted issuer, never {@literal null}
+	 * @throws NamespaceTrustedIssuerNotFoundException when the trusted issuer does not exist
+	 */
+	@DomainEventPublisher(publishes = "namespaces.trusted-issuer-updated")
+	NamespaceTrustedIssuer updateTrustedIssuer(Namespace namespace, EntityId id, NamespaceTrustedIssuerDefinition definition);
+
+	/**
+	 * Removes the {@link NamespaceTrustedIssuer} with the given entity identifier from the {@link Namespace}.
+	 *
+	 * @param namespace namespace for which the issuer is removed, can't be {@literal null}
+	 * @param id entity identifier of the trusted issuer to be removed, can't be {@literal null}
+	 * @throws NamespaceTrustedIssuerNotFoundException when the trusted issuer does not exist
+	 */
+	@DomainEventPublisher(publishes = "namespaces.trusted-issuer-removed")
+	void removeTrustedIssuer(Namespace namespace, EntityId id);
+
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceTrustedIssuer.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceTrustedIssuer.java
@@ -1,0 +1,354 @@
+package com.konfigyr.namespace;
+
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.support.SearchQuery;
+import org.jmolecules.ddd.annotation.Association;
+import org.jmolecules.ddd.annotation.Entity;
+import org.jmolecules.ddd.annotation.Identity;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Represents an OIDC issuer that a namespace trusts for Workload Identity token exchange.
+ *
+ * @param id unique entity identifier
+ * @param namespace identifier of the owning namespace
+ * @param name human-readable display name
+ * @param description optional description
+ * @param issuerUri OIDC issuer URI; must match the {@code iss} claim of subject tokens
+ * @param jwksUri explicit JWKS endpoint; when {@code null}, resolved via OIDC discovery
+ * @param active whether this issuer is currently trusted
+ * @param allowedAudiences set of accepted {@code aud} claim values; an empty list disables audience validation
+ * @param customClaims extra claim name → expected string value assertions applied during JWT validation
+ * @param createdAt creation timestamp
+ * @param updatedAt last-updated timestamp
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@Entity
+public record NamespaceTrustedIssuer(
+		@NonNull @Identity EntityId id,
+		@NonNull @Association(aggregateType = Namespace.class) EntityId namespace,
+		@NonNull String name,
+		@Nullable String description,
+		@NonNull String issuerUri,
+		@Nullable String jwksUri,
+		boolean active,
+		@NonNull List<String> allowedAudiences,
+		@NonNull Map<String, String> customClaims,
+		@Nullable OffsetDateTime createdAt,
+		@Nullable OffsetDateTime updatedAt
+) implements Serializable {
+
+	@Serial
+	private static final long serialVersionUID = 7102651946773004571L;
+
+	/**
+	 * The {@link SearchQuery.Criteria} descriptor used to filter {@link NamespaceTrustedIssuer issuers}
+	 * by their active state.
+	 */
+	public static final SearchQuery.Criteria<Boolean> ACTIVE_CRITERIA = SearchQuery.criteria("trusted-issuer.active", Boolean.class);
+
+	public NamespaceTrustedIssuer {
+		Assert.notNull(id, "NamespaceTrustedIssuer id must not be null");
+		Assert.notNull(namespace, "NamespaceTrustedIssuer namespace id must not be null");
+		Assert.hasText(name, "NamespaceTrustedIssuer name must not be blank");
+		Assert.hasText(issuerUri, "NamespaceTrustedIssuer issuer URI must not be blank");
+		allowedAudiences = List.copyOf(allowedAudiences);
+		customClaims = Map.copyOf(customClaims);
+	}
+
+	/**
+	 * Creates a new {@link Builder fluent builder} instance.
+	 *
+	 * @return namespace trusted issuer builder, never {@literal null}
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Fluent builder type used to create a {@link NamespaceTrustedIssuer}.
+	 */
+	public static final class Builder {
+
+		private EntityId id;
+		private EntityId namespace;
+		private String name;
+		private String description;
+		private String issuerUri;
+		private String jwksUri;
+		private boolean active = true;
+		private final List<String> allowedAudiences = new ArrayList<>();
+		private final Map<String, String> customClaims = new HashMap<>();
+		private OffsetDateTime createdAt;
+		private OffsetDateTime updatedAt;
+
+		private Builder() {
+		}
+
+		/**
+		 * Specify the internal {@link EntityId} for this {@link NamespaceTrustedIssuer}.
+		 *
+		 * @param id internal identifier
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder id(Long id) {
+			return id(EntityId.from(id));
+		}
+
+		/**
+		 * Specify the external {@link EntityId} for this {@link NamespaceTrustedIssuer}.
+		 *
+		 * @param id external identifier
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder id(String id) {
+			return id(EntityId.from(id));
+		}
+
+		/**
+		 * Specify the {@link EntityId} for this {@link NamespaceTrustedIssuer}.
+		 *
+		 * @param id entity identifier
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder id(EntityId id) {
+			this.id = id;
+			return this;
+		}
+
+		/**
+		 * Specify the internal {@link EntityId} of the owning {@link Namespace}.
+		 *
+		 * @param id internal namespace identifier
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder namespace(Long id) {
+			return namespace(EntityId.from(id));
+		}
+
+		/**
+		 * Specify the external {@link EntityId} of the owning {@link Namespace}.
+		 *
+		 * @param id external namespace identifier
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder namespace(String id) {
+			return namespace(EntityId.from(id));
+		}
+
+		/**
+		 * Specify the {@link EntityId} of the owning {@link Namespace}.
+		 *
+		 * @param id namespace identifier
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder namespace(EntityId id) {
+			this.namespace = id;
+			return this;
+		}
+
+		/**
+		 * Specify the human-readable display name.
+		 *
+		 * @param name display name
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		/**
+		 * Specify the optional description.
+		 *
+		 * @param description description
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder description(@Nullable String description) {
+			this.description = description;
+			return this;
+		}
+
+		/**
+		 * Specify the OIDC issuer URI.
+		 *
+		 * @param issuerUri issuer URI
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder issuerUri(String issuerUri) {
+			this.issuerUri = issuerUri;
+			return this;
+		}
+
+		/**
+		 * Specify the explicit JWKS endpoint URI. When {@code null}, it is resolved via OIDC discovery.
+		 *
+		 * @param jwksUri JWKS endpoint URI, or {@code null}
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder jwksUri(@Nullable String jwksUri) {
+			this.jwksUri = jwksUri;
+			return this;
+		}
+
+		/**
+		 * Specify whether this issuer is active.
+		 *
+		 * @param active active state
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder active(boolean active) {
+			this.active = active;
+			return this;
+		}
+
+		/**
+		 * Adds an accepted {@code aud} claim value.
+		 *
+		 * @param audience audience value to accept
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder allowedAudience(@Nullable String audience) {
+			if (audience != null && !audience.isBlank()) {
+				this.allowedAudiences.add(audience);
+			}
+			return this;
+		}
+
+		/**
+		 * Replaces all accepted {@code aud} claim values with the given collection.
+		 * An empty list disables audience validation.
+		 *
+		 * @param allowedAudiences accepted audience values, or {@code null} to clear
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder allowedAudiences(@Nullable Collection<String> allowedAudiences) {
+			this.allowedAudiences.clear();
+			if (allowedAudiences != null) {
+				allowedAudiences.forEach(this::allowedAudience);
+			}
+			return this;
+		}
+
+		/**
+		 * Adds a custom claim assertion. The JWT must contain a claim with the given name whose
+		 * string value equals the given expected value.
+		 *
+		 * @param claim claim name
+		 * @param value expected claim value
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder customClaim(String claim, String value) {
+			this.customClaims.put(claim, value);
+			return this;
+		}
+
+		/**
+		 * Replaces all custom claim assertions with the given map.
+		 *
+		 * @param customClaims claim name → expected value map, or {@code null} to clear
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder customClaims(@Nullable Map<String, String> customClaims) {
+			this.customClaims.clear();
+			if (customClaims != null) {
+				this.customClaims.putAll(customClaims);
+			}
+			return this;
+		}
+
+		/**
+		 * Specify when this {@link NamespaceTrustedIssuer} was created.
+		 *
+		 * @param createdAt creation timestamp
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder createdAt(Instant createdAt) {
+			return createdAt(OffsetDateTime.ofInstant(createdAt, ZoneOffset.UTC));
+		}
+
+		/**
+		 * Specify when this {@link NamespaceTrustedIssuer} was created.
+		 *
+		 * @param createdAt creation timestamp
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder createdAt(OffsetDateTime createdAt) {
+			this.createdAt = createdAt;
+			return this;
+		}
+
+		/**
+		 * Specify when this {@link NamespaceTrustedIssuer} was last updated.
+		 *
+		 * @param updatedAt last-updated timestamp
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder updatedAt(Instant updatedAt) {
+			return updatedAt(OffsetDateTime.ofInstant(updatedAt, ZoneOffset.UTC));
+		}
+
+		/**
+		 * Specify when this {@link NamespaceTrustedIssuer} was last updated.
+		 *
+		 * @param updatedAt last-updated timestamp
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder updatedAt(OffsetDateTime updatedAt) {
+			this.updatedAt = updatedAt;
+			return this;
+		}
+
+		/**
+		 * Creates a new {@link NamespaceTrustedIssuer} from this builder.
+		 *
+		 * @return namespace trusted issuer, never {@literal null}
+		 * @throws IllegalArgumentException when required fields are missing or invalid
+		 */
+		@NonNull
+		public NamespaceTrustedIssuer build() {
+			Assert.notNull(id, "Namespace trusted issuer identifier can not be null");
+			Assert.notNull(namespace, "Namespace identifier can not be null");
+			Assert.hasText(name, "Namespace trusted issuer name can not be blank");
+			Assert.hasText(issuerUri, "Namespace trusted issuer issuer URI can not be blank");
+
+			return new NamespaceTrustedIssuer(id, namespace, name, description, issuerUri,
+					jwksUri, active, allowedAudiences, customClaims, createdAt, updatedAt);
+		}
+
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceTrustedIssuerDefinition.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceTrustedIssuerDefinition.java
@@ -1,0 +1,192 @@
+package com.konfigyr.namespace;
+
+import org.jmolecules.ddd.annotation.ValueObject;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
+
+import java.io.Serial;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Value object used to create or update a {@link NamespaceTrustedIssuer} via {@link NamespaceManager}.
+ *
+ * @param name human-readable display name
+ * @param description optional description
+ * @param issuerUri OIDC issuer URI; must match the {@code iss} claim of subject tokens
+ * @param jwksUri explicit JWKS endpoint; when {@code null}, resolved via OIDC discovery
+ * @param allowedAudiences set of accepted {@code aud} claim values; an empty list disables audience validation
+ * @param customClaims extra claim name → expected string value assertions applied during JWT validation
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@ValueObject
+public record NamespaceTrustedIssuerDefinition(
+		@NonNull String name,
+		@Nullable String description,
+		@NonNull String issuerUri,
+		@Nullable String jwksUri,
+		@NonNull List<String> allowedAudiences,
+		@NonNull Map<String, String> customClaims
+) implements Serializable {
+
+	@Serial
+	private static final long serialVersionUID = 6623051866107394523L;
+
+	public NamespaceTrustedIssuerDefinition {
+		Assert.hasText(name, "NamespaceTrustedIssuerDefinition name must not be blank");
+		Assert.hasText(issuerUri, "NamespaceTrustedIssuerDefinition issuer URI must not be blank");
+		allowedAudiences = List.copyOf(allowedAudiences);
+		customClaims = Map.copyOf(customClaims);
+	}
+
+	/**
+	 * Creates a new {@link Builder} instance.
+	 *
+	 * @return builder, never {@literal null}
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Fluent builder for {@link NamespaceTrustedIssuerDefinition}.
+	 */
+	public static final class Builder {
+
+		private String name;
+		private String description;
+		private String issuerUri;
+		private String jwksUri;
+		private final List<String> allowedAudiences = new ArrayList<>();
+		private final Map<String, String> customClaims = new HashMap<>();
+
+		private Builder() {
+		}
+
+		/**
+		 * Specify the human-readable display name.
+		 *
+		 * @param name display name
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder name(String name) {
+			this.name = name;
+			return this;
+		}
+
+		/**
+		 * Specify the optional description.
+		 *
+		 * @param description description
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder description(@Nullable String description) {
+			this.description = description;
+			return this;
+		}
+
+		/**
+		 * Specify the OIDC issuer URI.
+		 *
+		 * @param issuerUri issuer URI
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder issuerUri(String issuerUri) {
+			this.issuerUri = issuerUri;
+			return this;
+		}
+
+		/**
+		 * Specify the explicit JWKS endpoint URI. When {@code null}, it is resolved via OIDC discovery.
+		 *
+		 * @param jwksUri JWKS endpoint URI, or {@code null}
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder jwksUri(@Nullable String jwksUri) {
+			this.jwksUri = jwksUri;
+			return this;
+		}
+
+		/**
+		 * Adds an accepted {@code aud} claim value.
+		 *
+		 * @param audience audience value to accept
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder allowedAudience(@Nullable String audience) {
+			if (audience != null && !audience.isBlank()) {
+				this.allowedAudiences.add(audience);
+			}
+			return this;
+		}
+
+		/**
+		 * Replaces all accepted {@code aud} claim values with the given collection.
+		 * An empty list disables audience validation.
+		 *
+		 * @param allowedAudiences accepted audience values, or {@code null} to clear
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder allowedAudiences(@Nullable Collection<String> allowedAudiences) {
+			this.allowedAudiences.clear();
+			if (allowedAudiences != null) {
+				allowedAudiences.forEach(this::allowedAudience);
+			}
+			return this;
+		}
+
+		/**
+		 * Adds a custom claim assertion.
+		 *
+		 * @param claim claim name
+		 * @param value expected claim value
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder customClaim(String claim, String value) {
+			this.customClaims.put(claim, value);
+			return this;
+		}
+
+		/**
+		 * Replaces all custom claim assertions with the given map.
+		 *
+		 * @param customClaims claim name → expected value map, or {@code null} to clear
+		 * @return this builder
+		 */
+		@NonNull
+		public Builder customClaims(@Nullable Map<String, String> customClaims) {
+			this.customClaims.clear();
+			if (customClaims != null) {
+				this.customClaims.putAll(customClaims);
+			}
+			return this;
+		}
+
+		/**
+		 * Builds a {@link NamespaceTrustedIssuerDefinition}.
+		 *
+		 * @return definition, never {@literal null}
+		 * @throws IllegalArgumentException when required fields are missing or invalid
+		 */
+		@NonNull
+		public NamespaceTrustedIssuerDefinition build() {
+			return new NamespaceTrustedIssuerDefinition(name, description, issuerUri, jwksUri,
+					allowedAudiences, customClaims);
+		}
+
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceTrustedIssuerNotFoundException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceTrustedIssuerNotFoundException.java
@@ -1,0 +1,29 @@
+package com.konfigyr.namespace;
+
+import com.konfigyr.entity.EntityId;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown when a {@link NamespaceTrustedIssuer} does not exist.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+public class NamespaceTrustedIssuerNotFoundException extends NamespaceException {
+
+	@Serial
+	private static final long serialVersionUID = -1782345890987654321L;
+
+	/**
+	 * Creates a new instance when no {@link NamespaceTrustedIssuer} matches the given {@link EntityId}.
+	 *
+	 * @param id trusted issuer entity identifier, can't be {@code null}
+	 */
+	public NamespaceTrustedIssuerNotFoundException(@NonNull EntityId id) {
+		super(HttpStatus.NOT_FOUND, "Could not find a namespace trusted issuer with the following identifier: " + id.serialize());
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/Service.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/Service.java
@@ -22,7 +22,7 @@ import java.time.ZoneOffset;
  * and access control features associated with that application.
  * <p>
  * Each service is uniquely identified by its {@code id} and scoped within a namespace through
- * {@code namespaceId}. The {@code slug} provides a human-readable, URL-safe identifier suitable for
+ * {@code namespace}. The {@code slug} provides a human-readable, URL-safe identifier suitable for
  * referencing services in APIs or UI routes.
  * <p>
  * In Domain-Driven Design terms, {@code Service} is an aggregate root within the {@code namespace} bounded

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/Assemblers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/Assemblers.java
@@ -23,6 +23,12 @@ interface Assemblers {
 				.add(linkBuilder(namespace, application).method(HttpMethod.DELETE).rel("delete"));
 	}
 
+	static RepresentationModelAssembler<NamespaceTrustedIssuer, EntityModel<NamespaceTrustedIssuer>> trustedIssuer(Namespace namespace) {
+		return issuer -> EntityModel.of(issuer, linkBuilder(namespace, issuer).selfRel())
+				.add(linkBuilder(namespace, issuer).method(HttpMethod.PUT).rel("update"))
+				.add(linkBuilder(namespace, issuer).method(HttpMethod.DELETE).rel("delete"));
+	}
+
 	static RepresentationModelAssembler<Service, EntityModel<Service>> service(Namespace namespace) {
 		return service -> EntityModel.of(service, linkBuilder(namespace, service).selfRel())
 				.add(linkBuilder(namespace, service).path("manifest").rel("manifest"))
@@ -62,6 +68,12 @@ interface Assemblers {
 		return linkBuilder(namespace)
 				.path("applications")
 				.path(application.id().serialize());
+	}
+
+	static LinkBuilder linkBuilder(Namespace namespace, NamespaceTrustedIssuer issuer) {
+		return linkBuilder(namespace)
+				.path("trusted-issuers")
+				.path(issuer.id().serialize());
 	}
 
 	static LinkBuilder linkBuilder(Namespace namespace, ServiceCatalog catalog) {

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/TrustedIssuersController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/TrustedIssuersController.java
@@ -1,0 +1,130 @@
+package com.konfigyr.namespace.controller;
+
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.hateoas.EntityModel;
+import com.konfigyr.hateoas.PagedModel;
+import com.konfigyr.namespace.*;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.security.oauth.RequiresScope;
+import com.konfigyr.support.SearchQuery;
+import jakarta.validation.constraints.*;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+import org.hibernate.validator.constraints.URL;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequiresScope(OAuthScope.READ_NAMESPACES)
+@RequestMapping("/namespaces/{slug}/trusted-issuers")
+class TrustedIssuersController {
+
+	private final NamespaceManager namespaces;
+
+	@GetMapping
+	@PreAuthorize("isAdmin(#slug)")
+	PagedModel<EntityModel<NamespaceTrustedIssuer>> find(
+			@PathVariable @NonNull String slug,
+			@RequestParam(required = false) @Nullable String term,
+			@RequestParam(required = false) @Nullable Boolean active,
+			@NonNull Pageable pageable
+	) {
+		final Namespace namespace = lookupNamespace(slug);
+		final SearchQuery query = SearchQuery.builder()
+				.term(term)
+				.criteria(NamespaceTrustedIssuer.ACTIVE_CRITERIA, active)
+				.pageable(pageable)
+				.build();
+
+		return Assemblers.trustedIssuer(namespace).assemble(
+				namespaces.findTrustedIssuers(namespace, query)
+		);
+	}
+
+	@GetMapping("{id}")
+	@PreAuthorize("isAdmin(#slug)")
+	EntityModel<NamespaceTrustedIssuer> get(@PathVariable @NonNull String slug, @PathVariable @NonNull EntityId id) {
+		final Namespace namespace = lookupNamespace(slug);
+
+		return Assemblers.trustedIssuer(namespace).assemble(
+				namespaces.getTrustedIssuer(namespace, id)
+						.orElseThrow(() -> new NamespaceTrustedIssuerNotFoundException(id))
+		);
+	}
+
+	@PostMapping
+	@PreAuthorize("isAdmin(#slug)")
+	@ResponseStatus(HttpStatus.CREATED)
+	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
+	EntityModel<NamespaceTrustedIssuer> create(
+			@PathVariable @NonNull String slug,
+			@Validated @RequestBody TrustedIssuerAttributes attributes
+	) {
+		final Namespace namespace = lookupNamespace(slug);
+
+		return Assemblers.trustedIssuer(namespace).assemble(
+				namespaces.createTrustedIssuer(namespace, attributes.toDefinition())
+		);
+	}
+
+	@PutMapping("{id}")
+	@PreAuthorize("isAdmin(#slug)")
+	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
+	EntityModel<NamespaceTrustedIssuer> update(
+			@PathVariable @NonNull String slug,
+			@PathVariable @NonNull EntityId id,
+			@Validated @RequestBody TrustedIssuerAttributes attributes
+	) {
+		final Namespace namespace = lookupNamespace(slug);
+
+		return Assemblers.trustedIssuer(namespace).assemble(
+				namespaces.updateTrustedIssuer(namespace, id, attributes.toDefinition())
+		);
+	}
+
+	@DeleteMapping("{id}")
+	@PreAuthorize("isAdmin(#slug)")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
+	void delete(@PathVariable @NonNull String slug, @PathVariable @NonNull EntityId id) {
+		final Namespace namespace = lookupNamespace(slug);
+		namespaces.removeTrustedIssuer(namespace, id);
+	}
+
+	@NonNull
+	private Namespace lookupNamespace(@NonNull String slug) {
+		return namespaces.findBySlug(slug).orElseThrow(() -> new NamespaceNotFoundException(slug));
+	}
+
+	record TrustedIssuerAttributes(
+			@NotBlank @Length(min = 3, max = 30) String name,
+			@Nullable @Length(max = 255) String description,
+			@NotBlank @URL String issuerUri,
+			@Nullable @URL String jwksUri,
+			@Nullable @Size(max = 10) List<@NotBlank String> allowedAudiences,
+			@Nullable @Size(max = 20) Map<@NotBlank String, @NotBlank String> customClaims
+	) {
+
+		NamespaceTrustedIssuerDefinition toDefinition() {
+			return NamespaceTrustedIssuerDefinition.builder()
+					.name(name())
+					.description(description())
+					.issuerUri(issuerUri())
+					.jwksUri(jwksUri())
+					.allowedAudiences(allowedAudiences())
+					.customClaims(customClaims())
+					.build();
+		}
+
+	}
+
+}

--- a/konfigyr-api/src/main/resources/messages/audit.properties
+++ b/konfigyr-api/src/main/resources/messages/audit.properties
@@ -15,6 +15,9 @@ audit.event.namespace.application-created=Application ''{0}'' was created
 audit.event.namespace.application-reset=Credentials were reset for ''{0}'' application
 audit.event.namespace.application-updated=Application ''{0}'' was updated
 audit.event.namespace.application-removed=Application ''{0}'' was removed
+audit.event.namespace.trusted-issuer-created=Trusted issuer ''{1}'' has been registered with issuer URI: {0}
+audit.event.namespace.trusted-issuer-updated=Trusted issuer ''{1}'' has been updated with issuer URI: {0}
+audit.event.namespace.trusted-issuer-removed=Trusted issuer ''{1}'' has been removed (issuer URI: {0})
 
 ## Invitation events ##
 

--- a/konfigyr-api/src/main/resources/messages/problem-detail.properties
+++ b/konfigyr-api/src/main/resources/messages/problem-detail.properties
@@ -141,6 +141,10 @@ problemDetail.title.com.konfigyr.namespace.ServiceExistsException=Service alread
 problemDetail.com.konfigyr.namespace.ServiceExistsException=A service with the same name or identifier already exists. \
   Please choose a different name or slug and try again.
 
+problemDetail.title.com.konfigyr.namespace.NamespaceTrustedIssuerNotFoundException=Trusted issuer not found
+problemDetail.com.konfigyr.namespace.NamespaceTrustedIssuerNotFoundException=We couldn't find a trusted issuer \
+  matching your request. Make sure the application exists and try again.
+
 ## Membership module exceptions ##
 
 problemDetail.title.com.konfigyr.membership.MemberNotFoundException=Member not found

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
@@ -396,6 +396,81 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("should persist audit record for namespace trusted issuer created event")
+	void shouldAuditNamespaceTrustedIssuerCreatedEvent() {
+		setSecurityContext(TestPrincipals.john());
+
+		final var namespace = mock(Namespace.class);
+		doReturn(EntityId.from(900)).when(namespace).id();
+
+		final var issuer = mock(NamespaceTrustedIssuer.class);
+		doReturn(EntityId.from(9010)).when(issuer).id();
+		doReturn("Konfigyr CI").when(issuer).name();
+		doReturn("https://ci.konfigyr.com").when(issuer).issuerUri();
+
+		listener.on(new NamespaceEvent.TrustedIssuerCreated(namespace, issuer));
+
+		assertAuditRecord("namespace-trusted-issuer", EntityId.from(9010))
+				.returns("namespace.trusted-issuer-created", AuditRecord::eventType)
+				.returns(EntityId.from(900), AuditRecord::namespaceId)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("name", "Konfigyr CI")
+						.containsEntry("issuerUri", "https://ci.konfigyr.com")
+				)
+				.satisfies(assertAuditRecordMessage("Trusted issuer '%s' has been registered with issuer URI: %s", issuer.name(), issuer.issuerUri()));
+	}
+
+	@Test
+	@DisplayName("should persist audit record for namespace trusted issuer updated event")
+	void shouldAuditNamespaceTrustedIssuerUpdatedEvent() {
+		setSecurityContext(TestPrincipals.john());
+
+		final var namespace = mock(Namespace.class);
+		doReturn(EntityId.from(900)).when(namespace).id();
+
+		final var issuer = mock(NamespaceTrustedIssuer.class);
+		doReturn(EntityId.from(9011)).when(issuer).id();
+		doReturn("Konfigyr CI updated").when(issuer).name();
+		doReturn("https://ci.konfigyr.com").when(issuer).issuerUri();
+
+		listener.on(new NamespaceEvent.TrustedIssuerUpdated(namespace, issuer));
+
+		assertAuditRecord("namespace-trusted-issuer", EntityId.from(9011))
+				.returns("namespace.trusted-issuer-updated", AuditRecord::eventType)
+				.returns(EntityId.from(900), AuditRecord::namespaceId)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("name", "Konfigyr CI updated")
+						.containsEntry("issuerUri", "https://ci.konfigyr.com")
+				)
+				.satisfies(assertAuditRecordMessage("Trusted issuer '%s' has been updated with issuer URI: %s", issuer.name(), issuer.issuerUri()));
+	}
+
+	@Test
+	@DisplayName("should persist audit record for namespace trusted issuer removed event")
+	void shouldAuditNamespaceTrustedIssuerRemovedEvent() {
+		setSecurityContext(TestPrincipals.john());
+
+		final var namespace = mock(Namespace.class);
+		doReturn(EntityId.from(900)).when(namespace).id();
+
+		final var issuer = mock(NamespaceTrustedIssuer.class);
+		doReturn(EntityId.from(9012)).when(issuer).id();
+		doReturn("Disabled issuer").when(issuer).name();
+		doReturn("https://disabled.konfigyr.com").when(issuer).issuerUri();
+
+		listener.on(new NamespaceEvent.TrustedIssuerRemoved(namespace, issuer));
+
+		assertAuditRecord("namespace-trusted-issuer", EntityId.from(9012))
+				.returns("namespace.trusted-issuer-removed", AuditRecord::eventType)
+				.returns(EntityId.from(900), AuditRecord::namespaceId)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("name", "Disabled issuer")
+						.containsEntry("issuerUri", "https://disabled.konfigyr.com")
+				)
+				.satisfies(assertAuditRecordMessage("Trusted issuer '%s' has been removed (issuer URI: %s)", issuer.name(), issuer.issuerUri()));
+	}
+
+	@Test
 	@DisplayName("should persist audit record for service created event")
 	void shouldAuditServiceCreated() {
 		setSecurityContext(TestPrincipals.john());

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/NamespaceManagerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/NamespaceManagerTest.java
@@ -868,6 +868,237 @@ class NamespaceManagerTest extends AbstractIntegrationTest {
 				.isFalse();
 	}
 
+	@Test
+	@DisplayName("should retrieve all trusted issuers for namespace")
+	void shouldFindTrustedIssuers() {
+		final var namespace = lookupNamespace("konfigyr");
+		final var query = SearchQuery.builder()
+				.pageable(PageRequest.of(0, 10, Sort.by("name").ascending()))
+				.build();
+
+		assertThat(manager.findTrustedIssuers(namespace, query))
+				.isNotNull()
+				.hasSize(3)
+				.extracting(NamespaceTrustedIssuer::id, NamespaceTrustedIssuer::name)
+				.containsExactly(
+						tuple(EntityId.from(3), "Disabled issuer"),
+						tuple(EntityId.from(1), "Konfigyr CI"),
+						tuple(EntityId.from(2), "Konfigyr staging CI")
+				);
+	}
+
+	@Test
+	@DisplayName("should retrieve only active trusted issuers for namespace")
+	void shouldFindActiveTrustedIssuers() {
+		final var namespace = lookupNamespace("konfigyr");
+		final var query = SearchQuery.builder()
+				.criteria(NamespaceTrustedIssuer.ACTIVE_CRITERIA, true)
+				.build();
+
+		assertThat(manager.findTrustedIssuers(namespace, query))
+				.isNotNull()
+				.hasSize(2)
+				.extracting(NamespaceTrustedIssuer::id)
+				.containsExactlyInAnyOrder(EntityId.from(1), EntityId.from(2));
+	}
+
+	@Test
+	@DisplayName("should retrieve trusted issuers for namespace matching the search term")
+	void shouldRetrieveMatchingTrustedIssuers() {
+		final var namespace = lookupNamespace("john-doe");
+		final var query = SearchQuery.builder()
+				.term("john-doe.example")
+				.build();
+
+		assertThat(manager.findTrustedIssuers(namespace, query))
+				.isNotNull()
+				.hasSize(1)
+				.extracting(NamespaceTrustedIssuer::id)
+				.containsExactlyInAnyOrder(EntityId.from(4));
+	}
+
+	@Test
+	@DisplayName("should retrieve trusted issuers belonging to the requested namespace only")
+	void shouldFindTrustedIssuersForNamespaceOnly() {
+		final var namespace = lookupNamespace("john-doe");
+		final var query = SearchQuery.builder().build();
+
+		assertThat(manager.findTrustedIssuers(namespace, query))
+				.isNotNull()
+				.hasSize(1)
+				.extracting(NamespaceTrustedIssuer::id)
+				.containsExactly(EntityId.from(4));
+	}
+
+	@Test
+	@DisplayName("should retrieve trusted issuer by entity identifier")
+	void shouldGetTrustedIssuer() {
+		final var namespace = lookupNamespace("konfigyr");
+
+		assertThat(manager.getTrustedIssuer(namespace, EntityId.from(1)))
+				.isPresent()
+				.get()
+				.returns(EntityId.from(1), NamespaceTrustedIssuer::id)
+				.returns(EntityId.from(2), NamespaceTrustedIssuer::namespace)
+				.returns("Konfigyr CI", NamespaceTrustedIssuer::name)
+				.returns("GitHub Actions for Konfigyr org", NamespaceTrustedIssuer::description)
+				.returns("https://ci.konfigyr.com", NamespaceTrustedIssuer::issuerUri)
+				.returns("https://ci.konfigyr.com/jwks.json", NamespaceTrustedIssuer::jwksUri)
+				.returns(true, NamespaceTrustedIssuer::active)
+				.satisfies(it -> assertThat(it.allowedAudiences()).containsExactly("konfigyr-api"))
+				.satisfies(it -> assertThat(it.customClaims()).containsEntry("environment", "production"));
+	}
+
+	@Test
+	@DisplayName("should return empty when trusted issuer belongs to a different namespace")
+	void shouldNotGetTrustedIssuerFromDifferentNamespace() {
+		final var namespace = lookupNamespace("konfigyr");
+
+		assertThat(manager.getTrustedIssuer(namespace, EntityId.from(4)))
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should return empty when trusted issuer does not exist")
+	void shouldNotGetUnknownTrustedIssuer() {
+		final var namespace = lookupNamespace("konfigyr");
+
+		assertThat(manager.getTrustedIssuer(namespace, EntityId.from(9999)))
+				.isEmpty();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should create trusted issuer for namespace")
+	void shouldCreateTrustedIssuer(AssertablePublishedEvents events) {
+		final var namespace = lookupNamespace("konfigyr");
+		final var definition = NamespaceTrustedIssuerDefinition.builder()
+				.name("New Jenkins CI")
+				.description("Self-hosted Jenkins instance")
+				.issuerUri("https://jenkins.konfigyr.com")
+				.allowedAudience("konfigyr-api")
+				.customClaim("environment", "production")
+				.build();
+
+		final var issuer = manager.createTrustedIssuer(namespace, definition);
+
+		assertThat(issuer.id()).isNotNull();
+		assertThat(issuer)
+				.returns(namespace.id(), NamespaceTrustedIssuer::namespace)
+				.returns("New Jenkins CI", NamespaceTrustedIssuer::name)
+				.returns("Self-hosted Jenkins instance", NamespaceTrustedIssuer::description)
+				.returns("https://jenkins.konfigyr.com", NamespaceTrustedIssuer::issuerUri)
+				.returns(null, NamespaceTrustedIssuer::jwksUri)
+				.returns(true, NamespaceTrustedIssuer::active)
+				.satisfies(it -> assertThat(it.allowedAudiences()).containsExactly("konfigyr-api"))
+				.satisfies(it -> assertThat(it.customClaims()).containsEntry("environment", "production"));
+
+		assertThat(issuer.createdAt()).isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.MINUTES));
+		assertThat(issuer.updatedAt()).isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.MINUTES));
+
+		assertThat(manager.getTrustedIssuer(namespace, issuer.id())).isPresent();
+
+		events.assertThat()
+				.contains(NamespaceEvent.TrustedIssuerCreated.class)
+				.matching(NamespaceEvent::get, namespace)
+				.matching(NamespaceEvent.TrustedIssuerCreated::issuer, issuer);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should update trusted issuer")
+	void shouldUpdateTrustedIssuer(AssertablePublishedEvents events) {
+		final var namespace = lookupNamespace("konfigyr");
+		final var definition = NamespaceTrustedIssuerDefinition.builder()
+				.name("Konfigyr CI updated")
+				.issuerUri("https://ci.konfigyr.com")
+				.jwksUri("https://ci.konfigyr.com/updated-jwks.json")
+				.allowedAudience("konfigyr-api")
+				.allowedAudience("konfigyr-cli")
+				.build();
+
+		final var issuer = manager.updateTrustedIssuer(namespace, EntityId.from(1), definition);
+
+		assertThat(issuer)
+				.returns(EntityId.from(1), NamespaceTrustedIssuer::id)
+				.returns(namespace.id(), NamespaceTrustedIssuer::namespace)
+				.returns("Konfigyr CI updated", NamespaceTrustedIssuer::name)
+				.returns(null, NamespaceTrustedIssuer::description)
+				.returns("https://ci.konfigyr.com", NamespaceTrustedIssuer::issuerUri)
+				.returns("https://ci.konfigyr.com/updated-jwks.json", NamespaceTrustedIssuer::jwksUri)
+				.satisfies(it -> assertThat(it.allowedAudiences())
+						.containsExactlyInAnyOrder("konfigyr-api", "konfigyr-cli"))
+				.satisfies(it -> assertThat(it.customClaims()).isEmpty());
+
+		assertThat(issuer.updatedAt()).isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.MINUTES));
+
+		events.assertThat()
+				.contains(NamespaceEvent.TrustedIssuerUpdated.class)
+				.matching(NamespaceEvent::get, namespace)
+				.matching(NamespaceEvent.TrustedIssuerUpdated::issuer, issuer);
+	}
+
+	@Test
+	@DisplayName("should fail to update trusted issuer from a different namespace")
+	void shouldNotUpdateTrustedIssuerFromDifferentNamespace(AssertablePublishedEvents events) {
+		final var definition = NamespaceTrustedIssuerDefinition.builder()
+				.name("Attempt")
+				.issuerUri("https://ci.konfigyr.com")
+				.build();
+
+		assertThatExceptionOfType(NamespaceTrustedIssuerNotFoundException.class)
+				.isThrownBy(() -> manager.updateTrustedIssuer(lookupNamespace("john-doe"), EntityId.from(1), definition));
+
+		assertThat(events.eventOfTypeWasPublished(NamespaceEvent.TrustedIssuerUpdated.class)).isFalse();
+	}
+
+	@Test
+	@DisplayName("should fail to update unknown trusted issuer")
+	void shouldNotUpdateUnknownTrustedIssuer(AssertablePublishedEvents events) {
+		final var definition = NamespaceTrustedIssuerDefinition.builder()
+				.name("Attempt")
+				.issuerUri("https://unknown.example.com")
+				.build();
+
+		assertThatExceptionOfType(NamespaceTrustedIssuerNotFoundException.class)
+				.isThrownBy(() -> manager.updateTrustedIssuer(lookupNamespace("konfigyr"), EntityId.from(9999), definition));
+
+		assertThat(events.eventOfTypeWasPublished(NamespaceEvent.TrustedIssuerUpdated.class)).isFalse();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should delete trusted issuer")
+	void shouldRemoveTrustedIssuer(AssertablePublishedEvents events) {
+		final var namespace = lookupNamespace("konfigyr");
+		assertThatNoException().isThrownBy(() -> manager.removeTrustedIssuer(namespace, EntityId.from(1)));
+
+		assertThat(manager.getTrustedIssuer(namespace, EntityId.from(1))).isEmpty();
+
+		events.assertThat()
+				.contains(NamespaceEvent.TrustedIssuerRemoved.class)
+				.matching(NamespaceEvent::get, namespace)
+				.matching(event -> event.issuer().id(), EntityId.from(1));
+	}
+
+	@Test
+	@DisplayName("should fail to delete trusted issuer from a different namespace")
+	void shouldNotRemoveTrustedIssuerFromDifferentNamespace(AssertablePublishedEvents events) {
+		assertThatExceptionOfType(NamespaceTrustedIssuerNotFoundException.class)
+				.isThrownBy(() -> manager.removeTrustedIssuer(lookupNamespace("john-doe"), EntityId.from(1)));
+
+		assertThat(events.eventOfTypeWasPublished(NamespaceEvent.TrustedIssuerRemoved.class)).isFalse();
+	}
+
+	@Test
+	@DisplayName("should fail to delete unknown trusted issuer")
+	void shouldNotRemoveUnknownTrustedIssuer(AssertablePublishedEvents events) {
+		assertThatExceptionOfType(NamespaceTrustedIssuerNotFoundException.class)
+				.isThrownBy(() -> manager.removeTrustedIssuer(lookupNamespace("konfigyr"), EntityId.from(9999)));
+
+		assertThat(events.eventOfTypeWasPublished(NamespaceEvent.TrustedIssuerRemoved.class)).isFalse();
+	}
+
 	private Namespace lookupNamespace(String slug) {
 		return assertThat(manager.findBySlug(slug))
 				.as("Namespace with slug '%s' not found", slug)

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/TrustedIssuersControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/TrustedIssuersControllerTest.java
@@ -1,0 +1,337 @@
+package com.konfigyr.namespace.controller;
+
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.hateoas.Link;
+import com.konfigyr.hateoas.LinkRelation;
+import com.konfigyr.hateoas.PagedModel;
+import com.konfigyr.namespace.NamespaceTrustedIssuer;
+import com.konfigyr.namespace.NamespaceTrustedIssuerNotFoundException;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.test.AbstractControllerTest;
+import com.konfigyr.test.TestPrincipals;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+
+public class TrustedIssuersControllerTest extends AbstractControllerTest {
+
+	@Test
+	@DisplayName("should retrieve trusted issuers for namespace")
+	void listTrustedIssuers() {
+		mvc.get().uri("/namespaces/{slug}/trusted-issuers", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.hasContentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+				.bodyJson()
+				.convertTo(pagedModel(NamespaceTrustedIssuer.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.hasSize(3)
+						.satisfiesExactly(
+								issuer -> assertThat(issuer)
+										.returns(EntityId.from(1L), NamespaceTrustedIssuer::id)
+										.returns(EntityId.from(2L), NamespaceTrustedIssuer::namespace)
+										.returns("Konfigyr CI", NamespaceTrustedIssuer::name)
+										.returns("GitHub Actions for Konfigyr org", NamespaceTrustedIssuer::description)
+										.returns("https://ci.konfigyr.com", NamespaceTrustedIssuer::issuerUri)
+										.returns("https://ci.konfigyr.com/jwks.json", NamespaceTrustedIssuer::jwksUri)
+										.returns(true, NamespaceTrustedIssuer::active)
+										.satisfies(i -> assertThat(i.allowedAudiences()).containsExactly("konfigyr-api"))
+										.satisfies(i -> assertThat(i.customClaims()).containsEntry("environment", "production")),
+								issuer -> assertThat(issuer)
+										.returns(EntityId.from(2L), NamespaceTrustedIssuer::id)
+										.returns(EntityId.from(2L), NamespaceTrustedIssuer::namespace)
+										.returns("Konfigyr staging CI", NamespaceTrustedIssuer::name)
+										.returns(null, NamespaceTrustedIssuer::description)
+										.returns("https://ci-staging.konfigyr.com", NamespaceTrustedIssuer::issuerUri)
+										.returns(null, NamespaceTrustedIssuer::jwksUri)
+										.returns(true, NamespaceTrustedIssuer::active)
+										.satisfies(i -> assertThat(i.allowedAudiences()).isEmpty())
+										.satisfies(i -> assertThat(i.customClaims()).isEmpty()),
+								issuer -> assertThat(issuer)
+										.returns(EntityId.from(3L), NamespaceTrustedIssuer::id)
+										.returns(EntityId.from(2L), NamespaceTrustedIssuer::namespace)
+										.returns("Disabled issuer", NamespaceTrustedIssuer::name)
+										.returns(false, NamespaceTrustedIssuer::active)
+						)
+				)
+				.satisfies(it -> assertThat(it.getMetadata())
+						.returns(20L, PagedModel.PageMetadata::size)
+						.returns(1L, PagedModel.PageMetadata::number)
+						.returns(3L, PagedModel.PageMetadata::totalElements)
+						.returns(1L, PagedModel.PageMetadata::totalPages)
+				)
+				.satisfies(it -> assertThat(it.getLinks())
+						.hasSize(2)
+						.containsExactly(
+								Link.of("http://localhost?page=1", LinkRelation.FIRST),
+								Link.of("http://localhost?page=1", LinkRelation.LAST)
+						)
+				);
+	}
+
+	@Test
+	@DisplayName("should retrieve only active trusted issuers for namespace")
+	void listActiveTrustedIssuers() {
+		mvc.get().uri("/namespaces/{slug}/trusted-issuers", "konfigyr")
+				.queryParam("active", "true")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(NamespaceTrustedIssuer.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.hasSize(2)
+						.allSatisfy(issuer -> assertThat(issuer.active()).isTrue())
+				);
+	}
+
+	@Test
+	@DisplayName("should retrieve trusted issuer by ID")
+	void getTrustedIssuer() {
+		mvc.get().uri("/namespaces/{slug}/trusted-issuers/{id}", "konfigyr", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.hasContentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+				.bodyJson()
+				.convertTo(NamespaceTrustedIssuer.class)
+				.returns(EntityId.from(1L), NamespaceTrustedIssuer::id)
+				.returns(EntityId.from(2L), NamespaceTrustedIssuer::namespace)
+				.returns("Konfigyr CI", NamespaceTrustedIssuer::name)
+				.returns("https://ci.konfigyr.com", NamespaceTrustedIssuer::issuerUri)
+				.returns("https://ci.konfigyr.com/jwks.json", NamespaceTrustedIssuer::jwksUri)
+				.satisfies(it -> assertThat(it.allowedAudiences()).containsExactly("konfigyr-api"))
+				.satisfies(it -> assertThat(it.customClaims()).containsEntry("environment", "production"));
+	}
+
+	@Test
+	@DisplayName("should not retrieve unknown trusted issuer")
+	void getUnknownTrustedIssuer() {
+		mvc.get().uri("/namespaces/{slug}/trusted-issuers/{id}", "konfigyr", EntityId.from(9999).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(trustedIssuerNotFound(9999));
+	}
+
+	@Test
+	@DisplayName("should not retrieve trusted issuer belonging to a different namespace")
+	void getTrustedIssuerFromDifferentNamespace() {
+		mvc.get().uri("/namespaces/{slug}/trusted-issuers/{id}", "konfigyr", EntityId.from(4).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(trustedIssuerNotFound(4));
+	}
+
+	@Test
+	@DisplayName("should not retrieve trusted issuers without namespaces:read scope")
+	void listTrustedIssuersWithoutScope() {
+		mvc.get().uri("/namespaces/{slug}/trusted-issuers", "konfigyr")
+				.with(authentication(TestPrincipals.john()))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.READ_NAMESPACES));
+	}
+
+	@Test
+	@DisplayName("should not retrieve trusted issuers when user is not a namespace admin")
+	void listTrustedIssuersWithoutAdminRole() {
+		mvc.get().uri("/namespaces/{slug}/trusted-issuers", "konfigyr")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should create trusted issuer for namespace")
+	void createTrustedIssuer() {
+		mvc.post().uri("/namespaces/{slug}/trusted-issuers", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"New CI\",\"issuerUri\":\"https://new-ci.example.com\",\"allowedAudiences\":[\"konfigyr-api\"]}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.CREATED)
+				.hasContentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+				.bodyJson()
+				.convertTo(NamespaceTrustedIssuer.class)
+				.returns(EntityId.from(2L), NamespaceTrustedIssuer::namespace)
+				.returns("New CI", NamespaceTrustedIssuer::name)
+				.returns("https://new-ci.example.com", NamespaceTrustedIssuer::issuerUri)
+				.returns(null, NamespaceTrustedIssuer::jwksUri)
+				.returns(true, NamespaceTrustedIssuer::active)
+				.satisfies(it -> assertThat(it.allowedAudiences()).containsExactly("konfigyr-api"))
+				.satisfies(it -> assertThat(it.customClaims()).isEmpty())
+				.satisfies(it -> assertThat(it.createdAt())
+						.isCloseTo(OffsetDateTime.now(), within(5, ChronoUnit.MINUTES))
+				);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to create trusted issuer for namespace with invalid payload")
+	void createTrustedIssuerWithInvalidData() {
+		mvc.post().uri("/namespaces/{slug}/trusted-issuers", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"issuerUri\":\"issuer\",\"jwksUri\":\"jwks\",\"allowedAudiences\":[\" \"],\"customClaims\":{\"missing\":\"\"}}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST)
+				.satisfies(problemDetailFor(HttpStatus.BAD_REQUEST, problem -> problem
+						.hasTitleContaining("Invalid")
+						.hasDetailContaining("invalid request data")
+						.hasPropertySatisfying("errors", errors -> assertThat(errors)
+								.isNotNull()
+								.isInstanceOf(Collection.class)
+								.asInstanceOf(InstanceOfAssertFactories.collection(Map.class))
+								.extracting("pointer")
+								.containsExactlyInAnyOrder("name", "issuerUri", "jwksUri", "allowedAudiences[0]", "customClaims[missing]")
+						)
+				));
+	}
+
+	@Test
+	@DisplayName("should not create trusted issuer without namespaces:write scope")
+	void createTrustedIssuerWithoutScope() {
+		mvc.post().uri("/namespaces/{slug}/trusted-issuers", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Missing scope\",\"issuerUri\":\"https://x.example.com\",\"allowedAudiences\":[]}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.WRITE_NAMESPACES));
+	}
+
+	@Test
+	@DisplayName("should not create trusted issuer for unknown namespace")
+	void createTrustedIssuerForUnknownNamespace() {
+		mvc.post().uri("/namespaces/{slug}/trusted-issuers", "unknown")
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Unknown\",\"issuerUri\":\"https://x.example.com\"}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(namespaceNotFound("unknown"));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should update trusted issuer")
+	void updateTrustedIssuer() {
+		mvc.put().uri("/namespaces/{slug}/trusted-issuers/{id}", "konfigyr", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Konfigyr CI updated\",\"description\":\"Updated description\"," +
+						"\"issuerUri\":\"https://ci.konfigyr.com\",\"allowedAudiences\":[\"konfigyr-api\", \"konfigyr-cli\"]," +
+						"\"customClaims\":{\"environment\":\"production\",\"org\":\"konfigyr\"}}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.hasContentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+				.bodyJson()
+				.convertTo(NamespaceTrustedIssuer.class)
+				.returns(EntityId.from(1L), NamespaceTrustedIssuer::id)
+				.returns("Konfigyr CI updated", NamespaceTrustedIssuer::name)
+				.returns("Updated description", NamespaceTrustedIssuer::description)
+				.satisfies(it -> assertThat(it.allowedAudiences())
+						.containsExactlyInAnyOrder("konfigyr-api", "konfigyr-cli"))
+				.satisfies(it -> assertThat(it.customClaims())
+						.containsEntry("environment", "production")
+						.containsEntry("org", "konfigyr"))
+				.satisfies(it -> assertThat(it.updatedAt())
+						.isCloseTo(OffsetDateTime.now(), within(5, ChronoUnit.MINUTES))
+				);
+	}
+
+	@Test
+	@DisplayName("should not update unknown trusted issuer")
+	void updateUnknownTrustedIssuer() {
+		mvc.put().uri("/namespaces/{slug}/trusted-issuers/{id}", "konfigyr", EntityId.from(9999).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"name\":\"Unknown\",\"issuerUri\":\"https://x.example.com\"}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(trustedIssuerNotFound(9999));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should delete trusted issuer")
+	void deleteTrustedIssuer() {
+		mvc.delete().uri("/namespaces/{slug}/trusted-issuers/{id}", "konfigyr", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NO_CONTENT);
+	}
+
+	@Test
+	@DisplayName("should not delete unknown trusted issuer")
+	void deleteUnknownTrustedIssuer() {
+		mvc.delete().uri("/namespaces/{slug}/trusted-issuers/{id}", "konfigyr", EntityId.from(9999).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(trustedIssuerNotFound(9999));
+	}
+
+	@Test
+	@DisplayName("should not delete trusted issuer without namespaces:write scope")
+	void deleteTrustedIssuerWithoutScope() {
+		mvc.delete().uri("/namespaces/{slug}/trusted-issuers/{id}", "konfigyr", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.WRITE_NAMESPACES));
+	}
+
+	static Consumer<MvcTestResult> trustedIssuerNotFound(long id) {
+		return problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+				.hasTitle("Trusted issuer not found")
+				.hasDetailContaining("We couldn't find a trusted issuer matching your request.")
+		).andThen(hasFailedWithException(NamespaceTrustedIssuerNotFoundException.class, ex -> ex
+				.hasMessageContaining("Could not find a namespace trusted issuer with the following identifier: %s",
+						EntityId.from(id).serialize())
+		));
+	}
+
+}

--- a/konfigyr-data/src/main/resources/migrations/namespaces/namespaces-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/namespaces/namespaces-1.0.0.xml
@@ -486,4 +486,76 @@
 			CREATE TABLE service_configuration_catalog_default PARTITION OF service_configuration_catalog DEFAULT;
 		</sql>
 	</changeSet>
+
+	<changeSet author="vspasic" id="1.0.0-create-namespace-trusted-issuers-table" context="identity or api">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<tableExists tableName="namespace_trusted_issuers" />
+			</not>
+		</preConditions>
+
+		<comment>Per-namespace OIDC issuer allowlist for Workload Identity token exchange</comment>
+
+		<createTable tableName="namespace_trusted_issuers" remarks="Per-namespace OIDC issuer allowlist for Workload Identity token exchange.">
+			<column name="id" type="bigint" autoIncrement="true">
+				<constraints primaryKey="true" nullable="false" />
+			</column>
+
+			<column name="namespace_id" type="bigint">
+				<constraints nullable="false" />
+			</column>
+
+			<column name="name" type="varchar(255)">
+				<constraints nullable="false" />
+			</column>
+
+			<column name="description" type="text">
+				<constraints nullable="true" />
+			</column>
+
+			<column name="issuer_uri" type="varchar(2048)">
+				<constraints nullable="false" />
+			</column>
+
+			<column name="jwks_uri" type="varchar(2048)">
+				<constraints nullable="true" />
+			</column>
+
+			<column name="is_active" type="boolean" defaultValueBoolean="true">
+				<constraints nullable="false" />
+			</column>
+
+			<column name="allowed_audiences" type="jsonb">
+				<constraints nullable="true" />
+			</column>
+
+			<column name="custom_claims" type="jsonb">
+				<constraints nullable="true" />
+			</column>
+
+			<column name="created_at" type="timestamptz" defaultValue="NOW()">
+				<constraints nullable="false" />
+			</column>
+
+			<column name="updated_at" type="timestamptz" defaultValue="NOW()">
+				<constraints nullable="false" />
+			</column>
+		</createTable>
+
+		<addForeignKeyConstraint
+				baseTableName="namespace_trusted_issuers"
+				baseColumnNames="namespace_id"
+				constraintName="fk_namespace_trusted_issuer"
+				referencedTableName="namespaces"
+				referencedColumnNames="id"
+				onDelete="CASCADE"
+		/>
+
+		<addUniqueConstraint
+				tableName="namespace_trusted_issuers"
+				columnNames="namespace_id, issuer_uri"
+				constraintName="unique_namespace_issuer"
+		/>
+	</changeSet>
+
 </databaseChangeLog>

--- a/konfigyr-frontend/src/components/vault/properties/property-dialog.tsx
+++ b/konfigyr-frontend/src/components/vault/properties/property-dialog.tsx
@@ -461,7 +461,7 @@ export function PropertyDialog<T>({ changeset, catalog, onAdd }: {
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger
         render={
-          <Button variant="outline" disabled={ changeset.profile.policy === 'IMMUTABLE'}>
+          <Button variant="outline" disabled={changeset.profile.policy === 'IMMUTABLE'}>
             <PlusIcon />
             <AddPropertyLabel />
           </Button>

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/NamespaceTrustedIssuerRepository.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/NamespaceTrustedIssuerRepository.java
@@ -1,0 +1,79 @@
+package com.konfigyr.identity.authorization.issuer;
+
+import com.konfigyr.data.converter.JsonbConverter;
+import com.konfigyr.entity.EntityId;
+import lombok.extern.slf4j.Slf4j;
+import org.jooq.Converter;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.json.JsonMapper;
+
+import java.util.List;
+
+import static com.konfigyr.data.tables.NamespaceTrustedIssuers.NAMESPACE_TRUSTED_ISSUERS;
+
+/**
+ * A {@link TrustedIssuerRepository} backed by the {@code namespace_trusted_issuers} database
+ * table. Returns a {@link TrustedIssuerRegistration} only when an active entry exists for the
+ * given namespace and issuer URI combination; returns {@code null} otherwise.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@Slf4j
+@NullMarked
+class NamespaceTrustedIssuerRepository implements TrustedIssuerRepository {
+
+	private final DSLContext context;
+	private final Converter<JSONB, List<String>> audiencesConverter;
+
+	NamespaceTrustedIssuerRepository(DSLContext context, JsonMapper jsonMapper) {
+		this.context = context;
+		this.audiencesConverter = JsonbConverter.create(jsonMapper, jsonMapper.getTypeFactory()
+				.constructCollectionType(List.class, String.class));
+	}
+
+	@Nullable
+	@Override
+	@Transactional(readOnly = true, label = "namespace-trusted-issuer-repository.lookup")
+	public TrustedIssuerRegistration lookup(EntityId namespace, String issuerUri) {
+		return context.select(
+						NAMESPACE_TRUSTED_ISSUERS.ID,
+						NAMESPACE_TRUSTED_ISSUERS.NAME,
+						NAMESPACE_TRUSTED_ISSUERS.ISSUER_URI,
+						NAMESPACE_TRUSTED_ISSUERS.JWKS_URI,
+						NAMESPACE_TRUSTED_ISSUERS.ALLOWED_AUDIENCES
+				)
+				.from(NAMESPACE_TRUSTED_ISSUERS)
+				.where(DSL.and(
+						NAMESPACE_TRUSTED_ISSUERS.NAMESPACE_ID.eq(namespace.get()),
+						NAMESPACE_TRUSTED_ISSUERS.ISSUER_URI.eq(issuerUri),
+						NAMESPACE_TRUSTED_ISSUERS.IS_ACTIVE.isTrue()
+				))
+				.fetchOne(this::toRegistration);
+	}
+
+	private TrustedIssuerRegistration toRegistration(Record record) {
+		final String id = EntityId.from(record.get(NAMESPACE_TRUSTED_ISSUERS.ID)).serialize();
+
+		if (log.isDebugEnabled()) {
+			log.debug("Resolved namespace trusted issuer: [id={}, issuer={}]",
+					id, record.get(NAMESPACE_TRUSTED_ISSUERS.ISSUER_URI));
+		}
+
+		final List<String> audiences = record.get(NAMESPACE_TRUSTED_ISSUERS.ALLOWED_AUDIENCES, audiencesConverter);
+
+		return TrustedIssuerRegistration.withId(id)
+				.name(record.get(NAMESPACE_TRUSTED_ISSUERS.NAME))
+				.issuerUri(record.get(NAMESPACE_TRUSTED_ISSUERS.ISSUER_URI))
+				.jwksUri(record.get(NAMESPACE_TRUSTED_ISSUERS.JWKS_URI))
+				.allowedAudiences(audiences)
+				.build();
+	}
+
+}

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerConfiguration.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/issuer/TrustedIssuerConfiguration.java
@@ -1,10 +1,13 @@
 package com.konfigyr.identity.authorization.issuer;
 
 import com.konfigyr.identity.authorization.AuthorizationProperties;
+import org.jooq.DSLContext;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.util.Assert;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Spring configuration that registers the trusted issuer infrastructure beans. All
@@ -28,9 +31,18 @@ import org.springframework.util.Assert;
 @Configuration(proxyBeanMethods = false)
 class TrustedIssuerConfiguration {
 
+	private static final String NAMESPACE_TRUSTED_ISSUER_REPOSITORY = "namespaceTrustedIssuerRepository";
+
+	@Bean(name = NAMESPACE_TRUSTED_ISSUER_REPOSITORY, defaultCandidate = false)
+	NamespaceTrustedIssuerRepository namespaceTrustedIssuerRepository(DSLContext context, JsonMapper jsonMapper) {
+		return new NamespaceTrustedIssuerRepository(context, jsonMapper);
+	}
+
 	@Bean
-	TrustedIssuerRepository trustedIssuerRepository() {
-		return new CompositeTrustedIssuerRepository(WellKnownTrustedIssuers.getInstance());
+	TrustedIssuerRepository trustedIssuerRepository(
+			@Qualifier(NAMESPACE_TRUSTED_ISSUER_REPOSITORY) TrustedIssuerRepository namespaceRepository
+	) {
+		return new CompositeTrustedIssuerRepository(WellKnownTrustedIssuers.getInstance(), namespaceRepository);
 	}
 
 	@Bean

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/NamespaceTrustedIssuerRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/issuer/NamespaceTrustedIssuerRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.konfigyr.identity.authorization.issuer;
+
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.identity.AbstractIntegrationTest;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class NamespaceTrustedIssuerRepositoryTest extends AbstractIntegrationTest {
+
+	static final EntityId KONFIGYR_NAMESPACE = EntityId.from(2L);
+	static final EntityId PERSONAL_NAMESPACE = EntityId.from(1L);
+
+	@Autowired
+	DSLContext context;
+
+	NamespaceTrustedIssuerRepository repository;
+
+	@BeforeEach
+	void setup() {
+		repository = new NamespaceTrustedIssuerRepository(context, JsonMapper.shared());
+	}
+
+	@Test
+	@DisplayName("should resolve active namespace issuer by namespace and issuer URI")
+	void shouldResolveActiveIssuer() {
+		final var registration = repository.lookup(KONFIGYR_NAMESPACE, "https://ci.konfigyr.com");
+
+		assertThat(registration)
+				.isNotNull()
+				.returns("Konfigyr CI", TrustedIssuerRegistration::name)
+				.returns("https://ci.konfigyr.com", TrustedIssuerRegistration::issuerUri)
+				.returns("https://ci.konfigyr.com/jwks.json", TrustedIssuerRegistration::jwksUri)
+				.satisfies(it -> assertThat(it.allowedAudiences())
+						.containsExactly("konfigyr-api")
+				);
+	}
+
+	@Test
+	@DisplayName("should resolve active namespace issuer with no jwks_uri and empty audiences")
+	void shouldResolveIssuerWithoutJwksUri() {
+		final var registration = repository.lookup(KONFIGYR_NAMESPACE, "https://ci-staging.konfigyr.com");
+
+		assertThat(registration)
+				.isNotNull()
+				.returns("Konfigyr staging CI", TrustedIssuerRegistration::name)
+				.returns("https://ci-staging.konfigyr.com", TrustedIssuerRegistration::issuerUri)
+				.returns(null, TrustedIssuerRegistration::jwksUri)
+				.satisfies(it -> assertThat(it.allowedAudiences()).isEmpty());
+	}
+
+	@Test
+	@DisplayName("should return null for inactive issuer")
+	void shouldReturnNullForInactiveIssuer() {
+		assertThat(repository.lookup(KONFIGYR_NAMESPACE, "https://disabled.konfigyr.com")).isNull();
+	}
+
+	@Test
+	@DisplayName("should return null when issuer URI does not match any registered issuer")
+	void shouldReturnNullForUnknownIssuerUri() {
+		assertThat(repository.lookup(KONFIGYR_NAMESPACE, "https://unknown.example.com")).isNull();
+	}
+
+	@Test
+	@DisplayName("should return null when issuer is registered under a different namespace")
+	void shouldReturnNullForWrongNamespace() {
+		assertThat(repository.lookup(PERSONAL_NAMESPACE, "https://ci.konfigyr.com")).isNull();
+	}
+
+	@Test
+	@DisplayName("should resolve issuer registered under a different namespace")
+	void shouldResolveIssuerForCorrectNamespace() {
+		assertThat(repository.lookup(PERSONAL_NAMESPACE, "https://ci.john-doe.example.com"))
+				.isNotNull()
+				.returns("Personal CI", TrustedIssuerRegistration::name);
+	}
+
+}

--- a/konfigyr-identity/src/test/resources/changelog.xml
+++ b/konfigyr-identity/src/test/resources/changelog.xml
@@ -10,6 +10,7 @@
 		<sqlFile path="data/users.sql" />
 		<sqlFile path="data/namespaces.sql" />
 		<sqlFile path="data/namespace-members.sql" />
+		<sqlFile path="data/namespace-trusted-issuers.sql" />
 		<sqlFile path="data/oauth-applications.sql" />
 	</changeSet>
 

--- a/konfigyr-test/src/main/resources/data/namespace-trusted-issuers.sql
+++ b/konfigyr-test/src/main/resources/data/namespace-trusted-issuers.sql
@@ -1,0 +1,6 @@
+-- This statement depends on namespaces.sql test data
+INSERT INTO namespace_trusted_issuers(id, namespace_id, name, description, issuer_uri, jwks_uri, is_active, allowed_audiences, custom_claims, created_at, updated_at) VALUES
+(1, 2, 'Konfigyr CI', 'GitHub Actions for Konfigyr org', 'https://ci.konfigyr.com', 'https://ci.konfigyr.com/jwks.json', true,  '["konfigyr-api"]', '{"environment":"production"}', now() - interval '10 days', now() - interval '2 days'),
+(2, 2, 'Konfigyr staging CI', NULL, 'https://ci-staging.konfigyr.com', NULL, true, '[]', '{}', now() - interval '5 days', now() - interval '5 days'),
+(3, 2, 'Disabled issuer', 'This issuer is inactive', 'https://disabled.konfigyr.com', NULL, false, '[]', '{}', now() - interval '7 days', now() - interval '7 days'),
+(4, 1, 'Personal CI', NULL, 'https://ci.john-doe.example.com', NULL, true, '[]', '{}', now() - interval '2 days', now() - interval '2 days');

--- a/konfigyr-test/src/main/resources/test-changelog.xml
+++ b/konfigyr-test/src/main/resources/test-changelog.xml
@@ -10,6 +10,7 @@
         <sqlFile path="data/users.sql" />
         <sqlFile path="data/namespaces.sql" />
 		<sqlFile path="data/namespace-members.sql" />
+		<sqlFile path="data/namespace-trusted-issuers.sql" />
 		<sqlFile path="data/oauth-applications.sql" />
 		<sqlFile path="data/services.sql" />
         <sqlFile path="data/artifactory.sql" />


### PR DESCRIPTION
## Summary

Adds per-tenant OIDC issuer registration so namespace admins can allow self-hosted CI providers (Jenkins, HashiCorp Vault, Spacelift, per-org Bitbucket, etc.) for Workload Identity token exchange without operator intervention. Well-known issuers (GitHub Actions, GitLab) remain the global backstop.

   - **DB**: `namespace_trusted_issuers` table with `allowed_audiences JSONB`, `custom_claims JSONB`, `is_active` flag, and a `(namespace_id, issuer_uri)` unique constraint
   - **Identity**: `NamespaceTrustedIssuerRepository` implements `TrustedIssuerRepository` and is composed after `WellKnownTrustedIssuers` in the `CompositeTrustedIssuerRepository`; every workload token-exchange lookup now consults namespace-registered issuers
   - **Domain**: `NamespaceTrustedIssuer` record + `NamespaceTrustedIssuerDefinition` value object; `NamespaceManager` extended with full CRUD (`findTrustedIssuers`, `getTrustedIssuer`, `createTrustedIssuer`, `updateTrustedIssuer`, `removeTrustedIssuer`)
   - **Events**: `TrustedIssuerCreated`, `TrustedIssuerUpdated`, `TrustedIssuerRemoved` sealed subtypes of `NamespaceEvent.TrustedIssuerEvent`, captured by `AuditEventListener` with human-readable messages
   - **REST**: `GET/POST/PUT/DELETE /namespaces/{slug}/trusted-issuers[/{id}]` protected by `@RequiresScope(WRITE_NAMESPACES)` and `@PreAuthorize("isAdmin")`