### PR TITLE
Introduce `ServiceManifests` interface  and retire the legacy manifest write path

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
@@ -1,7 +1,6 @@
 package com.konfigyr.namespace;
 
 import com.konfigyr.artifactory.*;
-import com.konfigyr.data.Keys;
 import com.konfigyr.data.PageableExecutor;
 import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
@@ -9,7 +8,6 @@ import com.konfigyr.io.ByteArray;
 import com.konfigyr.namespace.catalog.ServiceCatalogSource;
 import com.konfigyr.support.SearchQuery;
 import com.konfigyr.support.Slug;
-import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.*;
@@ -27,7 +25,6 @@ import org.springframework.util.Assert;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -44,7 +41,6 @@ class DefaultServices implements Services {
 	private static final Name SERVICE_ARTIFACTS_ALIAS = DSL.name("artifacts");
 
 	private final Marker CREATED = MarkerFactory.getMarker("SERVICE_CREATED");
-	private final Marker PUBLISHED = MarkerFactory.getMarker("MANIFEST_PUBLISHED");
 
 	static final PageableExecutor servicesExecutor = PageableExecutor.builder()
 			.defaultSortField(SERVICES.NAME.desc())
@@ -224,58 +220,6 @@ class DefaultServices implements Services {
 	@Override
 	public Page<PropertyDescriptor> search(@NonNull Service service, @NonNull SearchQuery query) {
 		return catalogSource.query(service, query);
-	}
-
-	@NonNull
-	@Override
-	@Transactional(label = "service-release")
-	@Observed(name = "konfigyr.namespace.service.publish")
-	public Manifest publish(@NonNull Service service, @NonNull Collection<? extends ArtifactCoordinates> artifacts) {
-		final Long releaseId = context.insertInto(SERVICE_RELEASES)
-				.set(
-						SettableRecord.of(context, SERVICE_RELEASES)
-								.set(SERVICE_RELEASES.ID, EntityId.generate().map(EntityId::get))
-								.set(SERVICE_RELEASES.SERVICE_ID, service.id().get())
-								.set(SERVICE_RELEASES.VERSION, "latest")
-								.set(SERVICE_RELEASES.STATE, "PENDING")
-								.set(SERVICE_RELEASES.CREATED_AT, OffsetDateTime.now())
-								.get()
-				)
-				.onConflictOnConstraint(Keys.UNIQUE_NAMESPACE_SERVICE_VERSION)
-				.doUpdate()
-				.set(SERVICE_RELEASES.STATE, "PENDING")
-				.set(SERVICE_RELEASES.CREATED_AT, OffsetDateTime.now())
-				.returning(SERVICE_RELEASES.ID)
-				.fetchOne(SERVICE_RELEASES.ID);
-
-		Assert.state(releaseId != null, "Failed to resolve the release identifier for: " + service);
-
-		// clear the previous artifact manifest state...
-		context.deleteFrom(SERVICE_ARTIFACTS)
-				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
-				.execute();
-
-		// insert the defined artifact coordinates now that we have a clear state...
-		final long count = context.insertInto(SERVICE_ARTIFACTS)
-				.set(artifacts.stream().map(coordinate -> SettableRecord.of(context, SERVICE_ARTIFACTS)
-						.set(SERVICE_ARTIFACTS.RELEASE_ID, releaseId)
-						.set(SERVICE_ARTIFACTS.GROUP_ID, coordinate.groupId())
-						.set(SERVICE_ARTIFACTS.ARTIFACT_ID, coordinate.artifactId())
-						.set(SERVICE_ARTIFACTS.VERSION, coordinate.version().get())
-						.get()
-				).toList())
-				.execute();
-
-		Assert.state(count == artifacts.size(), "Failed to insert all artifacts for: " + service);
-
-		final Manifest manifest = manifest(service);
-
-		log.info(PUBLISHED, "Successfully published manifest for service {} in namespace {}: {}",
-				service.id(), service.namespace(), manifest);
-
-		publisher.publishEvent(new ServiceEvent.Released(service, manifest));
-
-		return manifest;
 	}
 
 	@Override

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/Services.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/Services.java
@@ -10,7 +10,6 @@ import org.jspecify.annotations.NullMarked;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Repository;
 
-import java.util.Collection;
 import java.util.Optional;
 
 /**
@@ -157,28 +156,6 @@ public interface Services {
 	 * @see ServiceCatalog
 	 */
 	Page<PropertyDescriptor> search(Service service, SearchQuery query);
-
-	/**
-	 * Updates the manifest of a service with a new set of artifact dependencies.
-	 * <p>
-	 * The provided collection represents the complete set of artifacts that should be associated with the
-	 * service after the update. Each artifact is identified using its Maven coordinates ({@code groupId},
-	 * {@code artifactId}, {@code version}).
-	 * <p>
-	 * During this process the system performs several operations:
-	 * <ul>
-	 *     <li>Validates that each referenced artifact exists in the Artifactory</li>
-	 *     <li>Resolves configuration metadata contributed by the artifacts</li>
-	 *     <li>Computes the effective property definitions used by the service</li>
-	 *     <li>Updates the service manifest to reflect the new dependency set</li>
-	 * </ul>
-	 *
-	 * @param service service for which release should be created, can't be {@literal null}
-	 * @param artifacts the complete collection of artifacts that should compose the
-	 *                  service manifest, never {@literal null} but may be empty
-	 * @return the updated {@link Manifest} reflecting the resolved dependency set
-	 */
-	Manifest publish(Service service, Collection<? extends ArtifactCoordinates> artifacts);
 
 	/**
 	 * Deletes a single {@link Service} by its entity identifier.

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServicesController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServicesController.java
@@ -1,9 +1,7 @@
 package com.konfigyr.namespace.controller;
 
-import com.konfigyr.artifactory.ArtifactCoordinates;
 import com.konfigyr.artifactory.Manifest;
 import com.konfigyr.artifactory.PropertyDescriptor;
-import com.konfigyr.artifactory.ServiceReleaseCandidate;
 import com.konfigyr.hateoas.EntityModel;
 import com.konfigyr.hateoas.PagedModel;
 import com.konfigyr.namespace.*;
@@ -11,8 +9,6 @@ import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
 import com.konfigyr.support.SearchQuery;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import jakarta.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.data.domain.Pageable;
@@ -22,8 +18,6 @@ import org.jspecify.annotations.NonNull;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -142,44 +136,6 @@ class ServicesController {
 		return Assemblers.manifest(ns, service).assemble(services.manifest(service));
 	}
 
-	@PostMapping("{slug}/manifest")
-	@PreAuthorize("isMember(#namespace)")
-	@ResponseStatus(HttpStatus.CREATED)
-	@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)
-	EntityModel<Manifest> publish(
-			@PathVariable @NonNull String namespace,
-			@PathVariable @NonNull String slug,
-			@RequestBody @Validated PublishManifestRequest request
-	) {
-		final Namespace ns = lookupNamespace(namespace);
-		final Service service = services.get(ns, slug).orElseThrow(
-				() -> new ServiceNotFoundException(namespace, slug)
-		);
-
-		return Assemblers.manifest(ns, service).assemble(services.publish(service, request.coordinates()));
-	}
-
-	@PostMapping("{slug}/releases")
-	@PreAuthorize("isMember(#namespace)")
-	@ResponseStatus(HttpStatus.CREATED)
-	@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)
-	EntityModel<Manifest> release(
-			@PathVariable @NonNull String namespace,
-			@PathVariable @NonNull String slug,
-			@RequestBody @Validated @NotEmpty List<ServiceReleaseCandidate> candidates
-	) {
-		final Namespace ns = lookupNamespace(namespace);
-		final Service service = services.get(ns, slug).orElseThrow(
-				() -> new ServiceNotFoundException(namespace, slug)
-		);
-
-		final var coordinates = candidates.stream()
-				.map(ArtifactCoordinates::of)
-				.toList();
-
-		return Assemblers.manifest(ns, service).assemble(services.publish(service, coordinates));
-	}
-
 	@NonNull
 	Namespace lookupNamespace(@NonNull String slug) {
 		return namespaces.findBySlug(slug).orElseThrow(() -> new NamespaceNotFoundException(slug));
@@ -198,15 +154,5 @@ class ServicesController {
 					.description(description)
 					.build();
 		}
-	}
-
-	record PublishManifestRequest(@NotEmpty List<@NotBlank @Pattern(regexp = "^([^:]+):([^:]+):([^:]+)$") String> artifacts) {
-
-		List<ArtifactCoordinates> coordinates() {
-			return artifacts.stream()
-						.map(ArtifactCoordinates::parse)
-						.toList();
-		}
-
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifests.java
@@ -19,8 +19,8 @@ import java.util.Collection;
  * declared artifact remains unresolved.
  *
  * @author Vladimir Spasic
- * @see ServiceRelease
  * @since 1.0.0
+ * @see ServiceRelease
  **/
 public interface ServiceManifests {
 

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifests.java
@@ -1,0 +1,70 @@
+package com.konfigyr.namespace.manifest;
+
+import com.konfigyr.artifactory.ArtifactMetadata;
+import com.konfigyr.artifactory.ServiceRelease;
+import com.konfigyr.artifactory.ServiceReleaseCandidate;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.namespace.Service;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Collection;
+
+/**
+ * Interface that defines a contract for building a service's Service Configuration Manifest through
+ * the resolve/upload/complete protocol used by build plugins.
+ * <p>
+ * Implementations are responsible for enforcing the domain invariants of a single-row-per-service
+ * {@link ServiceRelease}: taking over an in-progress build rather than rejecting it, tracking which
+ * declared artifacts still need their metadata uploaded, and refusing to complete a release while any
+ * declared artifact remains unresolved.
+ *
+ * @author Vladimir Spasic
+ * @see ServiceRelease
+ * @since 1.0.0
+ **/
+public interface ServiceManifests {
+
+	/**
+	 * Opens a new build for the given service, or takes over its current {@link ServiceRelease} if one
+	 * is already in progress, there is only ever one pending release row per service.
+	 * <p>
+	 * Every declared candidate is resolved against artifacts already uploaded in this build and against
+	 * the Artifactory index, producing one {@link com.konfigyr.artifactory.ServiceReleaseEntry} per
+	 * candidate with its resolved {@link com.konfigyr.artifactory.ArtifactUploadStatus}. Declared
+	 * artifacts that are no longer part of the given {@code artifacts} collection are pruned.
+	 *
+	 * @param service the service opening or taking over a build, can't be {@literal null}.
+	 * @param artifacts the artifact coordinates and checksums resolved locally by the build plugin, can't be {@literal null}.
+	 * @return the resolved service release, never {@literal null}.
+	 */
+	@NonNull
+	ServiceRelease open(@NonNull Service service, @NonNull Collection<ServiceReleaseCandidate> artifacts);
+
+	/**
+	 * Records the Spring Boot configuration metadata uploaded by the build plugin for a single artifact
+	 * declared in the current build, exploding its property descriptors into the service configuration
+	 * catalog.
+	 *
+	 * @param service the service the release belongs to, can't be {@literal null}.
+	 * @param releaseId the entity identifier of the release the upload belongs to, can't be {@literal null}.
+	 * @param metadata the uploaded artifact metadata, can't be {@literal null}.
+	 */
+	void upload(@NonNull Service service, @NonNull EntityId releaseId, @NonNull ArtifactMetadata metadata);
+
+	/**
+	 * Completes the given build: validates that every declared artifact was uploaded, populates the
+	 * service configuration catalog for artifacts sourced from the Artifactory, and transitions the
+	 * release to {@link com.konfigyr.artifactory.ReleaseState#RELEASED} — or to
+	 * {@link com.konfigyr.artifactory.ReleaseState#FAILED} if any declared artifact was never uploaded.
+	 * <p>
+	 * Once the release transitions to {@link com.konfigyr.artifactory.ReleaseState#RELEASED}, a
+	 * {@link com.konfigyr.namespace.ServiceEvent.Released} event is published.
+	 *
+	 * @param service the service the release belongs to, can't be {@literal null}.
+	 * @param releaseId the entity identifier of the release to complete, can't be {@literal null}.
+	 * @return the completed service release, never {@literal null}.
+	 */
+	@NonNull
+	ServiceRelease complete(@NonNull Service service, @NonNull EntityId releaseId);
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceControllerTest.java
@@ -12,11 +12,8 @@ import com.konfigyr.test.AbstractControllerTest;
 import com.konfigyr.test.TestPrincipals;
 import com.konfigyr.version.Version;
 import org.assertj.core.api.InstanceOfAssertFactories;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
@@ -658,130 +655,6 @@ class ServiceControllerTest extends AbstractControllerTest {
 	void retrieveManifestWithoutMembership() {
 		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
 				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(forbidden());
-	}
-
-	@Test
-	@Disabled("""
-			Legacy Services.publish() write path never populates service_artifacts.checksum, which \
-			ManifestEntry now requires to be non-blank. Re-enable once the legacy manifest write path \
-			is retired in favor of the resolve/upload/publish release flow.""")
-	@DisplayName("should publish the namespace service manifest")
-	void publishServiceManifest() {
-		mvc.post().uri("/namespaces/konfigyr/services/konfigyr-api/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"artifacts\": [\"com.konfigyr:konfigyr-crypto-api:1.0.2\", \"com.konfigyr:konfigyr-crypto-tink:1.0.0\"]}")
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatus(HttpStatus.CREATED)
-				.bodyJson()
-				.convertTo(Manifest.class)
-				.returns(EntityId.from(2).serialize(), Manifest::id)
-				.returns("Konfigyr API", Manifest::name)
-				.satisfies(it -> assertThat(it.artifacts())
-						.hasSize(2)
-						.containsExactly(
-								ManifestEntry.builder()
-										.groupId("com.konfigyr")
-										.artifactId("konfigyr-crypto-api")
-										.version("1.0.2")
-										.name("Konfigyr Crypto API")
-										.description("Spring Boot Crypto API library")
-										.repository("https://github.com/konfigyr/konfigyr-crypto")
-										.build(),
-								ManifestEntry.builder()
-										.groupId("com.konfigyr")
-										.artifactId("konfigyr-crypto-tink")
-										.version("1.0.0")
-										.name("Konfigyr Crypto Tink")
-										.description("Tink support Konfigyr Crypto API library")
-										.repository("https://github.com/konfigyr/konfigyr-crypto")
-										.build()
-						)
-				)
-				.satisfies(it -> assertThat(it.createdAt())
-						.isCloseTo(Instant.now(), within(5, ChronoUnit.MINUTES))
-				);
-	}
-
-	@ValueSource(strings = {
-			"{}",
-			"{\"artifacts\": null}",
-			"{\"artifacts\": []}",
-			"{\"artifacts\": [null]}",
-			"{\"artifacts\": [\"\", \"  \"]}",
-			"{\"artifacts\": [\"invalid-coordinates\"]}",
-			"{\"artifacts\": [\"invalid:coordinates\", \"com.konfigyr:konfigyr-api:1.0.0\"]}"
-	})
-	@ParameterizedTest(name = "with payload: {0}")
-	@DisplayName("should fail to publish manifest with invalid payload")
-	void publishManifestWithInvalidArtifacts(String payload) {
-		mvc.post().uri("/namespaces/konfigyr/services/konfigyr-api/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(payload)
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(problemDetailFor(HttpStatus.BAD_REQUEST, problem -> problem
-						.hasTitleContaining("Invalid")
-						.hasDetailContaining("invalid request data")
-						.containsProperty("errors")
-				));
-	}
-
-	@Test
-	@DisplayName("should fail to publish manifest for unknown service")
-	void publishManifestForUnknownService() {
-		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"artifacts\": [\"com.konfigyr:konfigyr-crypto-api:1.0.0\"]}")
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(serviceNotFound("unknown-service"));
-	}
-
-	@Test
-	@DisplayName("should not publish a service manifest for an unknown namespace")
-	void publishManifestForUnknownNamespace() {
-		mvc.post().uri("/namespaces/unknown-namespace/services/unknown-service/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"artifacts\": [\"com.konfigyr:konfigyr-crypto-api:1.0.0\"]}")
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatus(HttpStatus.NOT_FOUND)
-				.satisfies(namespaceNotFound("unknown-namespace"));
-	}
-
-	@Test
-	@DisplayName("should not publish service manifest when namespaces:read scope is not present")
-	void publishManifestWithoutScope() {
-		mvc.post().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
-				.with(authentication(TestPrincipals.jane()))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"artifacts\": [\"com.konfigyr:konfigyr-crypto-api:1.0.0\"]}")
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(forbidden(OAuthScope.PUBLISH_MANIFESTS));
-	}
-
-	@Test
-	@DisplayName("should not publish service manifest when user is not a member of a namespace")
-	void publishManifestWithoutMembership() {
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
-				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content("{\"artifacts\": [\"com.konfigyr:konfigyr-crypto-api:1.0.0\"]}")
 				.exchange()
 				.assertThat()
 				.apply(log())


### PR DESCRIPTION
## Summary
- Introduces `ServiceManifests` in `com.konfigyr.namespace.manifest`: a pure service interface for  the resolve/upload/complete protocol build plugins use to submit a service's configuration manifest. `open`/`upload`/`complete` take the owning `Service` explicitly; `upload` accepts the SDK's `ArtifactMetadata` directly; `complete` publishes `ServiceEvent.Released` on success. No local re-declarations of SDK types.
- Retires the legacy write path: `Services.publish()`, `DefaultServices.publish()`, `POST {slug}/manifest`, the placeholder `POST {slug}/releases` handler, and `PublishManifestRequest` are all removed. `GET .../manifest` and `Services.manifest()` are untouched. This keeps `service_releases`/`service_artifacts` to a single writer at a time before the new resolve/upload/complete flow lands.