### PR TITLE
Finish Publication naming cleanup in the Artifactory module

### DIFF
--- a/.claude/skills/shared/project-overview/SKILL.md
+++ b/.claude/skills/shared/project-overview/SKILL.md
@@ -198,7 +198,7 @@ and third-party integrations alike.
 | `ArtifactVersion` | Immutable snapshot of a specific release. Owns `PropertyOccurrence` links. |
 | `PropertyDescriptor` | Configuration property metadata: name, type, description, default, JSON Schema. |
 | `ArtifactMetadata` | Upload envelope — aggregates all `PropertyDescriptor`s for one artifact version. Uploaded by build plugins via REST. |
-| `Release` | Version change event with lifecycle: `PENDING → RELEASED → FAILED`. |
+| `Publication` | Version change event with lifecycle: `PENDING → PUBLISHED → FAILED`. |
 | `Manifest` | A Konfigyr service's current metadata state — used to detect property differences across environments. |
 | `ServiceManifest` | Relational link between a namespace-owned service and one or more artifact versions. Enables metadata reuse (shared library configs) across services. |
 
@@ -216,7 +216,7 @@ Artifactory module
   5. Compute Occurrence Checksum (schema + description + deprecation)
   6. Deduplicate: reuse existing PropertyOccurrence if checksum matches
   7. Create Version-to-Property links
-  8. Update Release status: PENDING → RELEASED
+  8. Update Publication status: PENDING → PUBLISHED
 ```
 
 ## API Contracts

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryEvent.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryEvent.java
@@ -92,7 +92,7 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent permits Artifa
 
 		/**
 		 * Create a new {@link PublicationCompleted} event with the {@link EntityId entity identifier} of the
-		 * {@link VersionedArtifact} that was successfully released by the {@link Artifactory}.
+		 * {@link VersionedArtifact} that was successfully published by the {@link Artifactory}.
 		 *
 		 * @param id entity identifier of the artifact version
 		 * @param coordinates the artifact coordinates of the artifact version
@@ -119,7 +119,7 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent permits Artifa
 
 		/**
 		 * Create a new {@link PublicationFailed} event with the {@link EntityId entity identifier} of the
-		 * {@link VersionedArtifact} that was could not be released by the {@link Artifactory}.
+		 * {@link VersionedArtifact} that was could not be published by the {@link Artifactory}.
 		 *
 		 * @param id entity identifier of the artifact version
 		 * @param coordinates the artifact coordinates of the artifact version

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/VersionedArtifact.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/VersionedArtifact.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * Value object representing a specific version of an {@link ArtifactDefinition}.
  * <p>
- * Each {@code VersionedArtifact} represents a single release or build of an {@link ArtifactDefinition},
+ * Each {@code VersionedArtifact} represents a single publication or build of an {@link ArtifactDefinition},
  * identified by its semantic version (e.g., {@code 1.0.0}) and a content checksum.
  * <p>
  * In DDD terms, it belongs to the {@link ArtifactDefinition} aggregate and does not exist
@@ -31,11 +31,11 @@ import java.util.List;
  * @param coordinates Maven coordinates of the artifact, can't be {@literal null}.
  * @param name human-readable name of the artifact, may be {@literal null}.
  * @param description textual description of the artifact, may be {@literal null}.
- * @param state current release state of the artifact version, can't be {@literal null}.
- * @param checksum checksum that uniquely identifying the contents of this release, may be {@literal null}.
+ * @param state current publication state of the artifact version, can't be {@literal null}.
+ * @param checksum checksum that uniquely identifying the contents of this publication, may be {@literal null}.
  * @param website external URL for documentation or homepage, may be {@literal null}.
  * @param repository source control repository reference (SCM URL), may be {@literal null}.
- * @param publishedAt timestamp when was this artifact version released, can be {@literal null}
+ * @param publishedAt timestamp when was this artifact version published, can be {@literal null}
  * @author Vladimir Spasic
  * @since 1.0.0
  */
@@ -206,14 +206,14 @@ public record VersionedArtifact(
 		}
 
 		/**
-		 * Specify when this {@link VersionedArtifact} was released.
+		 * Specify when this {@link VersionedArtifact} was published.
 		 *
-		 * @param releasedAt release date
+		 * @param publishedAt publish date
 		 * @return versioned artifact builder
 		 */
 		@NonNull
-		public Builder publishedAt(OffsetDateTime releasedAt) {
-			return this.publishedAt(releasedAt == null ? null : releasedAt.toInstant());
+		public Builder publishedAt(OffsetDateTime publishedAt) {
+			return this.publishedAt(publishedAt == null ? null : publishedAt.toInstant());
 		}
 
 		/**

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/batch/ArtifactoryBatchJobConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/batch/ArtifactoryBatchJobConfiguration.java
@@ -30,7 +30,7 @@ class ArtifactoryBatchJobConfiguration {
 			JobExecutionListener artifactoryJobExecutionListener
 	) {
 		return new JobBuilder(ArtifactoryJobNames.PUBLISH_JOB, repository)
-				.validator(createReleaseParametersValidator())
+				.validator(createPublicationParametersValidator())
 				.start(provenance)
 				.listener(artifactoryJobExecutionListener)
 				.build();
@@ -50,7 +50,7 @@ class ArtifactoryBatchJobConfiguration {
 		return new ArtifactoryJobListener(registry, operator);
 	}
 
-	static JobParametersValidator createReleaseParametersValidator() {
+	static JobParametersValidator createPublicationParametersValidator() {
 		return new DefaultJobParametersValidator(new String[] { "artifact" }, new String[0]);
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
@@ -16,7 +16,7 @@ interface Assemblers {
 
 	static RepresentationModelAssembler<VersionedArtifact, EntityModel<VersionedArtifact>> artifact(ArtifactCoordinates coordinates) {
 		return artifact -> EntityModel.of(artifact, linkBuilder(coordinates).selfRel())
-				.add(linkBuilder(coordinates).method(HttpMethod.POST).rel("release"))
+				.add(linkBuilder(coordinates).method(HttpMethod.POST).rel("publish"))
 				.add(linkBuilder(coordinates).method(HttpMethod.GET).rel("properties"));
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/provenance/ProvenanceEvaluator.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/provenance/ProvenanceEvaluator.java
@@ -19,7 +19,7 @@ import org.jspecify.annotations.NonNull;
 public interface ProvenanceEvaluator {
 
 	/**
-	 * Evaluates the {@link Provenance} for the {@link PropertyDescriptor} that was released under the
+	 * Evaluates the {@link Provenance} for the {@link PropertyDescriptor} that was published under the
 	 * given {@link VersionedArtifact artifact version}.
 	 *
 	 * @param version the artifact version that declared the property metadata, can't be {@literal null}.

--- a/konfigyr-test/src/main/resources/data/artifactory.sql
+++ b/konfigyr-test/src/main/resources/data/artifactory.sql
@@ -11,17 +11,17 @@ INSERT INTO artifacts(id, group_id, artifact_id, name, description, website, rep
 (10, 'org.springframework.modulith', 'spring-modulith-moments', 'Spring Modulith Moments', 'Modular monoliths with Spring Boot', 'https://spring.io/projects/spring-modulith/spring-modulith-moments', 'https://github.com/spring-projects-experimental/spring-modulith', now() - interval '10 days', now() - interval '9 days');
 
 INSERT INTO artifact_versions(id, artifact_id, version, state, checksum, released_at) VALUES
-(1, 1, '1.0.0', 'RELEASED', decode('lmUgkxFN4ru/3vuoTkcrYdf2Z5IfcSnmmtfnZJh+Lwo=', 'base64'), now() - interval '1 days'),
-(2, 2, '1.0.0', 'RELEASED', decode('/dDqvCohLTXiFVbzK9EPgoFqx7LMj/PHtd/5ycpeV8s=', 'base64'), now() - interval '7 days'),
-(3, 2, '1.0.1', 'RELEASED', decode('tBFMF6xGmSUIYo1skF45tzoCCN9WN026PdxUUBb4P7c=', 'base64'), now() - interval '3 days'),
-(4, 2, '1.0.2', 'RELEASED', decode('Z4ZfvHMxf2DwgPPzOpWR/F19myuTCvYVVN7WSf3vxTs=', 'base64'), now() - interval '1 days'),
-(5, 3, '1.0.0', 'RELEASED', decode('xWl6bKMwnQ1ZVs/CVKuoFufZACtb7oh5uebZr0T6txA=', 'base64'), now() - interval '2 days'),
-(6, 5, '1.0.0', 'RELEASED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '1 hours'),
-(7, 6, '4.0.4', 'RELEASED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '6 hours'),
-(8, 7, '4.0.4', 'RELEASED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '3 days'),
-(9, 8, '4.0.4', 'RELEASED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '2 days'),
-(10, 9, '2.0.4', 'RELEASED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '10 days'),
-(11, 10, '2.0.4', 'RELEASED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '10 days');
+(1, 1, '1.0.0', 'PUBLISHED', decode('lmUgkxFN4ru/3vuoTkcrYdf2Z5IfcSnmmtfnZJh+Lwo=', 'base64'), now() - interval '1 days'),
+(2, 2, '1.0.0', 'PUBLISHED', decode('/dDqvCohLTXiFVbzK9EPgoFqx7LMj/PHtd/5ycpeV8s=', 'base64'), now() - interval '7 days'),
+(3, 2, '1.0.1', 'PUBLISHED', decode('tBFMF6xGmSUIYo1skF45tzoCCN9WN026PdxUUBb4P7c=', 'base64'), now() - interval '3 days'),
+(4, 2, '1.0.2', 'PUBLISHED', decode('Z4ZfvHMxf2DwgPPzOpWR/F19myuTCvYVVN7WSf3vxTs=', 'base64'), now() - interval '1 days'),
+(5, 3, '1.0.0', 'PUBLISHED', decode('xWl6bKMwnQ1ZVs/CVKuoFufZACtb7oh5uebZr0T6txA=', 'base64'), now() - interval '2 days'),
+(6, 5, '1.0.0', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '1 hours'),
+(7, 6, '4.0.4', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '6 hours'),
+(8, 7, '4.0.4', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '3 days'),
+(9, 8, '4.0.4', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '2 days'),
+(10, 9, '2.0.4', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '10 days'),
+(11, 10, '2.0.4', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '10 days');
 
 INSERT INTO property_definitions(id, artifact_id, checksum, name, type_name, schema, default_value, description, deprecation, occurrences, first_seen, last_seen) VALUES
 (1, 2, decode('cRJ8jlPpTPmTJEoZEZNDSjvdqafG05QkzNJplXyu9J0=', 'base64'), 'spring.application.name', 'java.lang.String', convert_to('{"type":"string"}', 'UTF-8'), NULL, 'Application name. Typically used with logging to help identify the application.', NULL, 1, '1.0.1', '1.0.1'),


### PR DESCRIPTION
Several javadoc, method-name, and seed-data references to the artifact-version lifecycle still said "release" after the type was renamed to Publication. Realign them before new release-scoped service-manifest code lands on top of this module.