### PR TITLE
Rename `ServiceEvent.Published` to `ServiceEvent.Released`

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -305,8 +305,8 @@ class AuditEventListener {
 		);
 	}
 
-	@TransactionalEventListener(id = "audit.service-published", classes = ServiceEvent.Published.class)
-	void on(ServiceEvent.Published event) {
+	@TransactionalEventListener(id = "audit.service-released", classes = ServiceEvent.Released.class)
+	void on(ServiceEvent.Released event) {
 		insert(event, builder -> {
 			final List<String> artifacts = new ArrayList<>();
 
@@ -316,7 +316,7 @@ class AuditEventListener {
 
 			builder.entityType("service")
 					.entityId(event.id())
-					.eventType("service.published")
+					.eventType("service.released")
 					.details("artifacts", Collections.unmodifiableList(artifacts));
 		});
 	}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
@@ -271,7 +271,7 @@ class DefaultServices implements Services {
 		log.info(PUBLISHED, "Successfully published manifest for service {} in namespace {}: {}",
 				service.id(), service.namespace(), manifest);
 
-		publisher.publishEvent(new ServiceEvent.Published(service, manifest));
+		publisher.publishEvent(new ServiceEvent.Released(service, manifest));
 
 		return manifest;
 	}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/ServiceEvent.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/ServiceEvent.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
  * @since 1.0.0
  **/
 public sealed abstract class ServiceEvent extends EntityEvent implements Supplier<Service>
-		permits ServiceEvent.Created, ServiceEvent.Renamed, ServiceEvent.Published, ServiceEvent.Deleted {
+		permits ServiceEvent.Created, ServiceEvent.Renamed, ServiceEvent.Released, ServiceEvent.Deleted {
 
 	protected final Service service;
 
@@ -98,29 +98,29 @@ public sealed abstract class ServiceEvent extends EntityEvent implements Supplie
 	}
 
 	/**
-	 * Event that would be published when a new {@link Manifest} for the {@link Service} is published.
+	 * Event that would be published when a new {@link Manifest} for the {@link Service} is released.
 	 */
-	@DomainEvent(name = "service-published", namespace = "namespaces")
-	public static final class Published extends ServiceEvent {
+	@DomainEvent(name = "service-released", namespace = "namespaces")
+	public static final class Released extends ServiceEvent {
 
 		private final Manifest manifest;
 
 		/**
-		 * Create a new {@link Published} event with the {@link EntityId entity identifier} of the
-		 * {@link Service} that was just published by the {@link Services service manager}.
+		 * Create a new {@link Released} event with the {@link EntityId entity identifier} of the
+		 * {@link Service} that was just released by the {@link Services service manager}.
 		 *
-		 * @param service the published service.
-		 * @param manifest the published manifest.
+		 * @param service the released service.
+		 * @param manifest the released manifest.
 		 */
-		public Published(Service service, Manifest manifest) {
+		public Released(Service service, Manifest manifest) {
 			super(service);
 			this.manifest = manifest;
 		}
 
 		/**
-		 * Returns the {@link Manifest} that was published for the {@link Service}.
+		 * Returns the {@link Manifest} that was released for the {@link Service}.
 		 *
-		 * @return the published manifest, never {@literal null}.
+		 * @return the released manifest, never {@literal null}.
 		 */
 		@NonNull
 		public Manifest manifest() {

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/catalog/ServiceCatalogQueueListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/catalog/ServiceCatalogQueueListener.java
@@ -147,7 +147,7 @@ class ServiceCatalogQueueListener {
 	 * This guarantees that the catalog remains a deterministic projection of the latest manifest
 	 * without producing intermediate or inconsistent states.
 	 *
-	 * @param event the manifest publication event containing the release identifier
+	 * @param event the manifest release event containing the release identifier
 	 */
 	@Async
 	@Transactional(
@@ -155,12 +155,12 @@ class ServiceCatalogQueueListener {
 			isolation = Isolation.SERIALIZABLE,
 			label = "service-catalog-queue.scheduler-for-manifest"
 	)
-	@TransactionalEventListener(id = "namespace.catalog.build.manifest-published")
-	void enqueue(ServiceEvent.Published event) {
+	@TransactionalEventListener(id = "namespace.catalog.build.manifest-released")
+	void enqueue(ServiceEvent.Released event) {
 		final Manifest manifest = event.manifest();
 
 		if (log.isDebugEnabled()) {
-			log.debug("Attempting to schedule service catalog builds for published manifest: [id={}, service={}]",
+			log.debug("Attempting to schedule service catalog builds for released manifest: [id={}, service={}]",
 					manifest.id(), event.id());
 		}
 
@@ -186,7 +186,7 @@ class ServiceCatalogQueueListener {
 				.set(WORKER_QUEUE.NEEDS_RESCHEDULE, true)
 				.execute();
 
-		log.info("Scheduled {} service catalog build(s) for published manifest: [id={}, service={}]",
+		log.info("Scheduled {} service catalog build(s) for released manifest: [id={}, service={}]",
 				rows, manifest.id(), event.id());
 	}
 

--- a/konfigyr-api/src/main/resources/messages/audit.properties
+++ b/konfigyr-api/src/main/resources/messages/audit.properties
@@ -30,7 +30,7 @@ audit.event.invitation.canceled=Invitation was canceled
 
 audit.event.service.created=Service was created
 audit.event.service.renamed=Service was renamed from ''{0}'' to ''{1}''
-audit.event.service.published=Service artifacts were published
+audit.event.service.released=Service was released
 audit.event.service.deleted=Service was deleted
 
 ## Profile events ##

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
@@ -516,8 +516,8 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("should persist audit record for service published event with empty artifact coordinates")
-	void shouldAuditEmptyServicePublishedManifest() {
+	@DisplayName("should persist audit record for service released event with empty artifact coordinates")
+	void shouldAuditEmptyServiceReleasedManifest() {
 		setSecurityContext(TestPrincipals.john());
 
 		final Service service = Service.builder()
@@ -530,20 +530,20 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 		final var manifest = mock(Manifest.class);
 		doReturn(Collections.emptyList()).when(manifest).artifacts();
 
-		listener.on(new ServiceEvent.Published(service, manifest));
+		listener.on(new ServiceEvent.Released(service, manifest));
 
 		assertAuditRecord("service", EntityId.from(902))
 				.returns(EntityId.from(10), AuditRecord::namespaceId)
-				.satisfies(assertAuditRecordMessage("Service artifacts were published"))
-				.returns("service.published", AuditRecord::eventType)
+				.satisfies(assertAuditRecordMessage("Service was released"))
+				.returns("service.released", AuditRecord::eventType)
 				.satisfies(it -> assertThat(it.details())
 						.containsEntry("artifacts", List.of())
 				);
 	}
 
 	@Test
-	@DisplayName("should persist audit record for service published event with artifact coordinates")
-	void shouldAuditServicePublishedManifest() {
+	@DisplayName("should persist audit record for service released event with artifact coordinates")
+	void shouldAuditServiceReleasedManifest() {
 		setSecurityContext(TestPrincipals.john());
 
 		final Service service = Service.builder()
@@ -559,12 +559,12 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 				Artifact.of("com.konfigyr", "konfigyr-identity", "1.0.0")
 		)).when(manifest).artifacts();
 
-		listener.on(new ServiceEvent.Published(service, manifest));
+		listener.on(new ServiceEvent.Released(service, manifest));
 
 		assertAuditRecord("service", EntityId.from(902))
 				.returns(EntityId.from(10), AuditRecord::namespaceId)
-				.returns("service.published", AuditRecord::eventType)
-				.satisfies(assertAuditRecordMessage("Service artifacts were published"))
+				.returns("service.released", AuditRecord::eventType)
+				.satisfies(assertAuditRecordMessage("Service was released"))
 				.satisfies(it -> assertThat(it.details())
 						.containsEntry("artifacts", List.of(
 								"com.konfigyr:konfigyr-api:1.0.0",

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ServiceCatalogQueueListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ServiceCatalogQueueListenerTest.java
@@ -80,9 +80,9 @@ class ServiceCatalogQueueListenerTest extends AbstractIntegrationTest {
 	}
 
 	@Test
-	@DisplayName("should schedule service catalog build task when service manifest was published")
-	void scheduleForPublishedManifest() {
-		final var event = createManifestPublishedEvent(2);
+	@DisplayName("should schedule service catalog build task when service manifest was released")
+	void scheduleForReleasedManifest() {
+		final var event = createManifestReleasedEvent(2);
 
 		assertThatNoException().isThrownBy(() -> queue.enqueue(event));
 
@@ -102,7 +102,7 @@ class ServiceCatalogQueueListenerTest extends AbstractIntegrationTest {
 	void enqueueBuildForSameRelease() throws InterruptedException {
 		final var timeout = Duration.ofSeconds(2);
 
-		assertThatNoException().isThrownBy(() -> queue.enqueue(createManifestPublishedEvent(2)));
+		assertThatNoException().isThrownBy(() -> queue.enqueue(createManifestReleasedEvent(2)));
 		await().atMost(timeout).untilAsserted(() -> assertQueue()
 				.hasSize(1)
 				.first()
@@ -139,7 +139,7 @@ class ServiceCatalogQueueListenerTest extends AbstractIntegrationTest {
 
 		Thread.sleep(timeout.plus(timeout));
 
-		assertThatNoException().isThrownBy(() -> queue.enqueue(createManifestPublishedEvent(2)));
+		assertThatNoException().isThrownBy(() -> queue.enqueue(createManifestReleasedEvent(2)));
 		await().atMost(timeout).untilAsserted(() -> assertQueue()
 				.hasSize(2)
 				.satisfiesExactlyInAnyOrder(
@@ -173,7 +173,7 @@ class ServiceCatalogQueueListenerTest extends AbstractIntegrationTest {
 				.returning(WORKER_QUEUE.ID)
 				.fetchOne(WORKER_QUEUE.ID);
 
-		assertThatNoException().isThrownBy(() -> queue.enqueue(createManifestPublishedEvent(2)));
+		assertThatNoException().isThrownBy(() -> queue.enqueue(createManifestReleasedEvent(2)));
 
 		await().untilAsserted(() -> assertQueue(WORKER_QUEUE.ID.eq(id))
 				.first()
@@ -188,7 +188,7 @@ class ServiceCatalogQueueListenerTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should fail to schedule service catalog build task for unknown service release identifier")
 	void scheduleForUnknownManifest() {
-		final var event = createManifestPublishedEvent(9999);
+		final var event = createManifestReleasedEvent(9999);
 
 		assertThatNoException().isThrownBy(() -> queue.enqueue(event));
 		await().untilAsserted(() -> assertQueue().isEmpty());
@@ -220,14 +220,14 @@ class ServiceCatalogQueueListenerTest extends AbstractIntegrationTest {
 		return new ArtifactoryEvent.PublicationCompleted(EntityId.from(id), mock(ArtifactCoordinates.class));
 	}
 
-	static ServiceEvent.Published createManifestPublishedEvent(long id) {
+	static ServiceEvent.Released createManifestReleasedEvent(long id) {
 		final var service = mock(Service.class);
 		doReturn(EntityId.from(id)).when(service).id();
 
 		final var manifest = mock(Manifest.class);
 		doReturn(EntityId.from(id).serialize()).when(manifest).id();
 
-		return new ServiceEvent.Published(service, manifest);
+		return new ServiceEvent.Released(service, manifest);
 	}
 
 }


### PR DESCRIPTION
A service releasing its manifest and an artifact being published are different concepts sharing the same word. Rename the event, its listeners, and the audit message key so a service-manifest build consistently says "release" instead of overlapping with the artifact-publish vocabulary.