### PR TITLE
KFG-15: Improve the Artifact Verification API

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
@@ -199,7 +199,7 @@ class DefaultArtifactory implements Artifactory {
 		final Owner owner = ownerResolver.findOwner(ownerId)
 				.orElseThrow(() -> new OwnerNotFoundException(HttpStatus.BAD_REQUEST, ownerId));
 
-		groupVerifications.findActiveCovering(groupId, owner)
+		groupVerifications.findActiveCovering(owner, groupId)
 				.orElseThrow(() -> new GroupIdNotVerifiedException(groupId, owner));
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/ChallengeState.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/ChallengeState.java
@@ -4,6 +4,7 @@ package com.konfigyr.artifactory.ownership;
  * Lifecycle state of a verification challenge attempt.
  *
  * @author Vitalii Kushnir
+ * @since 1.0.0
  */
 public enum ChallengeState {
 	/**
@@ -19,5 +20,5 @@ public enum ChallengeState {
 	/**
 	 * The challenge is no longer valid and can no longer be used.
 	 */
-	EXPIRED;
+	EXPIRED
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/DefaultGroupVerifications.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/DefaultGroupVerifications.java
@@ -1,20 +1,26 @@
 package com.konfigyr.artifactory.ownership;
 
+import com.konfigyr.data.PageableExecutor;
 import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
+import com.konfigyr.support.SearchQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.codec.binary.Hex;
 import org.jooq.Condition;
 import org.jooq.DSLContext;
 import org.jooq.Record;
+import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.data.domain.Page;
+import org.springframework.security.crypto.keygen.BytesKeyGenerator;
+import org.springframework.security.crypto.keygen.KeyGenerators;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
-import java.security.SecureRandom;
 import java.time.OffsetDateTime;
-import java.util.Base64;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -27,17 +33,20 @@ import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
 @RequiredArgsConstructor
 class DefaultGroupVerifications implements GroupVerifications {
 
+	private static final PageableExecutor groupVerificationPageableExecutor = PageableExecutor.builder()
+			.defaultSortField(GROUP_VERIFICATIONS.CREATED_AT.desc())
+			.sortField("date", GROUP_VERIFICATIONS.CREATED_AT)
+			.sortField("group", GROUP_VERIFICATIONS.GROUP_ID)
+			.build();
+
+	private final BytesKeyGenerator challengeTokenGenerator = KeyGenerators.secureRandom(6);
+
 	private final DSLContext context;
-
 	private final VerificationStrategies strategies;
-
-	private static final SecureRandom RANDOM = new SecureRandom();
 
 	@Override
 	@Transactional(readOnly = true, label = "group-verifications.find-active-covering")
-	public Optional<GroupVerification> findActiveCovering(String groupId, Owner owner) {
-		log.debug("Looking up active verification covering groupId '{}' for owner {} ({})", groupId, owner.slug(), owner.id());
-
+	public Optional<GroupVerification> findActiveCovering(Owner owner, String groupId) {
 		return context.select(GROUP_VERIFICATIONS.asterisk(), NAMESPACES.SLUG)
 				.from(GROUP_VERIFICATIONS)
 				.join(NAMESPACES)
@@ -51,7 +60,6 @@ class DefaultGroupVerifications implements GroupVerifications {
 	@Override
 	@Transactional(readOnly = true, label = "group-verifications.find-any-overlapping")
 	public Optional<GroupVerification> findAnyOverlapping(String groupId) {
-		log.debug("Checking for any overlapping active verification with groupId '{}'", groupId);
 		return context.select(GROUP_VERIFICATIONS.fields())
 				.select(NAMESPACES.SLUG)
 				.from(GROUP_VERIFICATIONS)
@@ -63,21 +71,29 @@ class DefaultGroupVerifications implements GroupVerifications {
 
 	@Override
 	@Transactional(readOnly = true, label = "group-verifications.find-by-owner")
-	public List<GroupVerification> findByOwner(Owner owner) {
-		log.debug("Listing group verifications for owner {} ({})", owner.slug(), owner.id());
+	public Page<GroupVerification> findByOwner(Owner owner, SearchQuery query) {
+		final List<Condition> conditions = new ArrayList<>();
+		conditions.add(GROUP_VERIFICATIONS.NAMESPACE_ID.eq(owner.id().get()));
 
-		return context.select(GROUP_VERIFICATIONS.fields())
-				.select(NAMESPACES.SLUG)
-				.from(GROUP_VERIFICATIONS)
-				.join(NAMESPACES).on(GROUP_VERIFICATIONS.NAMESPACE_ID.eq(NAMESPACES.ID))
-				.where(GROUP_VERIFICATIONS.NAMESPACE_ID.eq(owner.id().get()))
-				.fetch(DefaultGroupVerifications::toGroupVerification);
+		query.term().ifPresent(term -> conditions.add(
+				GROUP_VERIFICATIONS.GROUP_ID.containsIgnoreCase(term)
+		));
+
+		query.criteria(GroupVerification.STATE_CRITERIA).ifPresent(state -> conditions.add(
+				GROUP_VERIFICATIONS.STATE.eq(state.name())
+		));
+
+		return groupVerificationPageableExecutor.execute(
+				createGroupVerificationsQuery(DSL.and(conditions)),
+				DefaultGroupVerifications::toGroupVerification,
+				query.pageable(),
+				() -> context.fetchCount(createGroupVerificationsQuery(DSL.and(conditions)))
+		);
 	}
 
 	@Override
 	@Transactional(readOnly = true, label = "group-verifications.find-by-group-id")
-	public Optional<GroupVerification> findByGroupId(String groupId, Owner owner) {
-		log.debug("Looking up group verification '{}' for owner {} ({})", groupId, owner.slug(), owner.id());
+	public Optional<GroupVerification> findByGroupId(Owner owner, String groupId) {
 		return context.select(GROUP_VERIFICATIONS.fields())
 				.select(NAMESPACES.SLUG)
 				.from(GROUP_VERIFICATIONS)
@@ -90,7 +106,6 @@ class DefaultGroupVerifications implements GroupVerifications {
 	@Override
 	@Transactional(readOnly = true, label = "group-verifications.find-active-challenge")
 	public Optional<VerificationChallenge> findActiveChallenge(GroupVerification verification) {
-		log.debug("Looking up active challenge for verification {} with groupId '{}' and state {}", verification.id(), verification.groupId(), verification.state());
 		return context.select(GROUP_VERIFICATION_CHALLENGES.fields())
 				.from(GROUP_VERIFICATION_CHALLENGES)
 				.where(GROUP_VERIFICATION_CHALLENGES.GROUP_VERIFICATION_ID.eq(verification.id().get()))
@@ -100,12 +115,14 @@ class DefaultGroupVerifications implements GroupVerifications {
 
 	@Override
 	@Transactional(readOnly = true, label = "group-verifications.find-challenges")
-	public List<VerificationChallenge> findChallenges(EntityId verificationId, Owner owner) {
-		log.debug("Listing challenges for verification {} and owner {} ({})", verificationId, owner.slug(), owner.id());
+	public List<VerificationChallenge> findChallenges(Owner owner, EntityId verificationId) {
 		return context.select(GROUP_VERIFICATION_CHALLENGES.fields())
 				.from(GROUP_VERIFICATION_CHALLENGES)
 				.join(GROUP_VERIFICATIONS).on(GROUP_VERIFICATION_CHALLENGES.GROUP_VERIFICATION_ID.eq(GROUP_VERIFICATIONS.ID))
-				.where(GROUP_VERIFICATIONS.ID.eq(verificationId.get())).and(GROUP_VERIFICATIONS.NAMESPACE_ID.eq(owner.id().get()))
+				.where(DSL.and(
+						GROUP_VERIFICATIONS.ID.eq(verificationId.get()),
+						GROUP_VERIFICATIONS.NAMESPACE_ID.eq(owner.id().get())
+				))
 				.orderBy(GROUP_VERIFICATION_CHALLENGES.CREATED_AT.asc())
 				.fetch(DefaultGroupVerifications::toVerificationChallenge);
 	}
@@ -113,29 +130,41 @@ class DefaultGroupVerifications implements GroupVerifications {
 	@Override
 	@Transactional(label = "group-verifications.claim")
 	public GroupVerification claim(Owner owner, String groupId, VerificationMethod method) {
-		log.info(
-				"Claiming group verification for owner {} ({}), groupId '{}', method {}",
-				owner.slug(),
-				owner.id(),
-				groupId,
-				method
-		);
+		log.debug("Attempting to create a group verification and claim challenge for: [owner={}, groupId={}, method={}]",
+				owner, groupId, method);
 
 		findAnyOverlapping(groupId).ifPresent(ignore -> {
 			throw new GroupIdAlreadyClaimedException(groupId);
 		});
 
-		final GroupVerification verification = save(
-				GroupVerification.builder()
-						.owner(owner)
-						.groupId(groupId)
-						.state(VerificationState.PENDING)
-						.createdAt(OffsetDateTime.now())
-						.build()
-		);
+		final GroupVerification verification = context.insertInto(GROUP_VERIFICATIONS)
+				.set(SettableRecord.of(context, GROUP_VERIFICATIONS)
+						.set(GROUP_VERIFICATIONS.ID, EntityId.generate().map(EntityId::get))
+						.set(GROUP_VERIFICATIONS.NAMESPACE_ID, owner.id().get())
+						.set(GROUP_VERIFICATIONS.GROUP_ID, groupId)
+						.set(GROUP_VERIFICATIONS.STATE, VerificationState.PENDING.name())
+						.set(GROUP_VERIFICATIONS.CREATED_AT, OffsetDateTime.now())
+						.get())
+				.returning(GROUP_VERIFICATIONS.fields())
+				.fetchOne(it -> toGroupVerification(it, owner));
 
-		VerificationChallenge verificationChallenge = createChallenge(verification, method);
-		save(verificationChallenge);
+		Assert.state(verification != null, () -> "Could not create verification for: [owner=%s, groupId=%s]"
+				.formatted(owner.slug(),  groupId));
+
+		final VerificationChallenge challenge = context.insertInto(GROUP_VERIFICATION_CHALLENGES)
+				.set(GROUP_VERIFICATION_CHALLENGES.GROUP_VERIFICATION_ID, verification.id().get())
+				.set(GROUP_VERIFICATION_CHALLENGES.VERIFICATION_METHOD, method.name())
+				.set(GROUP_VERIFICATION_CHALLENGES.CHALLENGE_TOKEN, generateChallengeToken())
+				.set(GROUP_VERIFICATION_CHALLENGES.STATE, ChallengeState.UNVERIFIED.name())
+				.set(GROUP_VERIFICATION_CHALLENGES.CREATED_AT, verification.createdAt())
+				.returning(GROUP_VERIFICATION_CHALLENGES.fields())
+				.fetchOne(DefaultGroupVerifications::toVerificationChallenge);
+
+		Assert.state(challenge != null, () -> "Could not create challenge for: [verification=%s, groupId=%s, method=%s]"
+				.formatted(verification.id(), verification.groupId(), method.name()));
+
+		log.info("Successfully created group verification claim for owner {} ({}), groupId '{}', method {}",
+				owner.slug(), owner.id(), groupId, method);
 
 		return verification;
 	}
@@ -143,29 +172,51 @@ class DefaultGroupVerifications implements GroupVerifications {
 	@Override
 	@Transactional(label = "group-verifications.verify")
 	public GroupVerification verify(Owner owner, String groupId) {
-		log.info("Verifying group verification for owner {} ({}), groupId '{}'", owner.slug(), owner.id(), groupId);
-		final GroupVerification verification = findByGroupId(groupId, owner)
+		log.debug("Attempting to perform group verification for: [owner={}, groupId={}]", owner, groupId);
+
+		final GroupVerification verification = findByGroupId(owner, groupId)
 				.orElseThrow(() -> new VerificationChallengeNotFoundException(owner, groupId));
+
 		Assert.state(
 				verification.state().canTransitionTo(VerificationState.ACTIVE),
-				"Can only activate a pending verification, but was " + verification.state()
+				() -> "Can only verify a pending groupId verification, but it was in %s state".formatted(verification.state())
 		);
 
 		final VerificationChallenge challenge = findActiveChallenge(verification)
 				.orElseThrow(() -> new VerificationChallengeNotFoundException("No active challenge to verify for groupId " + groupId));
 
+		Assert.state(
+				challenge.state() == ChallengeState.UNVERIFIED,
+				() -> "Verification challenge must be in an '%s' state before it can be applied, but it was in %s state"
+						.formatted(ChallengeState.UNVERIFIED, challenge.state())
+		);
+
 		final VerificationStrategy strategy = strategies.get(challenge.method());
-		log.debug("Using verification strategy {} for verification {} and challenge {}", strategy.method(), verification.id(), challenge.id());
+		log.debug("Using verification strategy {} for verification {} and challenge {}",
+				strategy.method(), verification.id(), challenge.id());
 
 		final VerificationResult result = strategy.verify(verification, challenge);
-		final VerificationChallenge verifiedChallenge = applyVerificationResult(challenge, result);
-		save(verifiedChallenge);
 
-		if (result instanceof VerificationResult.Success) {
-			GroupVerification activated = verification.toBuilder()
+		if (result instanceof VerificationResult.Success(VerificationMethod method)) {
+			Assert.state(method == challenge.method(), "Verification methods do not match");
+
+			final GroupVerification activated = verification.toBuilder()
 					.state(VerificationState.ACTIVE)
 					.verifiedAt(OffsetDateTime.now())
 					.build();
+
+			context.update(GROUP_VERIFICATIONS)
+					.set(GROUP_VERIFICATIONS.STATE, activated.state().name())
+					.set(GROUP_VERIFICATIONS.VERIFIED_AT, activated.verifiedAt())
+					.where(GROUP_VERIFICATIONS.ID.eq(activated.id().get()))
+					.execute();
+
+			context.update(GROUP_VERIFICATION_CHALLENGES)
+					.set(GROUP_VERIFICATION_CHALLENGES.STATE, ChallengeState.VERIFIED.name())
+					.set(GROUP_VERIFICATION_CHALLENGES.VERIFIED_AT, activated.verifiedAt())
+					.where(GROUP_VERIFICATION_CHALLENGES.ID.eq(challenge.id()))
+					.execute();
+
 			log.info(
 					"Activated group verification {} for owner {} ({}), groupId '{}'",
 					activated.id(),
@@ -173,7 +224,8 @@ class DefaultGroupVerifications implements GroupVerifications {
 					activated.owner().id(),
 					activated.groupId()
 			);
-			return save(activated);
+
+			return activated;
 		}
 
 		log.info(
@@ -184,106 +236,55 @@ class DefaultGroupVerifications implements GroupVerifications {
 				groupId,
 				result
 		);
+
 		return verification;
 	}
 
 	@Override
 	@Transactional(label = "group-verifications.revoke")
 	public GroupVerification revoke(GroupVerification verification) {
-		log.info(
-				"Revoking group verification {} for owner {} ({}), groupId '{}', current state {}",
-				verification.id(),
-				verification.owner().slug(),
-				verification.owner().id(),
-				verification.groupId(),
-				verification.state()
+		log.debug("Attempting to revoke a group verification for: [owner={}, groupId={}, state={}]",
+				verification.owner(), verification.groupId(), verification.state()
 		);
 
 		Assert.state(
 				verification.state().canTransitionTo(VerificationState.REVOKED),
-				"Cannot revoke a \"" + verification.state() + "\" verification"
+				() -> "Can only revoke an active groupId verification, but it was in a '%s' state".formatted(verification.state())
 		);
-		GroupVerification revoked = verification.toBuilder()
+
+		final GroupVerification revoked = verification.toBuilder()
 				.state(VerificationState.REVOKED)
 				.revokedAt(OffsetDateTime.now())
 				.build();
-		final GroupVerification saved = save(revoked);
+
+		context.update(GROUP_VERIFICATIONS)
+				.set(GROUP_VERIFICATIONS.STATE, revoked.state().name())
+				.set(GROUP_VERIFICATIONS.REVOKED_AT, revoked.revokedAt())
+				.where(GROUP_VERIFICATIONS.ID.eq(revoked.id().get()))
+				.execute();
+
 		log.info(
-				"Revoked group verification {} for owner {} ({}), groupId '{}'",
-				saved.id(),
-				saved.owner().slug(),
-				saved.owner().id(),
-				saved.groupId()
+				"Successfully revoked group verification {} for owner {} ({}), groupId '{}'",
+				revoked.id(),
+				revoked.owner().slug(),
+				revoked.owner().id(),
+				revoked.groupId()
 		);
-		return saved;
+
+		return revoked;
 	}
 
-	private GroupVerification save(GroupVerification verification) {
-		log.debug(
-				"Saving group verification for owner {} ({}), groupId '{}', state {}",
-				verification.owner().slug(),
-				verification.owner().id(),
-				verification.groupId(),
-				verification.state()
-		);
-
-		final Record record = context.insertInto(GROUP_VERIFICATIONS)
-				.set(SettableRecord.of(context, GROUP_VERIFICATIONS)
-						.set(GROUP_VERIFICATIONS.NAMESPACE_ID, verification.owner().id().get())
-						.set(GROUP_VERIFICATIONS.GROUP_ID, verification.groupId())
-						.set(GROUP_VERIFICATIONS.STATE, verification.state().name())
-						.set(GROUP_VERIFICATIONS.CREATED_AT, verification.createdAt())
-						.set(GROUP_VERIFICATIONS.VERIFIED_AT, verification.verifiedAt())
-						.set(GROUP_VERIFICATIONS.REVOKED_AT, verification.revokedAt())
-						.get())
-				.onConflict(GROUP_VERIFICATIONS.NAMESPACE_ID, GROUP_VERIFICATIONS.GROUP_ID)
-				.doUpdate()
-				.set(GROUP_VERIFICATIONS.STATE, verification.state().name())
-				.set(GROUP_VERIFICATIONS.VERIFIED_AT, verification.verifiedAt())
-				.set(GROUP_VERIFICATIONS.REVOKED_AT, verification.revokedAt())
-				.returning(GROUP_VERIFICATIONS.fields())
-				.fetchOne();
-
-		Assert.state(record != null, "Could not save group verification: " + verification.groupId());
-		return toGroupVerification(record, verification.owner());
+	private String generateChallengeToken() {
+		final byte[] seed = challengeTokenGenerator.generateKey();
+		return Hex.encodeHexString(seed);
 	}
 
-	private VerificationChallenge save(VerificationChallenge challenge) {
-		Assert.notNull(challenge.verificationId(), "Verification challenge must be attached to a verification before saving");
-
-		log.debug(
-				"Saving challenge for verificationId {}, method {}, state {}, challengeId {}",
-				challenge.verificationId(),
-				challenge.method(),
-				challenge.state(),
-				challenge.id()
-		);
-
-		var insert = context.insertInto(GROUP_VERIFICATION_CHALLENGES);
-		if (challenge.id() != null) {
-			insert.set(GROUP_VERIFICATION_CHALLENGES.ID, challenge.id().get());
-		}
-
-		final Record record = insert
-				.set(SettableRecord.of(context, GROUP_VERIFICATION_CHALLENGES)
-						.set(GROUP_VERIFICATION_CHALLENGES.GROUP_VERIFICATION_ID, challenge.verificationId().get())
-						.set(GROUP_VERIFICATION_CHALLENGES.VERIFICATION_METHOD, challenge.method().name())
-						.set(GROUP_VERIFICATION_CHALLENGES.CHALLENGE_TOKEN, challenge.token())
-						.set(GROUP_VERIFICATION_CHALLENGES.STATE, challenge.state().name())
-						.set(GROUP_VERIFICATION_CHALLENGES.CREATED_AT, challenge.createdAt())
-						.set(GROUP_VERIFICATION_CHALLENGES.VERIFIED_AT, challenge.verifiedAt())
-						.set(GROUP_VERIFICATION_CHALLENGES.EXPIRES_AT, challenge.expiresAt())
-						.get())
-				.onConflict(GROUP_VERIFICATION_CHALLENGES.ID)
-				.doUpdate()
-				.set(GROUP_VERIFICATION_CHALLENGES.STATE, challenge.state().name())
-				.set(GROUP_VERIFICATION_CHALLENGES.VERIFIED_AT, challenge.verifiedAt())
-				.set(GROUP_VERIFICATION_CHALLENGES.EXPIRES_AT, challenge.expiresAt())
-				.returning(GROUP_VERIFICATION_CHALLENGES.fields())
-				.fetchOne();
-
-		Assert.state(record != null, "Could not save verification challenge: " + challenge.id());
-		return toVerificationChallenge(record);
+	private SelectConditionStep<? extends Record> createGroupVerificationsQuery(Condition condition) {
+		return context.select(GROUP_VERIFICATIONS.fields())
+				.select(NAMESPACES.SLUG)
+				.from(GROUP_VERIFICATIONS)
+				.join(NAMESPACES).on(GROUP_VERIFICATIONS.NAMESPACE_ID.eq(NAMESPACES.ID))
+				.where(condition);
 	}
 
 	private static Condition prefixOf(String groupId) {
@@ -307,10 +308,10 @@ class DefaultGroupVerifications implements GroupVerifications {
 
 	private static GroupVerification toGroupVerification(Record record, Owner owner) {
 		return GroupVerification.builder()
-				.id(EntityId.from(record.get(GROUP_VERIFICATIONS.ID)))
+				.id(record.get(GROUP_VERIFICATIONS.ID, EntityId.class))
 				.owner(owner)
 				.groupId(record.get(GROUP_VERIFICATIONS.GROUP_ID))
-				.state(VerificationState.valueOf(record.get(GROUP_VERIFICATIONS.STATE)))
+				.state(record.get(GROUP_VERIFICATIONS.STATE, VerificationState.class))
 				.createdAt(record.get(GROUP_VERIFICATIONS.CREATED_AT))
 				.verifiedAt(record.get(GROUP_VERIFICATIONS.VERIFIED_AT))
 				.revokedAt(record.get(GROUP_VERIFICATIONS.REVOKED_AT))
@@ -319,51 +320,15 @@ class DefaultGroupVerifications implements GroupVerifications {
 
 	private static VerificationChallenge toVerificationChallenge(Record record) {
 		return VerificationChallenge.builder()
-				.id(EntityId.from(record.get(GROUP_VERIFICATION_CHALLENGES.ID)))
-				.verificationId(EntityId.from(record.get(GROUP_VERIFICATION_CHALLENGES.GROUP_VERIFICATION_ID)))
-				.method(VerificationMethod.valueOf(record.get(GROUP_VERIFICATION_CHALLENGES.VERIFICATION_METHOD)))
+				.id(record.get(GROUP_VERIFICATION_CHALLENGES.ID))
+				.verificationId(record.get(GROUP_VERIFICATION_CHALLENGES.GROUP_VERIFICATION_ID, EntityId.class))
+				.method(record.get(GROUP_VERIFICATION_CHALLENGES.VERIFICATION_METHOD, VerificationMethod.class))
 				.token(record.get(GROUP_VERIFICATION_CHALLENGES.CHALLENGE_TOKEN))
-				.state(ChallengeState.valueOf(record.get(GROUP_VERIFICATION_CHALLENGES.STATE)))
+				.state(record.get(GROUP_VERIFICATION_CHALLENGES.STATE, ChallengeState.class))
 				.createdAt(record.get(GROUP_VERIFICATION_CHALLENGES.CREATED_AT))
 				.verifiedAt(record.get(GROUP_VERIFICATION_CHALLENGES.VERIFIED_AT))
 				.expiresAt(record.get(GROUP_VERIFICATION_CHALLENGES.EXPIRES_AT))
 				.build();
 	}
 
-	private VerificationChallenge applyVerificationResult(VerificationChallenge challenge, VerificationResult result) {
-		Assert.state(
-				challenge.state() == ChallengeState.UNVERIFIED,
-				"Challenge must be " + ChallengeState.UNVERIFIED + " before it can be applied"
-		);
-
-		if (result instanceof VerificationResult.Success success) {
-			Assert.state(
-					success.method() == challenge.method(),
-					"Cannot apply a " + success.method() + " result to a " + challenge.method() + " challenge"
-			);
-
-			return challenge.toBuilder()
-					.state(ChallengeState.VERIFIED)
-					.verifiedAt(OffsetDateTime.now())
-					.build();
-		}
-
-		return challenge.toBuilder()
-				.state(ChallengeState.UNVERIFIED)
-				.verifiedAt(null)
-				.build();
-	}
-
-	private VerificationChallenge createChallenge(GroupVerification verification, VerificationMethod method) {
-		final byte[] seed = new byte[20];
-		RANDOM.nextBytes(seed);
-
-		return VerificationChallenge.builder()
-				.method(method)
-				.token(Base64.getUrlEncoder().withoutPadding().encodeToString(seed))
-				.state(ChallengeState.UNVERIFIED)
-				.createdAt(OffsetDateTime.now())
-				.verificationId(verification.id())
-				.build();
-	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/DnsTxtVerificationStrategy.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/DnsTxtVerificationStrategy.java
@@ -33,6 +33,7 @@ import java.util.Hashtable;
  * </ul>
  *
  * @author Mila Zarkovic
+ * @since 1.0.0
  * @see VerificationStrategy
  * @see VerificationMethod#DNS
  */

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupIdAlreadyClaimedException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupIdAlreadyClaimedException.java
@@ -9,6 +9,7 @@ import java.io.Serial;
  * Exception thrown when a group identifier is already claimed by another namespace.
  *
  * @author Vitalii Kushnir
+ * @since 1.0.0
  **/
 public class GroupIdAlreadyClaimedException extends ArtifactoryException {
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupIdNotVerifiedException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupIdNotVerifiedException.java
@@ -11,6 +11,7 @@ import java.io.Serial;
  * artifact {@code groupId} and is therefore not allowed to publish artifacts for that group.
  *
  * @author Mila Zarkovic
+ * @since 1.0.0
  */
 public class GroupIdNotVerifiedException extends ArtifactoryException {
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupVerification.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupVerification.java
@@ -1,43 +1,206 @@
 package com.konfigyr.artifactory.ownership;
 
 import com.konfigyr.entity.EntityId;
-import lombok.Builder;
+import com.konfigyr.support.SearchQuery;
 import org.jmolecules.ddd.annotation.AggregateRoot;
 import org.jmolecules.ddd.annotation.Identity;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
 
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
 
 /**
- * Verification claim for a group identifier owned by a namespace.
+ * Ownership claim for a Maven {@code groupId} held by a namespace.
  * <p>
- * A group verification tracks the namespace that owns the claim, the claimed {@code groupId}, and the
- * current lifecycle {@link VerificationState}. Timestamps are populated as the claim moves through the
- * verification flow.
+ * A group verification tracks which namespace owns the claim, the claimed {@code groupId}, and the
+ * current lifecycle {@link VerificationState}. Ownership is confirmed by issuing one or more
+ * {@link VerificationChallenge} attempts; each attempt is tracked separately and coordinated
+ * by the {@link GroupVerifications} service.
+ * <p>
+ * The lifecycle starts at {@link VerificationState#PENDING} when the claim is first submitted.
+ * A successful challenge transitions the claim to {@link VerificationState#ACTIVE}. A claim that
+ * cannot be verified transitions to {@link VerificationState#FAILED}. An active or pending claim
+ * can be explicitly revoked, transitioning to {@link VerificationState#REVOKED}.
  *
- * @param id         the persistent verification identifier; may be {@literal null} before the claim is saved
- * @param owner      the namespace owner that claims the group; never {@literal null}
- * @param groupId    the claimed group identifier; never {@literal null}
- * @param state      the current verification state; never {@literal null}
- * @param createdAt  timestamp when the claim was created; may be {@literal null} before persistence
- * @param verifiedAt timestamp when the claim was verified; may be {@literal null}
- * @param revokedAt  timestamp when the claim was revoked; may be {@literal null}
+ * @param id         the persistent verification identifier; never {@literal null}
+ * @param owner      the namespace that holds this claim; never {@literal null}
+ * @param groupId    the claimed Maven group coordinate; never {@literal null}
+ * @param state      the current verification lifecycle state; never {@literal null}
+ * @param createdAt  timestamp when the claim was submitted; {@literal null} before persistence
+ * @param verifiedAt timestamp when the claim transitioned to {@link VerificationState#ACTIVE}; {@literal null} otherwise
+ * @param revokedAt  timestamp when the claim transitioned to {@link VerificationState#REVOKED}; {@literal null} otherwise
  * @author Vitalii Kushnir
+ * @since 1.0.0
+ * @see VerificationChallenge
+ * @see VerificationState
+ * @see GroupVerifications
  */
+@NullMarked
 @AggregateRoot
-@Builder(toBuilder = true)
 public record GroupVerification(
-	@Nullable @Identity EntityId id,
-	@NonNull Owner owner,
-	@NonNull String groupId,
-	@NonNull VerificationState state,
+	@Identity EntityId id,
+	Owner owner,
+	String groupId,
+	VerificationState state,
 	@Nullable OffsetDateTime createdAt,
 	@Nullable OffsetDateTime verifiedAt,
 	@Nullable OffsetDateTime revokedAt
 ) implements Serializable {
+
 	@Serial
 	private static final long serialVersionUID = -8982245386554212335L;
+
+	/**
+	 * Search criteria that can be used to filter group verifications by their state.
+	 */
+	public static final SearchQuery.Criteria<VerificationState> STATE_CRITERIA =
+			SearchQuery.criteria("state", VerificationState.class);
+
+	/**
+	 * Creates a new {@link Builder fluent builder} instance used to construct a {@link GroupVerification}.
+	 *
+	 * @return group verification builder, never {@literal null}
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Creates a new {@link Builder} pre-populated with all values from this verification, suitable
+	 * for producing a modified copy.
+	 *
+	 * @return group verification builder, never {@literal null}
+	 */
+	public Builder toBuilder() {
+		return new Builder()
+				.id(this.id)
+				.owner(this.owner)
+				.groupId(this.groupId)
+				.state(this.state)
+				.createdAt(this.createdAt)
+				.verifiedAt(this.verifiedAt)
+				.revokedAt(this.revokedAt);
+	}
+
+	/**
+	 * Fluent builder type used to create a {@link GroupVerification}.
+	 */
+	public static final class Builder {
+
+		private @Nullable EntityId id;
+		private @Nullable Owner owner;
+		private @Nullable String groupId;
+		private @Nullable VerificationState state;
+		private @Nullable OffsetDateTime createdAt;
+		private @Nullable OffsetDateTime verifiedAt;
+		private @Nullable OffsetDateTime revokedAt;
+
+		private Builder() {
+		}
+
+		/**
+		 * Specify the persistent identifier of this {@link GroupVerification}.
+		 *
+		 * @param id verification identifier; may be {@literal null} before persistence
+		 * @return group verification builder
+		 */
+		public Builder id(@Nullable Long id) {
+			return id(id == null ? null : EntityId.from(id));
+		}
+
+		/**
+		 * Specify the persistent identifier of this {@link GroupVerification}.
+		 *
+		 * @param id verification identifier; may be {@literal null} before persistence
+		 * @return group verification builder
+		 */
+		public Builder id(@Nullable EntityId id) {
+			this.id = id;
+			return this;
+		}
+
+		/**
+		 * Specify the {@link Owner} namespace that holds this claim.
+		 *
+		 * @param owner namespace owner; must not be {@literal null}
+		 * @return group verification builder
+		 */
+		public Builder owner(Owner owner) {
+			this.owner = owner;
+			return this;
+		}
+
+		/**
+		 * Specify the Maven group coordinate being claimed.
+		 *
+		 * @param groupId group identifier; must not be blank
+		 * @return group verification builder
+		 */
+		public Builder groupId(String groupId) {
+			this.groupId = groupId;
+			return this;
+		}
+
+		/**
+		 * Specify the current {@link VerificationState} of this claim.
+		 *
+		 * @param state verification lifecycle state; must not be {@literal null}
+		 * @return group verification builder
+		 */
+		public Builder state(VerificationState state) {
+			this.state = state;
+			return this;
+		}
+
+		/**
+		 * Specify when this claim was submitted.
+		 *
+		 * @param createdAt creation timestamp; may be {@literal null}
+		 * @return group verification builder
+		 */
+		public Builder createdAt(@Nullable OffsetDateTime createdAt) {
+			this.createdAt = createdAt;
+			return this;
+		}
+
+		/**
+		 * Specify when this claim was activated.
+		 *
+		 * @param verifiedAt activation timestamp; may be {@literal null}
+		 * @return group verification builder
+		 */
+		public Builder verifiedAt(@Nullable OffsetDateTime verifiedAt) {
+			this.verifiedAt = verifiedAt;
+			return this;
+		}
+
+		/**
+		 * Specify when this claim was revoked.
+		 *
+		 * @param revokedAt revocation timestamp; may be {@literal null}
+		 * @return group verification builder
+		 */
+		public Builder revokedAt(@Nullable OffsetDateTime revokedAt) {
+			this.revokedAt = revokedAt;
+			return this;
+		}
+
+		/**
+		 * Creates a new {@link GroupVerification} from the values set on this builder.
+		 *
+		 * @return group verification, never {@literal null}
+		 * @throws IllegalArgumentException when required fields are missing or invalid
+		 */
+		public GroupVerification build() {
+			Assert.notNull(id, "Group verification identifier is required");
+			Assert.notNull(owner, "Group verification owner must not be null");
+			Assert.hasText(groupId, "Group verification group identifier must not be blank");
+			Assert.notNull(state, "Group verification state must not be null");
+
+			return new GroupVerification(id, owner, groupId, state, createdAt, verifiedAt, revokedAt);
+		}
+	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupVerificationNotFoundException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupVerificationNotFoundException.java
@@ -10,6 +10,7 @@ import java.io.Serial;
  * Exception thrown when a {@link GroupVerification} cannot be found for the requested namespace and groupId.
  *
  * @author Vitalii Kushnir
+ * @since 1.0.0
  */
 public class GroupVerificationNotFoundException extends ArtifactoryException {
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupVerifications.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupVerifications.java
@@ -1,36 +1,81 @@
 package com.konfigyr.artifactory.ownership;
 
 import com.konfigyr.entity.EntityId;
+import com.konfigyr.support.SearchQuery;
 import org.jspecify.annotations.NullMarked;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
 
 /**
- * Service for managing ownership claims and verification attempts.
+ * Service for managing Maven {@code groupId} ownership claims and their verification attempts.
+ * <p>
+ * This service is the enforcement gate that prevents a namespace from publishing artifact metadata
+ * for a {@code groupId} it does not own. Before any artifact can be ingested through the
+ * Artifactory, the publishing namespace must hold an {@link VerificationState#ACTIVE} claim on the
+ * artifact's {@code groupId}. Use {@link #findActiveCovering(Owner, String)} to perform that check.
+ * <p>
+ * A claim follows this lifecycle:
+ * <ol>
+ *     <li>A namespace submits a claim via {@link #claim(Owner, String, VerificationMethod)}, which
+ *     creates a {@link VerificationState#PENDING} {@link GroupVerification} and issues an initial
+ *     {@link VerificationChallenge} for the chosen method.</li>
+ *     <li>The namespace publishes the challenge token to the verification target (e.g. a DNS
+ *     {@code TXT} record) and then calls {@link #verify(Owner, String)}. The appropriate
+ *     {@link VerificationStrategy} checks the target and transitions the claim to
+ *     {@link VerificationState#ACTIVE} on success.</li>
+ *     <li>A transient failure (network error, token not yet propagated) leaves the challenge
+ *     {@link ChallengeState#UNVERIFIED} and the claim {@link VerificationState#PENDING} so the
+ *     namespace can retry.</li>
+ *     <li>An {@link VerificationState#ACTIVE} or {@link VerificationState#PENDING} claim can be
+ *     explicitly revoked via {@link #revoke(GroupVerification)}.</li>
+ * </ol>
+ * <p>
+ * Ownership is prefix-based: a claim on {@code com.mycompany} covers {@code com.mycompany.utils}
+ * and all other descendants. Accordingly, no two active claims may overlap in either direction,
+ * see {@link #findAnyOverlapping(String)}.
  *
  * @author Vitalii Kushnir
+ * @since 1.0.0
+ * @see GroupVerification
+ * @see VerificationChallenge
+ * @see VerificationStrategy
+ * @see VerificationState
  */
 @NullMarked
 public interface GroupVerifications {
 
 	/**
-	 * Finds an active claim owned by the given namespace that covers the supplied groupId prefix.
+	 * Finds an active claim owned by the given namespace that covers the supplied {@code groupId}.
 	 * <p>
-	 * The lookup matches either the exact {@code groupId} or any descendant group identifier that
-	 * starts with {@code groupId + "."}.
+	 * The lookup uses prefix-based matching: it returns a claim whose {@code groupId} is either an
+	 * exact match or a prefix of the requested value. A claim on {@code com.mycompany} therefore
+	 * covers {@code com.mycompany}, {@code com.mycompany.utils}, and any other
+	 * {@code com.mycompany.*} descendant.
+	 * <p>
+	 * This is the primary check used by the publishing enforcement gate: if this method returns empty,
+	 * the namespace is not authorized to publish the artifact.
 	 *
-	 * @param groupId the group identifier to resolve
 	 * @param owner   the namespace owner to search within
-	 * @return the active claim if one exists; otherwise an empty optional
+	 * @param groupId the artifact group identifier to check
+	 * @return the active claim covering the groupId if one exists; otherwise an empty optional
 	 */
-	Optional<GroupVerification> findActiveCovering(String groupId, Owner owner);
+	Optional<GroupVerification> findActiveCovering(Owner owner, String groupId);
 
 	/**
-	 * Finds any active claim that overlaps the supplied groupId in either direction.
+	 * Finds any active claim that overlaps the supplied {@code groupId} in either direction.
 	 * <p>
-	 * This method is used before creating a new claim to ensure no other active verification already
-	 * owns the same group identifier or one of its parent or child identifiers.
+	 * Two claims overlap when one is a prefix of the other. Both directions are checked:
+	 * <ul>
+	 *     <li>A new claim for {@code com.mycompany.utils} conflicts with an existing claim for
+	 *     {@code com.mycompany}; the child is already covered by the parent's prefix claim.</li>
+	 *     <li>A new claim for {@code com.mycompany} conflicts with an existing claim for
+	 *     {@code com.mycompany.utils}; the parent would silently absorb a child already owned by
+	 *     another namespace.</li>
+	 * </ul>
+	 * This method must be called before {@link #claim(Owner, String, VerificationMethod)} to detect
+	 * conflicts that the database unique index on exact {@code groupId} values cannot catch.
 	 *
 	 * @param groupId the group identifier to inspect
 	 * @return an overlapping active claim if one exists; otherwise an empty optional
@@ -38,24 +83,33 @@ public interface GroupVerifications {
 	Optional<GroupVerification> findAnyOverlapping(String groupId);
 
 	/**
-	 * Lists all claims owned by the supplied namespace.
+	 * Returns a page of verification claims owned by the supplied namespace matching the query.
+	 * <p>
+	 * Supports filtering by {@link VerificationState} via {@link GroupVerification#STATE_CRITERIA}
+	 * and substring matching on the {@code groupId} via {@link com.konfigyr.support.SearchQuery#TERM}.
+	 * Results can be sorted by {@code group} (the {@code groupId} column) or {@code date}
+	 * (creation timestamp); the default order is creation timestamp descending.
 	 *
 	 * @param owner the namespace owner
-	 * @return all claims for that owner, ordered by the underlying query
+	 * @param query the search query containing filter and pagination instructions
+	 * @return paged claims for that owner matching the supplied search query
 	 */
-	List<GroupVerification> findByOwner(Owner owner);
+	Page<GroupVerification> findByOwner(Owner owner, SearchQuery query);
 
 	/**
-	 * Finds a claim for the supplied groupId within the given namespace.
+	 * Finds a claim for the supplied {@code groupId} within the given namespace.
 	 *
-	 * @param groupId the group identifier to look up
 	 * @param owner   the namespace owner
+	 * @param groupId the group identifier to look up
 	 * @return the matching claim if present; otherwise an empty optional
 	 */
-	Optional<GroupVerification> findByGroupId(String groupId, Owner owner);
+	Optional<GroupVerification> findByGroupId(Owner owner, String groupId);
 
 	/**
-	 * Finds the current unverified challenge attached to a verification claim.
+	 * Finds the single {@link ChallengeState#UNVERIFIED} challenge attached to a verification claim.
+	 * <p>
+	 * At most one challenge is active at a time. When no unverified challenge exists, either because
+	 * none has been issued yet or all previous attempts have been resolved, this returns empty.
 	 *
 	 * @param verification the verification claim
 	 * @return the active challenge if one exists; otherwise an empty optional
@@ -63,51 +117,67 @@ public interface GroupVerifications {
 	Optional<VerificationChallenge> findActiveChallenge(GroupVerification verification);
 
 	/**
-	 * Lists all challenges attached to a verification within the given namespace.
+	 * Returns all challenges attached to a verification, ordered by creation time ascending.
 	 * <p>
-	 * The returned list is ordered by creation time ascending.
+	 * This is the full attempt history: both resolved ({@link ChallengeState#VERIFIED} or
+	 * {@link ChallengeState#EXPIRED}) and the current {@link ChallengeState#UNVERIFIED} challenge,
+	 * if any.
 	 *
-	 * @param verificationId the verification identifier to look up
 	 * @param owner          the namespace owner
+	 * @param verificationId the verification identifier to look up
 	 * @return the challenge history for the claim, in creation order
 	 */
-	List<VerificationChallenge> findChallenges(EntityId verificationId, Owner owner);
+	List<VerificationChallenge> findChallenges(Owner owner, EntityId verificationId);
 
 	/**
-	 * Claims a new group verification for the supplied namespace owner.
+	 * Submits a new ownership claim for the supplied {@code groupId} on behalf of the namespace.
 	 * <p>
-	 * Implementations are expected to create a pending verification, create an initial challenge for
-	 * the supplied method, persist both records, and return the stored verification claim.
+	 * Creates a {@link VerificationState#PENDING} {@link GroupVerification} and an initial
+	 * {@link ChallengeState#UNVERIFIED} {@link VerificationChallenge} for the chosen method, persists
+	 * both records, and returns the {@link GroupVerification}. The challenge token, which the
+	 * namespace must publish to the verification target, is not included in the returned record; use
+	 * {@link #findActiveChallenge(GroupVerification)} to retrieve it.
+	 * <p>
+	 * {@link #findAnyOverlapping(String)} must be checked before calling this method. If an
+	 * overlapping active claim exists, implementations must throw
+	 * {@link GroupIdAlreadyClaimedException} before persisting anything.
 	 *
-	 * @param owner   the namespace owner that claims the group
-	 * @param groupId the group identifier to claim
+	 * @param owner   the namespace owner that is claiming the group
+	 * @param groupId the Maven group identifier to claim
 	 * @param method  the verification method used to prove ownership
-	 * @return the created verification claim
+	 * @return the created {@link VerificationState#PENDING} verification claim
+	 * @throws GroupIdAlreadyClaimedException when an active claim already covers the groupId
 	 */
 	GroupVerification claim(Owner owner, String groupId, VerificationMethod method);
 
 	/**
-	 * Verifies the supplied group verification for the given namespace owner.
+	 * Attempts to verify the ownership claim for the given {@code groupId} on behalf of the namespace.
 	 * <p>
-	 * Implementations should load the claim, resolve the active challenge, and delegate the actual
-	 * proof check to the {@link VerificationStrategy} selected by the challenge method. When the
-	 * strategy returns a successful result, the claim is activated and the verification timestamp is
-	 * recorded. Failed verifications keep the claim in its current state.
+	 * Loads the claim and its active {@link ChallengeState#UNVERIFIED} challenge, then delegates to
+	 * the {@link VerificationStrategy} matching the challenge's {@link VerificationMethod}. On a
+	 * successful result the claim transitions to {@link VerificationState#ACTIVE} and
+	 * {@code verifiedAt} is recorded. On a transient failure, like network errors, or token is not yet
+	 * propagated, the challenge remains {@link ChallengeState#UNVERIFIED} and the claim remains
+	 * {@link VerificationState#PENDING} so the namespace can retry without resubmitting.
 	 *
-	 * @param owner the namespace owner that owns the claim
+	 * @param owner   the namespace owner that holds the claim
 	 * @param groupId the group identifier to verify
-	 * @return the updated verification claim
+	 * @return the updated verification claim reflecting the outcome
+	 * @throws VerificationChallengeNotFoundException when no claim or no active challenge is found
 	 */
 	GroupVerification verify(Owner owner, String groupId);
 
 	/**
 	 * Revokes the supplied verification claim.
 	 * <p>
-	 * Implementations should reject claims that are not in a revocable state and return the stored
-	 * revoked claim when the transition succeeds.
+	 * Only claims in {@link VerificationState#ACTIVE} or {@link VerificationState#PENDING} state
+	 * can be revoked. Revoking an {@link VerificationState#ACTIVE} claim immediately removes
+	 * publish authorization for the associated {@code groupId}: subsequent calls to
+	 * {@link #findActiveCovering(Owner, String)} will return empty until a new claim is activated.
 	 *
 	 * @param verification the claim to revoke
-	 * @return the revoked claim
+	 * @return the revoked claim with {@code revokedAt} populated
+	 * @throws IllegalStateException when the claim is not in a revocable state
 	 */
 	GroupVerification revoke(GroupVerification verification);
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/Owner.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/Owner.java
@@ -16,6 +16,7 @@ import java.io.Serializable;
  * @param id   namespace entity identifier
  * @param slug namespace slug used for URL construction
  * @author Vitalii Kushnir
+ * @since 1.0.0
  */
 @ValueObject
 public record Owner(

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/OwnerNotFoundException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/OwnerNotFoundException.java
@@ -11,6 +11,7 @@ import java.io.Serial;
  * Exception thrown when a namespace owner cannot be resolved from the supplied slug or identifier.
  *
  * @author Vitalii Kushnir
+ * @since 1.0.0
  **/
 public class OwnerNotFoundException extends ArtifactoryException {
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/OwnerResolver.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/OwnerResolver.java
@@ -16,6 +16,7 @@ import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
  * Resolves a namespace into a lightweight {@link Owner} reference used by ownership workflows.
  *
  * @author Mila Zarkovic
+ * @since 1.0.0
  */
 @Slf4j
 @NullMarked

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/SourceCodeHost.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/SourceCodeHost.java
@@ -19,6 +19,7 @@ import java.util.Optional;
  * {@link #toURI(String, String)} builds the host API URL used to assert that the repository exists.
  *
  * @author Mila Zarkovic
+ * @since 1.0.0
  */
 @NullMarked
 public enum SourceCodeHost {

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/SourceCodeVerificationStrategy.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/SourceCodeVerificationStrategy.java
@@ -32,6 +32,7 @@ import java.net.URI;
  * </ul>
  *
  * @author Mila Zarkovic
+ * @since 1.0.0
  * @see VerificationStrategy
  * @see VerificationMethod#SOURCE_CODE
  * @see SourceCodeHost

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationChallenge.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationChallenge.java
@@ -1,38 +1,51 @@
 package com.konfigyr.artifactory.ownership;
 
 import com.konfigyr.entity.EntityId;
-import lombok.Builder;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
 
 import java.io.Serial;
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.UUID;
 
 /**
- * Verification challenge attached to a group verification claim.
+ * Verification challenge attached to a {@link GroupVerification} claim.
  * <p>
- * A challenge stores the issued verification method, the generated token, and its current lifecycle
- * state. The challenge is created in an unverified state and then transitions to verified or expired
- * depending on the verification outcome.
+ * A challenge holds the proof token that the namespace owner must publish in the verification
+ * target appropriate for the chosen {@link VerificationMethod}. The {@link VerificationStrategy}
+ * is responsible for checking whether the token is present at that target to confirm ownership.
+ * <p>
+ * The lifecycle starts at {@link ChallengeState#UNVERIFIED}. A successful strategy check
+ * transitions the challenge to {@link ChallengeState#VERIFIED}; a failed check leaves it at
+ * {@link ChallengeState#UNVERIFIED} so the owner can retry. A challenge that is no longer
+ * eligible for verification transitions to {@link ChallengeState#EXPIRED}.
+ * <p>
+ * {@code expiresAt} is set only for time-limited challenges (e.g. {@link VerificationMethod#DNS});
+ * it is {@literal null} for open-ended methods such as {@link VerificationMethod#SOURCE_CODE}.
  *
- * @param id             the persistent challenge identifier; may be {@literal null} before the challenge is saved
- * @param verificationId the owning verification identifier; may be {@literal null} before persistence
- * @param method         the verification method used to issue and validate the challenge; never {@literal null}
- * @param token          the challenge token exposed to the external verification target; never {@literal null}
- * @param state          the current challenge state; never {@literal null}
- * @param createdAt      timestamp when the challenge was created; may be {@literal null} before persistence
- * @param verifiedAt     timestamp when the challenge was verified; may be {@literal null}
- * @param expiresAt      timestamp when the challenge expires; may be {@literal null}
+ * @param id             the persistent challenge identifier; never {@literal null}
+ * @param verificationId the identifier of the owning {@link GroupVerification}; never {@literal null}
+ * @param method         the verification method used to issue and validate this challenge; never {@literal null}
+ * @param token          the opaque token the owner must publish in the verification target; never {@literal null}
+ * @param state          the current challenge lifecycle state; never {@literal null}
+ * @param createdAt      timestamp when the challenge was issued; {@literal null} before persistence
+ * @param verifiedAt     timestamp when the challenge transitioned to {@link ChallengeState#VERIFIED}; {@literal null} otherwise
+ * @param expiresAt      timestamp after which the challenge is no longer valid; {@literal null} for open-ended methods
  * @author Vitalii Kushnir
+ * @since 1.0.0
+ * @see GroupVerification
+ * @see VerificationStrategy
+ * @see ChallengeState
  */
-@Builder(toBuilder = true)
+@NullMarked
 public record VerificationChallenge(
-	@Nullable EntityId id,
-	@Nullable EntityId verificationId,
-	@NonNull VerificationMethod method,
-	@NonNull String token,
-	@NonNull ChallengeState state,
+	UUID id,
+	EntityId verificationId,
+	VerificationMethod method,
+	String token,
+	ChallengeState state,
 	@Nullable OffsetDateTime createdAt,
 	@Nullable OffsetDateTime verifiedAt,
 	@Nullable OffsetDateTime expiresAt
@@ -41,4 +54,135 @@ public record VerificationChallenge(
 	@Serial
 	private static final long serialVersionUID = 8383658221756321454L;
 
+	/**
+	 * Creates a new {@link Builder fluent builder} instance used to construct a {@link VerificationChallenge}.
+	 *
+	 * @return challenge builder, never {@literal null}
+	 */
+	public static Builder builder() {
+		return new Builder();
+	}
+
+	/**
+	 * Fluent builder type used to create a {@link VerificationChallenge}.
+	 */
+	public static final class Builder {
+
+		private @Nullable UUID id;
+		private @Nullable EntityId verificationId;
+		private @Nullable VerificationMethod method;
+		private @Nullable String token;
+		private @Nullable ChallengeState state;
+		private @Nullable OffsetDateTime createdAt;
+		private @Nullable OffsetDateTime verifiedAt;
+		private @Nullable OffsetDateTime expiresAt;
+
+		private Builder() {
+		}
+
+		/**
+		 * Specify the persistent identifier of this {@link VerificationChallenge}.
+		 *
+		 * @param id challenge identifier; may be {@literal null} before persistence
+		 * @return challenge builder
+		 */
+		public Builder id(@Nullable UUID id) {
+			this.id = id;
+			return this;
+		}
+
+		/**
+		 * Specify the identifier of the {@link GroupVerification} this challenge belongs to.
+		 *
+		 * @param verificationId owning verification identifier; may be {@literal null} before persistence
+		 * @return challenge builder
+		 */
+		public Builder verificationId(@Nullable EntityId verificationId) {
+			this.verificationId = verificationId;
+			return this;
+		}
+
+		/**
+		 * Specify the {@link VerificationMethod} used to issue and validate this challenge.
+		 *
+		 * @param method verification method; must not be {@literal null}
+		 * @return challenge builder
+		 */
+		public Builder method(VerificationMethod method) {
+			this.method = method;
+			return this;
+		}
+
+		/**
+		 * Specify the opaque token the owner must publish in the verification target.
+		 *
+		 * @param token challenge token; must not be blank
+		 * @return challenge builder
+		 */
+		public Builder token(String token) {
+			this.token = token;
+			return this;
+		}
+
+		/**
+		 * Specify the current {@link ChallengeState} of this challenge.
+		 *
+		 * @param state challenge lifecycle state; must not be {@literal null}
+		 * @return challenge builder
+		 */
+		public Builder state(ChallengeState state) {
+			this.state = state;
+			return this;
+		}
+
+		/**
+		 * Specify when this challenge was issued.
+		 *
+		 * @param createdAt creation timestamp; may be {@literal null}
+		 * @return challenge builder
+		 */
+		public Builder createdAt(@Nullable OffsetDateTime createdAt) {
+			this.createdAt = createdAt;
+			return this;
+		}
+
+		/**
+		 * Specify when this challenge was verified.
+		 *
+		 * @param verifiedAt verification timestamp; may be {@literal null}
+		 * @return challenge builder
+		 */
+		public Builder verifiedAt(@Nullable OffsetDateTime verifiedAt) {
+			this.verifiedAt = verifiedAt;
+			return this;
+		}
+
+		/**
+		 * Specify when this challenge expires. Set only for time-limited methods; pass
+		 * {@literal null} for open-ended methods such as {@link VerificationMethod#SOURCE_CODE}.
+		 *
+		 * @param expiresAt expiry timestamp; may be {@literal null}
+		 * @return challenge builder
+		 */
+		public Builder expiresAt(@Nullable OffsetDateTime expiresAt) {
+			this.expiresAt = expiresAt;
+			return this;
+		}
+
+		/**
+		 * Creates a new {@link VerificationChallenge} from the values set on this builder.
+		 *
+		 * @return verification challenge, never {@literal null}
+		 * @throws IllegalArgumentException when required fields are missing or invalid
+		 */
+		public VerificationChallenge build() {
+			Assert.notNull(id, "Verification challenge identifier is required");
+			Assert.notNull(verificationId, "Verification challenge must have a group verification id");
+			Assert.notNull(method, "Verification challenge method must not be null");
+			Assert.hasText(token, "Verification challenge token must not be blank");
+			Assert.notNull(state, "Verification challenge state must not be null");
+
+			return new VerificationChallenge(id, verificationId, method, token, state, createdAt, verifiedAt, expiresAt);
+		}
+	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationChallengeNotFoundException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationChallengeNotFoundException.java
@@ -9,6 +9,7 @@ import java.io.Serial;
  * Exception thrown when a verification challenge cannot be found for the requested verification.
  *
  * @author Vitalii Kushnir
+ * @since 1.0.0
  **/
 public class VerificationChallengeNotFoundException extends ArtifactoryException {
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationMethod.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationMethod.java
@@ -4,6 +4,7 @@ package com.konfigyr.artifactory.ownership;
  * Verification methods supported for proving ownership of a groupId.
  *
  * @author Vitalii Kushnir
+ * @since 1.0.0
  */
 public enum VerificationMethod {
 	/**
@@ -14,5 +15,5 @@ public enum VerificationMethod {
 	/**
 	 * Source code host verification using a temporary public repository as proof (etc. GitHub, GitLab...).
 	 */
-	SOURCE_CODE;
+	SOURCE_CODE
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationResult.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationResult.java
@@ -3,19 +3,42 @@ package com.konfigyr.artifactory.ownership;
 import org.jspecify.annotations.NonNull;
 
 /**
- * Represents the outcome of a verification attempt performed by a {@link VerificationStrategy}.
+ * Outcome of a verification attempt performed by a {@link VerificationStrategy}.
  * <p>
- * A verification result is either a {@link Success} or a {@link Failure}.
+ * A result is either a {@link Success} or a {@link Failure}. {@link VerificationStrategy#verify}
+ * always returns one of these two variants — it never throws. {@link GroupVerifications#verify}
+ * consumes the result to drive two state transitions: the {@link VerificationChallenge} moves to
+ * {@link ChallengeState#VERIFIED} on success or remains {@link ChallengeState#UNVERIFIED} on
+ * failure; the {@link GroupVerification} moves to {@link VerificationState#ACTIVE} on success or
+ * remains {@link VerificationState#PENDING} on failure.
+ * <p>
+ * Callers discriminate between the two variants using pattern matching on the sealed type:
+ * <pre>{@code
+ * VerificationResult result = strategy.verify(verification, challenge);
+ * if (result instanceof VerificationResult.Success success) {
+ *     // activate the claim
+ * } else if (result instanceof VerificationResult.Failure failure) {
+ *     // inspect failure.reason()
+ * }
+ * }</pre>
  *
  * @author Mila Zarkovic
+ * @since 1.0.0
+ * @see VerificationStrategy
+ * @see GroupVerifications
+ * @see VerificationChallenge
  */
 public sealed interface VerificationResult permits VerificationResult.Success, VerificationResult.Failure {
 
 	/**
 	 * Creates a successful verification result.
+	 * <p>
+	 * The {@code method} argument must match the {@link VerificationChallenge#method()} of the
+	 * challenge being verified. {@link GroupVerifications} asserts this at the point of consumption
+	 * to catch strategy implementations that accidentally return a result for the wrong method.
 	 *
-	 * @param method the {@link VerificationMethod} that successfully verified ownership
-	 * @return a successful verification result
+	 * @param method the {@link VerificationMethod} that confirmed ownership
+	 * @return a successful verification result; never {@literal null}
 	 */
 	@NonNull
 	static Success success(@NonNull VerificationMethod method) {
@@ -23,10 +46,14 @@ public sealed interface VerificationResult permits VerificationResult.Success, V
 	}
 
 	/**
-	 * Creates a failed verification result using a predefined {@link FailureReason}.
+	 * Creates a failed verification result from a standardised {@link FailureReason}.
+	 * <p>
+	 * The reason is stored as {@link FailureReason#name()}, so callers can round-trip
+	 * {@link Failure#reason()} back to a {@link FailureReason} via {@link FailureReason#valueOf}.
+	 * Prefer this overload over {@link #failure(String)} whenever a predefined reason applies.
 	 *
-	 * @param reason the failure reason enum value
-	 * @return a failed verification result
+	 * @param reason the standardized failure reason
+	 * @return a failed verification result; never {@literal null}
 	 */
 	@NonNull
 	static Failure failure(@NonNull FailureReason reason) {
@@ -34,13 +61,14 @@ public sealed interface VerificationResult permits VerificationResult.Success, V
 	}
 
 	/**
-	 * Creates a failed verification result using a custom reason string.
+	 * Creates a failed verification result with a custom reason string.
 	 * <p>
-	 * This overload allows strategies to provide additional context beyond the predefined
-	 * {@link FailureReason} values.
+	 * Use this overload only when none of the predefined {@link FailureReason} values accurately
+	 * describes the failure. A free-form reason is opaque to callers that attempt to parse it as a
+	 * {@link FailureReason} — prefer {@link #failure(FailureReason)} whenever possible.
 	 *
-	 * @param reason a failure reason
-	 * @return a failed verification result
+	 * @param reason a free-form, machine-readable description of the failure
+	 * @return a failed verification result; never {@literal null}
 	 */
 	@NonNull
 	static Failure failure(@NonNull String reason) {
@@ -48,39 +76,61 @@ public sealed interface VerificationResult permits VerificationResult.Success, V
 	}
 
 	/**
-	 * Represents a successful verification outcome.
+	 * Successful verification outcome.
+	 * <p>
+	 * Carries the {@link VerificationMethod} that confirmed ownership so that
+	 * {@link GroupVerifications} can assert the strategy's result is consistent with the
+	 * {@link VerificationChallenge} it was asked to verify.
 	 *
-	 * @param method the verification method that succeeded
+	 * @param method the verification method that confirmed ownership; never {@literal null}
 	 */
 	record Success(@NonNull VerificationMethod method) implements VerificationResult {
 	}
 
 	/**
-	 * Represents a failed verification outcome.
+	 * Failed verification outcome.
 	 * <p>
-	 * The failure is represented as a string to allow both structured
-	 * {@link FailureReason} values and custom failure descriptions.
+	 * The reason is a machine-readable string. When constructed via {@link #failure(FailureReason)},
+	 * it equals {@link FailureReason#name()} and can be round-tripped back to the enum via
+	 * {@link FailureReason#valueOf}. When constructed via {@link #failure(String)}, it is an
+	 * arbitrary string and no such guarantee holds.
 	 *
-	 * @param reason machine-readable reason for failure
+	 * @param reason machine-readable description of the failure; never {@literal null}
 	 */
 	record Failure(@NonNull String reason) implements VerificationResult {
 	}
 
 	/**
-	 * Standardized set of failure reasons that can occur during verification.
+	 * Standardised set of failure reasons returned by {@link VerificationStrategy} implementations.
 	 * <p>
-	 * Strategies should map external errors (HTTP, DNS, API responses, etc.)
-	 * into these values whenever possible to ensure consistent behavior across
-	 * verification mechanisms.
+	 * Strategies must prefer these values over free-form strings so that callers can handle failures
+	 * consistently regardless of which verification mechanism produced them. Values serialize to
+	 * their {@link #name()} when stored in a {@link Failure#reason()}.
 	 */
 	enum FailureReason {
-		/** The challenge token was not found in the verification target. */
+		/**
+		 * The verification target was reachable but did not contain the expected challenge token.
+		 * Distinguishable from {@link #TARGET_NOT_FOUND}: the target exists, the token is simply
+		 * absent or wrong.
+		 */
 		TOKEN_MISMATCH,
-		/** The verification target (e.g. DNS record, file) could not be found. */
+
+		/**
+		 * The verification target (e.g. DNS record, repository) could not be found. The namespace
+		 * owner has not yet set up the required proof at the expected location.
+		 */
 		TARGET_NOT_FOUND,
-		/** The verification service is temporarily unavailable. */
+
+		/**
+		 * The external verification service is temporarily unavailable. This is a transient
+		 * condition, retrying after a delay may succeed.
+		 */
 		SERVICE_UNAVAILABLE,
-		/** An unexpected error occurred during verification. */
+
+		/**
+		 * An unexpected error occurred during verification that is not covered by the other reasons.
+		 * Unlike {@link #SERVICE_UNAVAILABLE}, this does not indicate a retryable condition.
+		 */
 		INTERNAL_ERROR,
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationState.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationState.java
@@ -10,6 +10,7 @@ import java.util.List;
  * Lifecycle state of a group verification claim.
  *
  * @author Vitalii Kushnir
+ * @since 1.0.0
  */
 public enum VerificationState {
 	/**

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationStrategies.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationStrategies.java
@@ -25,6 +25,7 @@ import java.util.stream.StreamSupport;
  * that class closed to changes when new {@link VerificationMethod} values are added.
  *
  * @author Vladimir Spasic
+ * @since 1.0.0
  * @see VerificationStrategy
  * @see VerificationMethod
  */

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationStrategy.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/VerificationStrategy.java
@@ -3,18 +3,27 @@ package com.konfigyr.artifactory.ownership;
 import org.jspecify.annotations.NullMarked;
 
 /**
- * Defines a strategy for verifying ownership of a {@code groupId} using a specific verification mechanism.
+ * SPI for proving ownership of a Maven {@code groupId} using a specific verification mechanism.
  * <p>
- * Implementations encapsulate different verification approaches (e.g. DNS TXT records, source code hosting
- * providers, etc.), each identified by a {@link VerificationMethod}.
+ * Each implementation encapsulates one verification approach (e.g. DNS {@code TXT} record lookup,
+ * source code repository existence check) and is identified by the {@link VerificationMethod} it
+ * returns from {@link #method()}. At most one implementation per method may be registered; the
+ * {@link VerificationStrategies} registry enforces this at startup and throws
+ * {@link IllegalArgumentException} on a duplicate.
  * <p>
- * A strategy receives a {@link GroupVerification} request and a {@link VerificationChallenge}, and must
- * return a {@link VerificationResult} indicating whether verification succeeded or failed, including
- * a reason in case of failure.
+ * Implementations must be registered as Spring beans. {@link VerificationStrategies} collects all
+ * {@link VerificationStrategy} beans automatically and selects the correct one by matching
+ * {@link #method()} to the {@link VerificationChallenge#method()} of the active challenge.
+ * <p>
+ * The {@link #verify(GroupVerification, VerificationChallenge)} contract requires that
+ * implementations never throw: all external failures like DNS timeouts, HTTP errors, connection
+ * problems; must be caught and mapped to an appropriate {@link VerificationResult.Failure}.
  *
  * @author Mila Zarkovic
+ * @since 1.0.0
  * @see VerificationMethod
  * @see VerificationResult
+ * @see VerificationStrategies
  * @see GroupVerification
  * @see VerificationChallenge
  */
@@ -22,25 +31,42 @@ import org.jspecify.annotations.NullMarked;
 public interface VerificationStrategy {
 
 	/**
-	 * Returns the verification method supported by this strategy.
+	 * Returns the {@link VerificationMethod} handled by this strategy.
 	 * <p>
-	 * This is used to route verification requests to the appropriate implementation.
+	 * This value is the dispatch key used by {@link VerificationStrategies} to select the correct
+	 * implementation. Each registered strategy must return a unique method — duplicates are rejected
+	 * at startup.
 	 *
-	 * @return the {@link VerificationMethod} handled by this strategy
+	 * @return the verification method handled by this strategy; never {@literal null}
 	 */
 	VerificationMethod method();
 
 	/**
-	 * Executes verification of a {@code groupId} using the provided challenge.
+	 * Executes the ownership proof for the given verification using the supplied challenge token.
 	 * <p>
-	 * The implementation should perform the necessary external checks (e.g. DNS lookup,
-	 * HTTP request to a repository hosting API, etc.) and return a {@link VerificationResult}
-	 * describing the outcome.
+	 * The implementation must perform the external check appropriate for its {@link VerificationMethod}
+	 * — for example a DNS {@code TXT} record lookup or an HTTP request to a repository hosting API —
+	 * and map the outcome to a {@link VerificationResult}.
+	 * <p>
+	 * <strong>Implementations must never throw.</strong> All external errors must be caught and
+	 * returned as a {@link VerificationResult.Failure}. Use the standardised
+	 * {@link VerificationResult.FailureReason} values whenever possible:
+	 * <ul>
+	 *     <li>{@link VerificationResult.FailureReason#TOKEN_MISMATCH} — the target was reachable but
+	 *     did not carry the expected token.</li>
+	 *     <li>{@link VerificationResult.FailureReason#TARGET_NOT_FOUND} — the verification target
+	 *     (DNS record, repository) does not exist.</li>
+	 *     <li>{@link VerificationResult.FailureReason#SERVICE_UNAVAILABLE} — the external service
+	 *     is temporarily unreachable.</li>
+	 *     <li>{@link VerificationResult.FailureReason#INTERNAL_ERROR} — any other unexpected
+	 *     failure.</li>
+	 * </ul>
+	 * A free-form string reason may be used only when none of the above values apply.
 	 *
-	 * @param verification the verification request containing the target group and metadata
-	 * @param challenge the challenge data used to prove ownership
-	 * @return the result of the verification attempt
+	 * @param verification the ownership claim containing the target {@code groupId} and metadata
+	 * @param challenge    the challenge holding the token to match against the external target
+	 * @return a {@link VerificationResult.Success} when the token is confirmed, or a
+	 *         {@link VerificationResult.Failure} describing why the check did not pass
 	 */
 	VerificationResult verify(GroupVerification verification, VerificationChallenge challenge);
 }
-

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/controller/GroupVerificationsController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/controller/GroupVerificationsController.java
@@ -1,33 +1,23 @@
 package com.konfigyr.artifactory.ownership.controller;
 
-import com.konfigyr.artifactory.ownership.GroupVerification;
-import com.konfigyr.artifactory.ownership.GroupVerificationNotFoundException;
-import com.konfigyr.artifactory.ownership.GroupVerifications;
-import com.konfigyr.artifactory.ownership.Owner;
-import com.konfigyr.artifactory.ownership.OwnerNotFoundException;
-import com.konfigyr.artifactory.ownership.OwnerResolver;
-import com.konfigyr.artifactory.ownership.VerificationChallenge;
-import com.konfigyr.artifactory.ownership.VerificationMethod;
+import com.konfigyr.artifactory.ownership.*;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.hateoas.CollectionModel;
 import com.konfigyr.hateoas.EntityModel;
+import com.konfigyr.hateoas.PagedModel;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
+import com.konfigyr.support.SearchQuery;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -43,10 +33,21 @@ public class GroupVerificationsController {
 	@GetMapping
 	@PreAuthorize("isAdmin(#namespace)")
 	@RequiresScope(OAuthScope.READ_NAMESPACES)
-	public CollectionModel<EntityModel<GroupVerification>> getGroupVerifications(@PathVariable String namespace) {
+	public PagedModel<EntityModel<GroupVerification>> getGroupVerifications(
+			@PathVariable String namespace,
+			@Nullable @RequestParam(required = false) String term,
+			@Nullable @RequestParam(required = false) VerificationState state,
+			Pageable pageable
+	) {
 		final Owner owner = resolveOwner(namespace);
-		final List<GroupVerification> verifications = groupVerifications.findByOwner(owner);
-		return assembler(namespace).groupVerification().assemble(verifications);
+
+		final SearchQuery query = SearchQuery.builder()
+				.pageable(pageable)
+				.term(term)
+				.criteria(GroupVerification.STATE_CRITERIA, state)
+				.build();
+
+		return assembler(namespace).groupVerification().assemble(groupVerifications.findByOwner(owner, query));
 	}
 
 	@GetMapping("/{groupId}")
@@ -54,7 +55,7 @@ public class GroupVerificationsController {
 	@RequiresScope(OAuthScope.READ_NAMESPACES)
 	public EntityModel<GroupVerification> getGroupVerification(@PathVariable String namespace, @PathVariable String groupId) {
 		final Owner owner = resolveOwner(namespace);
-		final GroupVerification verification = groupVerifications.findByGroupId(groupId, owner)
+		final GroupVerification verification = groupVerifications.findByGroupId(owner, groupId)
 				.orElseThrow(() -> new GroupVerificationNotFoundException(owner, groupId));
 		return assembler(namespace).groupVerification().assemble(verification);
 	}
@@ -76,7 +77,7 @@ public class GroupVerificationsController {
 	@RequiresScope(OAuthScope.READ_NAMESPACES)
 	public CollectionModel<EntityModel<VerificationChallenge>> getVerificationChallenges(@PathVariable String namespace, @PathVariable  EntityId verificationId) {
 		final Owner owner = resolveOwner(namespace);
-		final List<VerificationChallenge> verificationChallenges = groupVerifications.findChallenges(verificationId, owner);
+		final List<VerificationChallenge> verificationChallenges = groupVerifications.findChallenges(owner, verificationId);
 		return assembler(namespace).verificationChallenge().assemble(verificationChallenges);
 	}
 
@@ -100,7 +101,7 @@ public class GroupVerificationsController {
 	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
 	public void revoke(@PathVariable String namespace, @PathVariable String groupId) {
 		final Owner owner = resolveOwner(namespace);
-		final GroupVerification verification = groupVerifications.findByGroupId(groupId, owner)
+		final GroupVerification verification = groupVerifications.findByGroupId(owner, groupId)
 				.orElseThrow(() -> new GroupVerificationNotFoundException(owner, groupId));
 		groupVerifications.revoke(verification);
 	}

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/DefaultGroupVerificationsTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/DefaultGroupVerificationsTest.java
@@ -1,13 +1,17 @@
 package com.konfigyr.artifactory.ownership;
 
 import com.konfigyr.entity.EntityId;
+import com.konfigyr.support.SearchQuery;
 import com.konfigyr.test.AbstractIntegrationTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedConstruction;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.UUID;
+
 import org.springframework.dao.DuplicateKeyException;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +37,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	void shouldFundActiveCoveringByIdAndOwner() {
 		final var owner = Owner.of(EntityId.from(2), "konfigyr");
 		final var groupId = "com.konfigyr";
-		final var result = verifications.findActiveCovering(groupId, owner);
+		final var result = verifications.findActiveCovering(owner, groupId);
 
 		assertThat(result)
 				.isPresent()
@@ -51,7 +55,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	void shouldReturnEmptyResultForUnrelatedGroupId() {
 		final var owner = Owner.of(EntityId.from(2), "konfigyr");
 		final var groupId = "com.config";
-		final var result = verifications.findActiveCovering(groupId, owner);
+		final var result = verifications.findActiveCovering(owner, groupId);
 
 		assertThat(result).isEmpty();
 	}
@@ -60,7 +64,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@DisplayName("should find covering by owner")
 	void shouldFindCoveringByOwner() {
 		final var owner = Owner.of(EntityId.from(1), "john-doe");
-		final var result = verifications.findByOwner(owner);
+		final var result = verifications.findByOwner(owner, SearchQuery.of(Pageable.ofSize(10)));
 
 		assertThat(result.stream())
 				.hasSize(2)
@@ -69,11 +73,93 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("should find claims by owner filtered by state")
+	void shouldFindByOwnerFilteredByState() {
+		final var owner = Owner.of(EntityId.from(1), "john-doe");
+
+		final var pending = verifications.findByOwner(owner, SearchQuery.builder()
+				.pageable(Pageable.ofSize(10))
+				.criteria(GroupVerification.STATE_CRITERIA, VerificationState.PENDING)
+				.build());
+
+		assertThat(pending.stream())
+				.hasSize(1)
+				.extracting(GroupVerification::id)
+				.containsExactly(EntityId.from(3));
+
+		final var failed = verifications.findByOwner(owner, SearchQuery.builder()
+				.pageable(Pageable.ofSize(10))
+				.criteria(GroupVerification.STATE_CRITERIA, VerificationState.FAILED)
+				.build());
+
+		assertThat(failed.stream())
+				.hasSize(1)
+				.extracting(GroupVerification::id)
+				.containsExactly(EntityId.from(2));
+	}
+
+	@Test
+	@DisplayName("should find claims by owner filtered by search term")
+	void shouldFindByOwnerFilteredByTerm() {
+		final var owner = Owner.of(EntityId.from(1), "john-doe");
+
+		final var both = verifications.findByOwner(owner, SearchQuery.builder()
+				.pageable(Pageable.ofSize(10))
+				.term("springframework")
+				.build());
+
+		assertThat(both.stream())
+				.hasSize(2)
+				.extracting(GroupVerification::id)
+				.contains(EntityId.from(2), EntityId.from(3));
+
+		final var one = verifications.findByOwner(owner, SearchQuery.builder()
+				.pageable(Pageable.ofSize(10))
+				.term("boot")
+				.build());
+
+		assertThat(one.stream())
+				.hasSize(1)
+				.extracting(GroupVerification::groupId)
+				.containsExactly("org.springframework.boot");
+	}
+
+	@Test
+	@DisplayName("should return empty page when no claims match state filter")
+	void shouldReturnEmptyPageForUnmatchedStateFilter() {
+		final var owner = Owner.of(EntityId.from(1), "john-doe");
+
+		final var result = verifications.findByOwner(owner, SearchQuery.builder()
+				.pageable(Pageable.ofSize(10))
+				.criteria(GroupVerification.STATE_CRITERIA, VerificationState.ACTIVE)
+				.build());
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should find claims by owner filtered by state and search term")
+	void shouldFindByOwnerFilteredByStateAndTerm() {
+		final var owner = Owner.of(EntityId.from(1), "john-doe");
+
+		final var result = verifications.findByOwner(owner, SearchQuery.builder()
+				.pageable(Pageable.ofSize(10))
+				.term("springframework")
+				.criteria(GroupVerification.STATE_CRITERIA, VerificationState.PENDING)
+				.build());
+
+		assertThat(result.stream())
+				.hasSize(1)
+				.extracting(GroupVerification::groupId)
+				.containsExactly("org.springframework.boot");
+	}
+
+	@Test
 	@DisplayName("should find covering by group id")
 	void shouldFindCoveringByGroupId() {
 		final var owner = Owner.of(EntityId.from(1), "john-doe");
 		final var groupId = "org.springframework.boot";
-		final var result = verifications.findByGroupId(groupId, owner);
+		final var result = verifications.findByGroupId(owner, groupId);
 
 		assertThat(result)
 				.isPresent()
@@ -100,7 +186,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 		assertThat(result)
 				.isPresent()
 				.get()
-				.returns(EntityId.from(3L), VerificationChallenge::id)
+				.returns(UUID.fromString("018f4c2a-1b3f-7e5f-9a6b-7c8d9e0f1a2d"), VerificationChallenge::id)
 				.returns(ChallengeState.UNVERIFIED, VerificationChallenge::state)
 				.returns(VerificationMethod.DNS, VerificationChallenge::method);
 	}
@@ -111,7 +197,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	void findAnyOverlapping() {
 		final var owner = Owner.of(EntityId.from(2), "konfigyr");
 		final var groupId = "com.konfigyr";
-		final var verification = verifications.findActiveCovering(groupId, owner);
+		final var verification = verifications.findActiveCovering(owner, groupId);
 
 		assertThat(verification).isPresent();
 
@@ -233,7 +319,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 
 		assertThatThrownBy(() -> verifications.revoke(revokedResult))
 				.isInstanceOf(IllegalStateException.class)
-				.hasMessageContaining("Cannot revoke a \"REVOKED\" verification");
+				.hasMessage("Can only revoke an active groupId verification, but it was in a '%s' state", VerificationState.REVOKED);
 	}
 
 	@Test
@@ -300,7 +386,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 				.isNotNull()
 				.actual();
 
-		assertThat(verifications.findChallenges(pendingVerification.id(), owner))
+		assertThat(verifications.findChallenges(owner, pendingVerification.id()))
 				.hasSize(1)
 				.first()
 				.returns(VerificationMethod.DNS, VerificationChallenge::method)
@@ -312,7 +398,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 					.returns(null, GroupVerification::verifiedAt)
 					.returns(VerificationState.PENDING, GroupVerification::state);
 
-			assertThat(verifications.findChallenges(pendingVerification.id(), owner))
+			assertThat(verifications.findChallenges(owner, pendingVerification.id()))
 					.hasSize(1)
 					.first()
 					.returns(ChallengeState.UNVERIFIED, VerificationChallenge::state);
@@ -330,7 +416,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 				.isNotNull()
 				.actual();
 
-		final var activeVerificationChallenge = assertThat(verifications.findChallenges(pendingVerification.id(), owner))
+		final var activeVerificationChallenge = assertThat(verifications.findChallenges(owner, pendingVerification.id()))
 				.hasSize(1)
 				.first()
 				.returns(VerificationMethod.SOURCE_CODE, VerificationChallenge::method)
@@ -346,7 +432,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 				.returns(null, GroupVerification::verifiedAt)
 				.returns(VerificationState.PENDING, GroupVerification::state);
 
-		assertThat(verifications.findChallenges(pendingVerification.id(), owner))
+		assertThat(verifications.findChallenges(owner, pendingVerification.id()))
 				.hasSize(1)
 				.first()
 				.returns(ChallengeState.UNVERIFIED, VerificationChallenge::state);

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/DnsTxtVerificationStrategyTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/DnsTxtVerificationStrategyTest.java
@@ -12,6 +12,8 @@ import javax.naming.NamingException;
 import javax.naming.ServiceUnavailableException;
 import javax.naming.directory.InitialDirContext;
 
+import java.util.UUID;
+
 import static com.konfigyr.artifactory.ownership.VerificationResult.FailureReason.*;
 import static com.konfigyr.artifactory.ownership.VerificationStrategyTestUtils.mockDnsException;
 import static org.assertj.core.api.Assertions.*;
@@ -139,6 +141,7 @@ class DnsTxtVerificationStrategyTest {
 
 	private static GroupVerification verification(String groupId) {
 		return GroupVerification.builder()
+				.id(1L)
 				.owner(Owner.of(EntityId.from(1L), "test-namespace"))
 				.groupId(groupId)
 				.state(VerificationState.PENDING)
@@ -147,6 +150,8 @@ class DnsTxtVerificationStrategyTest {
 
 	private static VerificationChallenge challenge(String token) {
 		return VerificationChallenge.builder()
+				.id(UUID.randomUUID())
+				.verificationId(EntityId.from(1L))
 				.method(VerificationMethod.DNS)
 				.token(token)
 				.state(ChallengeState.UNVERIFIED)

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/SourceCodeVerificationStrategyTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/SourceCodeVerificationStrategyTest.java
@@ -9,6 +9,7 @@ import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
 import java.io.IOException;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
@@ -85,37 +86,38 @@ class SourceCodeVerificationStrategyTest {
 	@Test
 	@DisplayName("should return SERVICE_UNAVAILABLE on any 5xx error")
 	void verifyInternalErrorOn5xx() {
-		server.expect(requestTo("https://api.github.com/repos/alice/kfgyr-test-token"))
+		server.expect(requestTo("https://api.github.com/repos/alice/kfgyr-500-error-token"))
 				.andRespond(withServerError());
 
-		assertThat(strategy.verify(verification("io.github.alice"), challenge("test-token")))
+		assertThat(strategy.verify(verification("io.github.alice"), challenge("500-error-token")))
 				.isEqualTo(VerificationResult.failure(VerificationResult.FailureReason.SERVICE_UNAVAILABLE));
 	}
 
 	@Test
 	@DisplayName("should return INTERNAL_ERROR on unexpected 4xx error")
 	void verifyInternalErrorOn4xx() {
-		server.expect(requestTo("https://api.github.com/repos/alice/kfgyr-test-token"))
+		server.expect(requestTo("https://api.github.com/repos/alice/kfgyr-400-error-token"))
 				.andRespond(withStatus(HttpStatus.FORBIDDEN));
 
-		assertThat(strategy.verify(verification("io.github.alice"), challenge("test-token")))
+		assertThat(strategy.verify(verification("io.github.alice"), challenge("400-error-token")))
 				.isEqualTo(VerificationResult.failure(VerificationResult.FailureReason.INTERNAL_ERROR));
 	}
 
 	@Test
 	@DisplayName("should return INTERNAL_ERROR on connection failure")
 	void verifyInternalErrorOnConnectionFailure() {
-		server.expect(requestTo("https://api.github.com/repos/alice/kfgyr-test-token"))
+		server.expect(requestTo("https://api.github.com/repos/alice/kfgyr-error-token"))
 				.andRespond(_ -> {
 					throw new IOException("Connection refused");
 				});
 
-		assertThat(strategy.verify(verification("io.github.alice"), challenge("test-token")))
+		assertThat(strategy.verify(verification("io.github.alice"), challenge("error-token")))
 				.isEqualTo(VerificationResult.failure(VerificationResult.FailureReason.INTERNAL_ERROR));
 	}
 
 	private static GroupVerification verification(String groupId) {
 		return GroupVerification.builder()
+				.id(1L)
 				.owner(Owner.of(EntityId.from(1L), "test-namespace"))
 				.groupId(groupId)
 				.state(VerificationState.PENDING)
@@ -124,6 +126,8 @@ class SourceCodeVerificationStrategyTest {
 
 	private static VerificationChallenge challenge(String token) {
 		return VerificationChallenge.builder()
+				.id(UUID.randomUUID())
+				.verificationId(EntityId.from(1L))
 				.method(VerificationMethod.SOURCE_CODE)
 				.token(token)
 				.state(ChallengeState.UNVERIFIED)

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/controller/GroupVerificationsControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/controller/GroupVerificationsControllerTest.java
@@ -60,6 +60,100 @@ class GroupVerificationsControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@DisplayName("should list claims for a namespace filtered by state")
+	void shouldListClaimsFilteredByState() {
+		mvc.get().uri("/namespaces/{namespace}/group-verifications?state=PENDING", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(collectionModel(GroupVerification.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(GroupVerification::groupId, GroupVerification::state)
+						.containsExactly(tuple("org.springframework.boot", VerificationState.PENDING)));
+	}
+
+	@Test
+	@DisplayName("should list claims for a namespace filtered by search term")
+	void shouldListClaimsFilteredByTerm() {
+		mvc.get().uri("/namespaces/{namespace}/group-verifications?term=ai", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(collectionModel(GroupVerification.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(GroupVerification::groupId, GroupVerification::state)
+						.containsExactly(tuple("org.springframework.ai", VerificationState.FAILED)));
+	}
+
+	@Test
+	@DisplayName("should list claims for a namespace filtered by state and search term")
+	void shouldListClaimsFilteredByStateAndTerm() {
+		mvc.get().uri("/namespaces/{namespace}/group-verifications?term=springframework&state=PENDING", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(collectionModel(GroupVerification.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(GroupVerification::groupId, GroupVerification::state)
+						.containsExactly(tuple("org.springframework.boot", VerificationState.PENDING)));
+	}
+
+	@Test
+	@DisplayName("should list claims sorted by groupId ascending")
+	void shouldListClaimsSortedByGroupAscending() {
+		mvc.get().uri("/namespaces/{namespace}/group-verifications?sort=group,asc", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(collectionModel(GroupVerification.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(GroupVerification::groupId)
+						.containsExactly("org.springframework.ai", "org.springframework.boot"));
+	}
+
+	@Test
+	@DisplayName("should list claims sorted by groupId descending")
+	void shouldListClaimsSortedByGroupDescending() {
+		mvc.get().uri("/namespaces/{namespace}/group-verifications?sort=group,desc", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(collectionModel(GroupVerification.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(GroupVerification::groupId)
+						.containsExactly("org.springframework.boot", "org.springframework.ai"));
+	}
+
+	@Test
+	@DisplayName("should return empty page when no claims match the filter")
+	void shouldReturnEmptyPageForUnmatchedFilter() {
+		mvc.get().uri("/namespaces/{namespace}/group-verifications?state=ACTIVE", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(collectionModel(GroupVerification.class))
+				.satisfies(it -> assertThat(it.getContent()).isEmpty());
+	}
+
+	@Test
 	@DisplayName("should submit a new verification claim")
 	@Transactional
 	void shouldSubmitNewVerificationClaim() {

--- a/konfigyr-data/src/main/resources/migrations/artifactory/artifactory-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/artifactory/artifactory-1.0.0.xml
@@ -284,7 +284,7 @@
 		<comment>Initial group verification challenges table migration</comment>
 
 		<createTable tableName="group_verification_challenges">
-			<column name="id" type="bigint" autoIncrement="true">
+			<column name="id" type="uuid" defaultValueComputed="uuidv7()">
 				<constraints primaryKey="true" nullable="false" />
 			</column>
 
@@ -325,33 +325,34 @@
 				referencedColumnNames="id"
 				onDelete="CASCADE"
 		/>
+		
+		<addUniqueConstraint
+				constraintName="unique_group_verification_challenge"
+				tableName="group_verifications"
+				columnNames="namespace_id, group_id"
+		/>
 
 		<createIndex tableName="group_verification_challenges" indexName="idx_group_verification_challenges_verification_id">
 			<column name="group_verification_id" />
 		</createIndex>
 	</changeSet>
 
-	<changeSet author="vitalii.kushnir" id="1.0.0-group-verifications-active-unique-idx" context="api">
+	<changeSet author="vitalii.kushnir" id="1.0.0-idx_unique_active_group_verification" context="api">
 		<sql>
-			CREATE UNIQUE INDEX group_verifications_active_group_id_idx
+			CREATE UNIQUE INDEX idx_unique_active_group_verification
 				ON group_verifications (group_id)
 				WHERE state = 'ACTIVE';
 		</sql>
+		<rollback>DROP INDEX idx_unique_active_group_verification;</rollback>
 	</changeSet>
 
-	<changeSet author="vitalii.kushnir" id="1.0.0-group-verifications-namespace-group-id-unique-idx" context="api">
+	<changeSet author="vitalii.kushnir" id="1.0.0-idx_unique_unverified_group_verification_challenge" context="api">
 		<sql>
-			CREATE UNIQUE INDEX group_verifications_namespace_group_id_idx
-				ON group_verifications (namespace_id, group_id);
-		</sql>
-	</changeSet>
-
-	<changeSet author="vitalii.kushnir" id="1.0.0-group_verification_challenges_unverified_group_verification_id_idx" context="api">
-		<sql>
-			CREATE UNIQUE INDEX group_verification_challenges_unverified_group_verification_id_idx
+			CREATE UNIQUE INDEX idx_unique_unverified_group_verification_challenge
 				ON group_verification_challenges (group_verification_id)
 				WHERE state = 'UNVERIFIED';
 		</sql>
+		<rollback>DROP INDEX idx_unique_unverified_group_verification_challenge;</rollback>
 	</changeSet>
 
 </databaseChangeLog>

--- a/konfigyr-test/src/main/resources/data/artifactory.sql
+++ b/konfigyr-test/src/main/resources/data/artifactory.sql
@@ -74,13 +74,11 @@ INSERT INTO group_verifications(id, namespace_id, group_id, state, created_at, v
 (3, 1, 'org.springframework.boot', 'PENDING', now() - interval '2 days', NULL, NULL);
 
 INSERT INTO group_verification_challenges(id, group_verification_id, verification_method, challenge_token, state, created_at, verified_at, expires_at) VALUES
-(1, 1, 'GITHUB', 'gh-verified-token-1', 'VERIFIED', now() - interval '7 days', now() - interval '6 days', NULL),
-(2, 2, 'DNS', 'dns-failed-token-1', 'UNVERIFIED', now() - interval '3 days', NULL, null),
-(3, 3, 'DNS', 'dns-pending-token-1', 'UNVERIFIED', now() - interval '2 days', NULL, null);
+('018f4c2a-1b3d-7e5f-9a6b-7c8d9e0f1a2b', 1, 'GITHUB', 'gh-verified-token-1', 'VERIFIED', now() - interval '7 days', now() - interval '6 days', NULL),
+('018f4c2a-1b3e-7e5f-9a6b-7c8d9e0f1a2c', 2, 'DNS', 'dns-failed-token-1', 'UNVERIFIED', now() - interval '3 days', NULL, null),
+('018f4c2a-1b3f-7e5f-9a6b-7c8d9e0f1a2d', 3, 'DNS', 'dns-pending-token-1', 'UNVERIFIED', now() - interval '2 days', NULL, null);
 
 /** updates the auto-increment sequences to start at 1000 **/
 ALTER SEQUENCE artifacts_id_seq RESTART with 1000;
 ALTER SEQUENCE artifact_versions_id_seq RESTART with 1000;
 ALTER SEQUENCE property_definitions_id_seq RESTART with 1000;
-ALTER SEQUENCE group_verifications_id_seq RESTART with 1000;
-ALTER SEQUENCE group_verification_challenges_id_seq RESTART with 1000;


### PR DESCRIPTION
### Summary

  - Replaces Lombok @Builder(toBuilder = true) with hand-written builders on GroupVerification and VerificationChallenge, following the Namespace builder convention
  - Adds `SearchQuery`-based filtering (by state and search term) and group-column sorting to `GroupVerifications#findByOwner` and the `GET /namespaces/{namespace}/group-verifications` endpoint
  - Migrates `group_verification_challenges.id` seed data from `bigint` to `UUID v7`
  - Comprehensive Javadoc pass over the entire ownership subdomain

### Changes in detail

#### Hand-written builders on domain records
  - `GroupVerification` and `VerificationChallenge` now use explicit `Builder` inner classes with: private constructors, `@Nullable`-annotated fields, `build()` with Assert guards on required fields, and a `toBuilder()` method for producing modified copies
  - Lombok `@Builder` and its generated `delombok` output are removed from both types

#### `findByOwner` filtering and sorting
  - `GroupVerifications#findByOwner` now accepts a `SearchQuery` and returns `Page<GroupVerification>`
  - `DefaultGroupVerifications` applies `GROUP_ID ILIKE %term%` for the search term and an equality filter for `GroupVerification.STATE_CRITERIA`

#### Seed data
  - `group_verification_challenges` integer PKs replaced with `UUID v7` values to match the actual column type `(UUID DEFAULT gen_random_uuid())`
  - Sequence restart for that table removed from the SQL seed

#### Javadocs
  - `GroupVerifications`: class-level lifecycle walkthrough, prefix-inheritance model explained, both conflict directions named in findAnyOverlapping, challenge token retrieval gap documented in claim, transient vs. permanent failure distinction added to verify, valid revocable states
  named in revoke, @throws added throughout
  - `VerificationStrategy`: SPI role, bean registration and automatic collection, uniqueness constraint, and the no-throw contract with FailureReason preference hierarchy
  - `VerificationResult`: pattern-matching guidance, name()/valueOf round-trip contract on Failure.reason, and per-constant clarifications distinguishing TOKEN_MISMATCH (target reachable, wrong token) from TARGET_NOT_FOUND (target absent) and SERVICE_UNAVAILABLE (transient, retryable)
  from INTERNAL_ERROR (not retryable)
  - `GroupVerification`, `VerificationChallenge`, `VerificationStrategies`: lifecycle docs, nullability corrections, and @see cross-references

