### PR TITLE
Add `POST /releases` to resolve or take over a service's current build

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
@@ -71,11 +71,13 @@ public interface Artifactory {
 	boolean exists(@NonNull ArtifactCoordinates coordinates);
 
 	/**
-	 * Returns the subset of the given {@link ArtifactCoordinates} that are already indexed by this
-	 * {@code Artifactory}.
+	 * Returns the {@link Publication} for each of the given {@link ArtifactCoordinates} that is already
+	 * indexed by this {@code Artifactory}.
 	 * <p>
 	 * This is a batch counterpart to {@link #exists(ArtifactCoordinates)}, intended for callers that
 	 * need to resolve the existence of many coordinates at once without issuing one query per coordinate.
+	 * Returning the {@link Publication} rather than just the matched coordinate lets callers read its
+	 * {@link Publication#checksum()} directly, without a further lookup.
 	 * <p>
 	 * Coordinates from the input that have no matching artifact version indexed by this {@code Artifactory}
 	 * are simply omitted from the returned set — they are not reported back as missing or invalid, since
@@ -83,10 +85,10 @@ public interface Artifactory {
 	 * need to know which of their coordinates are absent should compute the difference against the input.
 	 *
 	 * @param coordinates coordinates to check, can be empty
-	 * @return the subset of the given coordinates that exist, never {@literal null}, empty if the input is empty
+	 * @return the publications matching the given coordinates that exist, never {@literal null}, empty if the input is empty
 	 */
 	@NonNull
-	Set<ArtifactCoordinates> existing(@NonNull Collection<ArtifactCoordinates> coordinates);
+	Set<Publication> existing(@NonNull Collection<ArtifactCoordinates> coordinates);
 
 	/**
 	 * Publishes a new artifact version based on the provided metadata.

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
@@ -16,6 +16,7 @@ import org.jooq.Condition;
 import org.jooq.Converter;
 import org.jooq.DSLContext;
 import org.jooq.Record;
+import org.jooq.SelectJoinStep;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NonNull;
 import org.springframework.context.ApplicationEventPublisher;
@@ -53,23 +54,7 @@ class DefaultArtifactory implements Artifactory {
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.get-versioned-artifact")
 	public Optional<VersionedArtifact> get(@NonNull ArtifactCoordinates coordinates) {
-		return context.select(
-						ARTIFACT_VERSIONS.ID,
-						ARTIFACT_VERSIONS.STATE,
-						ARTIFACT_VERSIONS.CHECKSUM,
-						ARTIFACTS.ID,
-						ARTIFACTS.GROUP_ID,
-						ARTIFACTS.ARTIFACT_ID,
-						ARTIFACT_VERSIONS.VERSION,
-						ARTIFACTS.NAME,
-						ARTIFACTS.DESCRIPTION,
-						ARTIFACTS.WEBSITE,
-						ARTIFACTS.REPOSITORY,
-						ARTIFACT_VERSIONS.RELEASED_AT
-				)
-				.from(ARTIFACT_VERSIONS)
-				.innerJoin(ARTIFACTS)
-				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
+		return createVersionedArtifactQuery()
 				.where(toCondition(coordinates))
 				.fetchOptional(DefaultArtifactory::toVersionedArtifact);
 	}
@@ -89,7 +74,7 @@ class DefaultArtifactory implements Artifactory {
 	@NonNull
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.existing-coordinates")
-	public Set<ArtifactCoordinates> existing(@NonNull Collection<ArtifactCoordinates> coordinates) {
+	public Set<Publication> existing(@NonNull Collection<ArtifactCoordinates> coordinates) {
 		if (coordinates.isEmpty()) {
 			return Set.of();
 		}
@@ -98,16 +83,12 @@ class DefaultArtifactory implements Artifactory {
 		final String[] artifactIds = coordinates.stream().map(ArtifactCoordinates::artifactId).toArray(String[]::new);
 		final String[] versions = coordinates.stream().map(coordinate -> coordinate.version().get()).toArray(String[]::new);
 
-		return context.select(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, ARTIFACT_VERSIONS.VERSION)
-				.from(ARTIFACT_VERSIONS)
-				.innerJoin(ARTIFACTS)
-				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
+		return createVersionedArtifactQuery()
 				.where(DSL.row(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, ARTIFACT_VERSIONS.VERSION)
 						.in(DSL.select(DSL.field("g", String.class), DSL.field("a", String.class), DSL.field("v", String.class))
 								.from("unnest({0}::text[], {1}::text[], {2}::text[]) AS t(g, a, v)",
 										groupIds, artifactIds, versions)))
-				.fetchSet(record -> ArtifactCoordinates.of(
-						record.get(ARTIFACTS.GROUP_ID), record.get(ARTIFACTS.ARTIFACT_ID), record.get(ARTIFACT_VERSIONS.VERSION)));
+				.fetchSet(DefaultArtifactory::toVersionedArtifact);
 	}
 
 	@Override
@@ -215,6 +196,27 @@ class DefaultArtifactory implements Artifactory {
 				.on(PROPERTY_DEFINITIONS.ID.eq(ARTIFACT_VERSION_PROPERTIES.PROPERTY_DEFINITION_ID))
 				.where(ARTIFACT_VERSION_PROPERTIES.ARTIFACT_VERSION_ID.eq(artifactVersionId))
 				.fetch(record -> toPropertyDefinition(record, converters));
+	}
+
+	@NonNull
+	private SelectJoinStep<? extends Record> createVersionedArtifactQuery() {
+		return context.select(
+						ARTIFACT_VERSIONS.ID,
+						ARTIFACT_VERSIONS.STATE,
+						ARTIFACT_VERSIONS.CHECKSUM,
+						ARTIFACTS.ID,
+						ARTIFACTS.GROUP_ID,
+						ARTIFACTS.ARTIFACT_ID,
+						ARTIFACT_VERSIONS.VERSION,
+						ARTIFACTS.NAME,
+						ARTIFACTS.DESCRIPTION,
+						ARTIFACTS.WEBSITE,
+						ARTIFACTS.REPOSITORY,
+						ARTIFACT_VERSIONS.RELEASED_AT
+				)
+				.from(ARTIFACT_VERSIONS)
+				.innerJoin(ARTIFACTS)
+				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID));
 	}
 
 	private void assertCanRelease(EntityId ownerId, String groupId) {

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
@@ -1,0 +1,61 @@
+package com.konfigyr.namespace.controller;
+
+import com.konfigyr.artifactory.ServiceRelease;
+import com.konfigyr.artifactory.ServiceReleaseCandidate;
+import com.konfigyr.namespace.Namespace;
+import com.konfigyr.namespace.NamespaceManager;
+import com.konfigyr.namespace.NamespaceNotFoundException;
+import com.konfigyr.namespace.Service;
+import com.konfigyr.namespace.ServiceNotFoundException;
+import com.konfigyr.namespace.Services;
+import com.konfigyr.namespace.manifest.ServiceManifests;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.security.oauth.RequiresScope;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NonNull;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)
+@RequestMapping("/namespaces/{namespace}/services/{slug}/releases")
+class ServiceManifestController {
+
+	private final NamespaceManager namespaces;
+	private final Services services;
+	private final ServiceManifests manifests;
+
+	@PostMapping
+	@PreAuthorize("isMember(#namespace)")
+	ServiceRelease resolve(
+			@PathVariable String namespace,
+			@PathVariable String slug,
+			@RequestBody @Validated ResolveReleaseRequest request
+	) {
+		final Namespace ns = lookupNamespace(namespace);
+		final Service service = services.get(ns, slug).orElseThrow(
+				() -> new ServiceNotFoundException(namespace, slug)
+		);
+
+		return manifests.open(service, request.artifacts());
+	}
+
+	@NonNull
+	Namespace lookupNamespace(@NonNull String slug) {
+		return namespaces.findBySlug(slug).orElseThrow(() -> new NamespaceNotFoundException(slug));
+	}
+
+	record ResolveReleaseRequest(@NotNull List<@NotNull ServiceReleaseCandidate> artifacts) {
+
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
@@ -1,0 +1,174 @@
+package com.konfigyr.namespace.manifest;
+
+import com.konfigyr.artifactory.*;
+import com.konfigyr.data.Keys;
+import com.konfigyr.data.SettableRecord;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.namespace.Service;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.jspecify.annotations.NonNull;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
+import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
+
+@RequiredArgsConstructor
+class DefaultServiceManifests implements ServiceManifests {
+
+	private static final String VERSION = "latest";
+
+	private final DSLContext context;
+	private final Artifactory artifactory;
+
+	@NonNull
+	@Override
+	@Transactional(label = "service-manifest.open")
+	public ServiceRelease open(@NonNull Service service, @NonNull Collection<ServiceReleaseCandidate> artifacts) {
+		final Long releaseId = upsertRelease(service);
+		final Map<ArtifactCoordinates, ExistingArtifact> existing = loadExistingArtifacts(releaseId);
+
+		final Set<ArtifactCoordinates> coordinates = new LinkedHashSet<>();
+		for (ServiceReleaseCandidate candidate : artifacts) {
+			coordinates.add(ArtifactCoordinates.of(candidate));
+		}
+
+		final Set<ArtifactCoordinates> indexed = artifactory.existing(coordinates);
+		final List<ServiceReleaseEntry> entries = new ArrayList<>(artifacts.size());
+
+		var insert = context.insertInto(SERVICE_ARTIFACTS,
+				SERVICE_ARTIFACTS.RELEASE_ID, SERVICE_ARTIFACTS.GROUP_ID, SERVICE_ARTIFACTS.ARTIFACT_ID,
+				SERVICE_ARTIFACTS.VERSION, SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM);
+
+		for (ServiceReleaseCandidate candidate : artifacts) {
+			final ArtifactCoordinates coordinate = ArtifactCoordinates.of(candidate);
+			final ExistingArtifact current = existing.get(coordinate);
+
+			final ArtifactUploadStatus status;
+			final ArtifactSource source;
+			final String checksum;
+
+			if (current != null && current.checksum() != null && current.checksum().equals(candidate.checksum())) {
+				status = ArtifactUploadStatus.SKIP;
+				source = current.source();
+				checksum = current.checksum();
+			} else if (current != null && current.checksum() != null) {
+				status = ArtifactUploadStatus.UPLOAD_REQUIRED;
+				source = ArtifactSource.LOCAL;
+				checksum = null;
+			} else if (indexed.contains(coordinate)) {
+				status = ArtifactUploadStatus.SKIP;
+				source = ArtifactSource.ARTIFACTORY;
+				checksum = null;
+			} else {
+				status = ArtifactUploadStatus.UPLOAD_REQUIRED;
+				source = ArtifactSource.LOCAL;
+				checksum = null;
+			}
+
+			entries.add(ServiceReleaseEntry.of(coordinate.groupId(), coordinate.artifactId(), coordinate.version().get(), status));
+			insert = insert.values(releaseId, coordinate.groupId(), coordinate.artifactId(), coordinate.version().get(), source.name(), checksum);
+		}
+
+		if (!coordinates.isEmpty()) {
+			insert.onConflict(SERVICE_ARTIFACTS.RELEASE_ID, SERVICE_ARTIFACTS.GROUP_ID, SERVICE_ARTIFACTS.ARTIFACT_ID, SERVICE_ARTIFACTS.VERSION)
+					.doUpdate()
+					.set(SERVICE_ARTIFACTS.SOURCE, DSL.excluded(SERVICE_ARTIFACTS.SOURCE))
+					.set(SERVICE_ARTIFACTS.CHECKSUM, DSL.excluded(SERVICE_ARTIFACTS.CHECKSUM))
+					.execute();
+		}
+
+		pruneStaleArtifacts(releaseId, coordinates);
+
+		return ServiceRelease.builder()
+				.id(EntityId.from(releaseId).serialize())
+				.state(ReleaseState.PENDING)
+				.artifacts(entries)
+				.build();
+	}
+
+	@NonNull
+	private Long upsertRelease(@NonNull Service service) {
+		final Long releaseId = context.insertInto(SERVICE_RELEASES)
+				.set(
+						SettableRecord.of(context, SERVICE_RELEASES)
+								.set(SERVICE_RELEASES.ID, EntityId.generate().map(EntityId::get))
+								.set(SERVICE_RELEASES.SERVICE_ID, service.id().get())
+								.set(SERVICE_RELEASES.VERSION, VERSION)
+								.set(SERVICE_RELEASES.STATE, ReleaseState.PENDING.name())
+								.set(SERVICE_RELEASES.CREATED_AT, OffsetDateTime.now())
+								.get()
+				)
+				.onConflictOnConstraint(Keys.UNIQUE_NAMESPACE_SERVICE_VERSION)
+				.doUpdate()
+				.set(SERVICE_RELEASES.STATE, ReleaseState.PENDING.name())
+				.set(SERVICE_RELEASES.CREATED_AT, OffsetDateTime.now())
+				.returning(SERVICE_RELEASES.ID)
+				.fetchOne(SERVICE_RELEASES.ID);
+
+		Assert.state(releaseId != null, "Failed to resolve the release identifier for: " + service);
+
+		return releaseId;
+	}
+
+	@NonNull
+	private Map<ArtifactCoordinates, ExistingArtifact> loadExistingArtifacts(@NonNull Long releaseId) {
+		return context.select(SERVICE_ARTIFACTS.GROUP_ID, SERVICE_ARTIFACTS.ARTIFACT_ID, SERVICE_ARTIFACTS.VERSION,
+						SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
+				.from(SERVICE_ARTIFACTS)
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
+				.fetchMap(
+						record -> ArtifactCoordinates.of(
+								record.get(SERVICE_ARTIFACTS.GROUP_ID), record.get(SERVICE_ARTIFACTS.ARTIFACT_ID), record.get(SERVICE_ARTIFACTS.VERSION)),
+						record -> new ExistingArtifact(
+								record.get(SERVICE_ARTIFACTS.CHECKSUM),
+								ArtifactSource.valueOf(record.get(SERVICE_ARTIFACTS.SOURCE)))
+				);
+	}
+
+	private void pruneStaleArtifacts(@NonNull Long releaseId, @NonNull Collection<ArtifactCoordinates> coordinates) {
+		if (coordinates.isEmpty()) {
+			context.deleteFrom(SERVICE_ARTIFACTS)
+					.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
+					.execute();
+			return;
+		}
+
+		final String[] groupIds = coordinates.stream().map(ArtifactCoordinates::groupId).toArray(String[]::new);
+		final String[] artifactIds = coordinates.stream().map(ArtifactCoordinates::artifactId).toArray(String[]::new);
+		final String[] versions = coordinates.stream().map(coordinate -> coordinate.version().get()).toArray(String[]::new);
+
+		context.deleteFrom(SERVICE_ARTIFACTS)
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
+				.and(DSL.row(SERVICE_ARTIFACTS.GROUP_ID, SERVICE_ARTIFACTS.ARTIFACT_ID, SERVICE_ARTIFACTS.VERSION)
+						.notIn(DSL.select(DSL.field("g", String.class), DSL.field("a", String.class), DSL.field("v", String.class))
+								.from("unnest({0}::text[], {1}::text[], {2}::text[]) AS t(g, a, v)", groupIds, artifactIds, versions)))
+				.execute();
+	}
+
+	@Override
+	public void upload(@NonNull Service service, @NonNull EntityId releaseId, @NonNull ArtifactMetadata metadata) {
+		throw new UnsupportedOperationException("Not yet implemented");
+	}
+
+	@NonNull
+	@Override
+	public ServiceRelease complete(@NonNull Service service, @NonNull EntityId releaseId) {
+		throw new UnsupportedOperationException("Not yet implemented");
+	}
+
+	private record ExistingArtifact(String checksum, ArtifactSource source) {
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
@@ -6,90 +6,144 @@ import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.Service;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
-import org.jooq.Record;
 import org.jooq.impl.DSL;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
 import java.time.OffsetDateTime;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
 import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
 
+/**
+ * Default {@link ServiceManifests} implementation.
+ * <p>
+ * A build plugin uses three calls, in order, to publish a service's Spring Boot configuration
+ * metadata:
+ * <ol>
+ *     <li>{@link #open}: tell the server which Maven coordinates this build depends on, and get
+ *     back which of them the plugin still needs to upload metadata for.</li>
+ *     <li>{@link #upload}: for each coordinate the server asked for, upload the parsed
+ *     {@code spring-configuration-metadata.json} contents.</li>
+ *     <li>{@link #complete}: tell the server the build is done, so it can check every required
+ *     upload happened and make the resulting property catalog available.</li>
+ * </ol>
+ * All three calls read and write the same two database tables: {@code service_releases} (one row
+ * per service, tracking the state of its current build) and {@code service_artifacts} (one row per
+ * declared coordinate within that build).
+ * <p>
+ * Each {@code service_artifacts} row has a {@code source} and a {@code checksum} column, and the
+ * two are linked by a rule that the rest of this class depends on:
+ * <ul>
+ *     <li>{@code source = LOCAL} means the coordinate is the build's own artifact, or one of its
+ *     dependencies, whose metadata this service itself uploads via {@link #upload}. Until that
+ *     upload happens, {@code checksum} is {@literal null}. That is precisely how the code tells
+ *     "declared but not yet uploaded" apart from "already uploaded". Once uploaded, {@code checksum}
+ *     holds the SHA-256 of the uploaded bytes, so a later {@link #open} call can tell whether the
+ *     plugin's local copy still matches what was last uploaded.</li>
+ *     <li>{@code source = ARTIFACTORY} means the coordinate is a third-party dependency whose
+ *     metadata already exists in the shared Artifactory registry (see {@link Artifactory}), so this
+ *     service never uploads anything for it. Its {@code checksum} column is therefore always
+ *     {@literal null}: that column only ever records what <em>this service</em> uploaded, and for an
+ *     {@code ARTIFACTORY} row that never happens. The Artifactory does have its own checksum for
+ *     the coordinate (see {@link Publication#checksum()}), but that value is only ever held in memory,
+ *     inside {@link ExistingArtifact}, for the duration of a single {@link #open} call, it is never
+ *     written to {@code service_artifacts.checksum}. See {@link CandidateArtifact#resolveChecksum}
+ *     for where this is enforced.</li>
+ * </ul>
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@Slf4j
+@NullMarked
 @RequiredArgsConstructor
 class DefaultServiceManifests implements ServiceManifests {
 
 	private static final String VERSION = "latest";
 
+	private final Marker RELEASE_OPENED = MarkerFactory.getMarker("SERVICE_RELEASE_OPENED");
+
 	private final DSLContext context;
 	private final Artifactory artifactory;
 
-	@NonNull
 	@Override
 	@Transactional(label = "service-manifest.open")
-	public ServiceRelease open(@NonNull Service service, @NonNull Collection<ServiceReleaseCandidate> artifacts) {
+	public ServiceRelease open(Service service, Collection<ServiceReleaseCandidate> artifacts) {
+		log.debug("Attempting to open a service manifest for {} with: {}", service, artifacts);
+
 		final Long releaseId = upsertRelease(service);
-		final Map<ArtifactCoordinates, ExistingArtifact> existing = loadExistingArtifacts(releaseId);
 
-		final Set<ArtifactCoordinates> coordinates = new LinkedHashSet<>();
-		for (ServiceReleaseCandidate candidate : artifacts) {
-			coordinates.add(ArtifactCoordinates.of(candidate));
-		}
+		// Convert the incoming candidates to their ArtifactCoordinates pairs...
+		final List<CandidateArtifact> candidates = artifacts.stream().map(CandidateArtifact::new).toList();
 
-		final Set<ArtifactCoordinates> indexed = artifactory.existing(coordinates);
+		// Merge in whatever the Artifactory already has indexed for these coordinates, without
+		// overriding a real, previously uploaded checksum already recorded for this release: a
+		// LOCAL row with a non-null checksum is settled and must win over merely being indexed.
+		final Map<ArtifactCoordinates, ExistingArtifact> existing = new LinkedHashMap<>();
+		existing.putAll(loadExistingPublications(artifacts));
+		existing.putAll(loadExistingServiceArtifacts(releaseId));
+
 		final List<ServiceReleaseEntry> entries = new ArrayList<>(artifacts.size());
 
-		var insert = context.insertInto(SERVICE_ARTIFACTS,
-				SERVICE_ARTIFACTS.RELEASE_ID, SERVICE_ARTIFACTS.GROUP_ID, SERVICE_ARTIFACTS.ARTIFACT_ID,
-				SERVICE_ARTIFACTS.VERSION, SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM);
+		// prepare the bulk insert query for the release///
+		var insert = context.insertInto(SERVICE_ARTIFACTS).columns(
+				SERVICE_ARTIFACTS.RELEASE_ID,
+				SERVICE_ARTIFACTS.GROUP_ID,
+				SERVICE_ARTIFACTS.ARTIFACT_ID,
+				SERVICE_ARTIFACTS.VERSION,
+				SERVICE_ARTIFACTS.SOURCE,
+				SERVICE_ARTIFACTS.CHECKSUM
+		);
 
-		for (ServiceReleaseCandidate candidate : artifacts) {
-			final ArtifactCoordinates coordinate = ArtifactCoordinates.of(candidate);
-			final ExistingArtifact current = existing.get(coordinate);
+		for (CandidateArtifact candidate : candidates) {
+			final ExistingArtifact current = existing.get(candidate.coordinates());
 
 			final ArtifactUploadStatus status;
 			final ArtifactSource source;
 			final String checksum;
 
-			if (current != null && current.checksum() != null && current.checksum().equals(candidate.checksum())) {
-				status = ArtifactUploadStatus.SKIP;
+			if (current != null) {
+				status = candidate.resolveStatus(current);
 				source = current.source();
-				checksum = current.checksum();
-			} else if (current != null && current.checksum() != null) {
-				status = ArtifactUploadStatus.UPLOAD_REQUIRED;
-				source = ArtifactSource.LOCAL;
-				checksum = null;
-			} else if (indexed.contains(coordinate)) {
-				status = ArtifactUploadStatus.SKIP;
-				source = ArtifactSource.ARTIFACTORY;
-				checksum = null;
+				checksum = candidate.resolveChecksum(status, current);
 			} else {
 				status = ArtifactUploadStatus.UPLOAD_REQUIRED;
 				source = ArtifactSource.LOCAL;
 				checksum = null;
 			}
 
-			entries.add(ServiceReleaseEntry.of(coordinate.groupId(), coordinate.artifactId(), coordinate.version().get(), status));
-			insert = insert.values(releaseId, coordinate.groupId(), coordinate.artifactId(), coordinate.version().get(), source.name(), checksum);
+			entries.add(ServiceReleaseEntry.of(candidate.artifact(), status));
+
+			// append the insert row statement for the artifact...
+			insert = insert.values(
+					releaseId,
+					candidate.coordinates().groupId(),
+					candidate.coordinates().artifactId(),
+					candidate.coordinates().version().get(),
+					source.name(),
+					checksum
+			);
 		}
 
-		if (!coordinates.isEmpty()) {
-			insert.onConflict(SERVICE_ARTIFACTS.RELEASE_ID, SERVICE_ARTIFACTS.GROUP_ID, SERVICE_ARTIFACTS.ARTIFACT_ID, SERVICE_ARTIFACTS.VERSION)
+		if (!candidates.isEmpty()) {
+			insert.onConflictOnConstraint(Keys.UNIQUE_SERVICE_ARTIFACT)
 					.doUpdate()
 					.set(SERVICE_ARTIFACTS.SOURCE, DSL.excluded(SERVICE_ARTIFACTS.SOURCE))
 					.set(SERVICE_ARTIFACTS.CHECKSUM, DSL.excluded(SERVICE_ARTIFACTS.CHECKSUM))
 					.execute();
 		}
 
-		pruneStaleArtifacts(releaseId, coordinates);
+		pruneStaleArtifacts(releaseId, candidates);
+
+		log.info(RELEASE_OPENED, "Successfully opened release {} for service {}: {} artifact(s) declared",
+				releaseId, service.id(), entries.size());
 
 		return ServiceRelease.builder()
 				.id(EntityId.from(releaseId).serialize())
@@ -98,8 +152,23 @@ class DefaultServiceManifests implements ServiceManifests {
 				.build();
 	}
 
-	@NonNull
-	private Long upsertRelease(@NonNull Service service) {
+	/**
+	 * Upserts the single {@code service_releases} row for this service to
+	 * {@link ReleaseState#PENDING}, taking over an in-progress or previously completed build rather
+	 * than rejecting it, since there is only ever one release row per service.
+	 * <p>
+	 * The upsert is keyed on the {@code unique_namespace_service_version} constraint with a fixed
+	 * {@link #VERSION}. Every build for a service therefore lands on the same row.
+	 * <p>
+	 * If proper version tracking (multiple retained releases, history, diffs) lands in a future,
+	 * this fixed-version upsert is what needs to change first, into an actual insert of a new row per
+	 * build. The release id returned from here is already addressable in every URL specifically so
+	 * that change doesn't have to touch the request/response protocol.
+	 *
+	 * @param service the service opening or taking over a build, can't be {@literal null}.
+	 * @return the entity identifier of the upserted release row, never {@literal null}.
+	 */
+	private Long upsertRelease(Service service) {
 		final Long releaseId = context.insertInto(SERVICE_RELEASES)
 				.set(
 						SettableRecord.of(context, SERVICE_RELEASES)
@@ -122,32 +191,97 @@ class DefaultServiceManifests implements ServiceManifests {
 		return releaseId;
 	}
 
-	@NonNull
-	private Map<ArtifactCoordinates, ExistingArtifact> loadExistingArtifacts(@NonNull Long releaseId) {
-		return context.select(SERVICE_ARTIFACTS.GROUP_ID, SERVICE_ARTIFACTS.ARTIFACT_ID, SERVICE_ARTIFACTS.VERSION,
-						SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
+	/**
+	 * Loads the {@code service_artifacts} rows already recorded for this release, keyed by their
+	 * {@link ArtifactCoordinates}.
+	 * <p>
+	 * This is the release's current state of record, checked against each incoming artifact in
+	 * {@link #open(Service, Collection)} to resolve its {@link ArtifactUploadStatus}: a matching
+	 * checksum means the metadata behind this coordinate was already uploaded and can be skipped; a
+	 * non-null but different checksum means it was uploaded before but is now stale; a coordinate
+	 * missing here entirely has never been seen in this release.
+	 *
+	 * @param releaseId the release to load existing artifacts for, can't be {@literal null}.
+	 * @return existing artifacts for the release keyed by their coordinates, never {@literal null}.
+	 */
+	private Map<ArtifactCoordinates, ExistingArtifact> loadExistingServiceArtifacts(Long releaseId) {
+		return context.select(
+						SERVICE_ARTIFACTS.GROUP_ID,
+						SERVICE_ARTIFACTS.ARTIFACT_ID,
+						SERVICE_ARTIFACTS.VERSION,
+						SERVICE_ARTIFACTS.SOURCE,
+						SERVICE_ARTIFACTS.CHECKSUM
+				)
 				.from(SERVICE_ARTIFACTS)
 				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
 				.fetchMap(
 						record -> ArtifactCoordinates.of(
-								record.get(SERVICE_ARTIFACTS.GROUP_ID), record.get(SERVICE_ARTIFACTS.ARTIFACT_ID), record.get(SERVICE_ARTIFACTS.VERSION)),
+								record.get(SERVICE_ARTIFACTS.GROUP_ID),
+								record.get(SERVICE_ARTIFACTS.ARTIFACT_ID),
+								record.get(SERVICE_ARTIFACTS.VERSION)
+						),
 						record -> new ExistingArtifact(
 								record.get(SERVICE_ARTIFACTS.CHECKSUM),
-								ArtifactSource.valueOf(record.get(SERVICE_ARTIFACTS.SOURCE)))
+								record.get(SERVICE_ARTIFACTS.SOURCE)
+						)
 				);
 	}
 
-	private void pruneStaleArtifacts(@NonNull Long releaseId, @NonNull Collection<ArtifactCoordinates> coordinates) {
-		if (coordinates.isEmpty()) {
+	/**
+	 * Resolves the {@link Publication} already indexed by the {@link Artifactory} for each of the
+	 * given candidates, keyed by {@link ArtifactCoordinates}.
+	 * <p>
+	 * Every match is reported as an {@link ArtifactSource#ARTIFACTORY} entry carrying the
+	 * {@link Publication}'s own checksum: since {@code service_artifacts.checksum} is always
+	 * {@literal null} for {@code ARTIFACTORY} rows, this is the only place that checksum is actually
+	 * available. Candidates with no matching {@link Publication} are simply absent from the result,
+	 * since they haven't been indexed yet.
+	 *
+	 * @param candidates the release candidates to resolve against the Artifactory, can't be {@literal null}.
+	 * @return existing publications keyed by their coordinates, never {@literal null}.
+	 */
+	private Map<ArtifactCoordinates, ExistingArtifact> loadExistingPublications(Collection<ServiceReleaseCandidate> candidates) {
+		final Map<ArtifactCoordinates, ExistingArtifact> existing = new LinkedHashMap<>();
+
+		if (candidates.isEmpty()) {
+			return existing;
+		}
+
+		final Set<ArtifactCoordinates> coordinates = new LinkedHashSet<>(candidates.size());
+		for (ServiceReleaseCandidate candidate : candidates) {
+			coordinates.add(ArtifactCoordinates.of(candidate));
+		}
+
+		for (Publication publication : artifactory.existing(coordinates)) {
+			existing.put(ArtifactCoordinates.of(publication), new ExistingArtifact(publication));
+		}
+
+		return existing;
+	}
+
+	/**
+	 * Deletes every {@code service_artifacts} row for this release whose coordinates are not part of
+	 * the given candidates.
+	 * <p>
+	 * This is how a declared artifact drops out of a release: a build that stops depending on a
+	 * coordinate it previously declared is expected to have that coordinate's row removed the next
+	 * time it resolves a release, rather than leaving it behind indefinitely.
+	 *
+	 * @param releaseId the release to prune, can't be {@literal null}.
+	 * @param candidates the complete, current set of declared candidates, can't be {@literal null}; an
+	 *                    empty collection removes every row for this release.
+	 */
+	private void pruneStaleArtifacts(Long releaseId, Collection<CandidateArtifact> candidates) {
+		if (candidates.isEmpty()) {
 			context.deleteFrom(SERVICE_ARTIFACTS)
 					.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
 					.execute();
 			return;
 		}
 
-		final String[] groupIds = coordinates.stream().map(ArtifactCoordinates::groupId).toArray(String[]::new);
-		final String[] artifactIds = coordinates.stream().map(ArtifactCoordinates::artifactId).toArray(String[]::new);
-		final String[] versions = coordinates.stream().map(coordinate -> coordinate.version().get()).toArray(String[]::new);
+		final String[] groupIds = candidates.stream().map(CandidateArtifact::artifact).map(Artifact::groupId).toArray(String[]::new);
+		final String[] artifactIds = candidates.stream().map(CandidateArtifact::artifact).map(Artifact::artifactId).toArray(String[]::new);
+		final String[] versions = candidates.stream().map(CandidateArtifact::artifact).map(Artifact::version).toArray(String[]::new);
 
 		context.deleteFrom(SERVICE_ARTIFACTS)
 				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
@@ -157,18 +291,132 @@ class DefaultServiceManifests implements ServiceManifests {
 				.execute();
 	}
 
+	/**
+	 * Not yet implemented. Notes for whoever picks this up:
+	 * <ul>
+	 *     <li>Reject the call if there is no {@code LOCAL} {@code service_artifacts} row for this
+	 *     release matching the given {@code metadata}'s coordinates — an upload for a coordinate that
+	 *     was never declared via {@link #open} should not be accepted.</li>
+	 *     <li>Reject the call if the release is not currently {@link ReleaseState#PENDING} — once a
+	 *     release is {@code RELEASED}, the plugin must call {@link #open} again to start a new build
+	 *     before uploading anything.</li>
+	 *     <li>Explode {@code metadata.properties()} into {@code service_configuration_catalog} rows
+	 *     for this coordinate, replacing whatever rows already exist there for it (a re-upload of the
+	 *     same coordinate should overwrite, not duplicate).</li>
+	 *     <li>Update the matching {@code service_artifacts} row's {@code checksum} to
+	 *     {@code metadata.checksum()} — this is what turns it from "declared" into "uploaded", see
+	 *     this class's own Javadoc for why that column doubles as that signal.</li>
+	 *     <li>Log the outcome, matching the {@code log.info(...)} call at the top of {@link #open}.</li>
+	 * </ul>
+	 *
+	 * @param service the service the release belongs to, can't be {@literal null}.
+	 * @param releaseId the entity identifier of the release the upload belongs to, can't be {@literal null}.
+	 * @param metadata the uploaded artifact metadata, can't be {@literal null}.
+	 */
 	@Override
-	public void upload(@NonNull Service service, @NonNull EntityId releaseId, @NonNull ArtifactMetadata metadata) {
+	public void upload(Service service, EntityId releaseId, ArtifactMetadata metadata) {
 		throw new UnsupportedOperationException("Not yet implemented");
 	}
 
-	@NonNull
+	/**
+	 * Not yet implemented. Notes for whoever picks this up:
+	 * <ul>
+	 *     <li>First check whether any {@code service_artifacts} row for this release still has
+	 *     {@code source = LOCAL AND checksum IS NULL} — meaning something declared via {@link #open}
+	 *     was never actually uploaded via {@link #upload}. If so, this release cannot complete: set
+	 *     {@code service_releases.state} to {@link ReleaseState#FAILED} and return a
+	 *     {@link ServiceRelease} whose {@link ServiceRelease#errors()} lists those coordinates.</li>
+	 *     <li>Otherwise, build the property catalog for this release in
+	 *     {@code service_configuration_catalog}. The {@code LOCAL} coordinates were already exploded
+	 *     into the catalog by {@link #upload}; what is still missing here is the {@code ARTIFACTORY}
+	 *     coordinates, whose property descriptors live in the Artifactory's own tables instead of
+	 *     having been uploaded directly. {@code ServiceCatalogWorker} (in the sibling
+	 *     {@code com.konfigyr.namespace.catalog} package) already contains the exact join needed —
+	 *     from {@code service_artifacts} through {@code artifacts}, {@code artifact_versions},
+	 *     {@code artifact_version_properties}, to {@code property_definitions} — but it is
+	 *     package-private today, so either expose it for reuse here or re-create the same join.</li>
+	 *     <li>Set {@code service_releases.state} to {@link ReleaseState#RELEASED} and
+	 *     {@code published_at} to the current time.</li>
+	 *     <li>Publish a {@code ServiceEvent.Released} event so that
+	 *     {@code ServiceCatalogQueueListener} picks up this release for indexing. Building that event
+	 *     needs the {@link Service} (already a parameter here) and a {@code Manifest}
+	 *     ({@code Services.manifest(Service)}), which means this class needs a new dependency on
+	 *     {@code Services} that it does not have today.</li>
+	 *     <li>Log the outcome, matching the {@code log.info(...)} call at the top of {@link #open}.</li>
+	 * </ul>
+	 *
+	 * @param service the service the release belongs to, can't be {@literal null}.
+	 * @param releaseId the entity identifier of the release to complete, can't be {@literal null}.
+	 * @return the completed service release, never {@literal null}.
+	 */
 	@Override
-	public ServiceRelease complete(@NonNull Service service, @NonNull EntityId releaseId) {
+	public ServiceRelease complete(Service service, EntityId releaseId) {
 		throw new UnsupportedOperationException("Not yet implemented");
 	}
 
+	private record CandidateArtifact(ArtifactCoordinates coordinates, ServiceReleaseCandidate artifact) {
+
+		private CandidateArtifact(ServiceReleaseCandidate candidate) {
+			this(ArtifactCoordinates.of(candidate),  candidate);
+		}
+
+		/**
+		 * Resolves the {@link ArtifactUploadStatus} of this candidate against what is already known
+		 * about its coordinates, either a previously recorded {@code service_artifacts} row or a
+		 * {@link Publication} indexed by the {@link Artifactory}.
+		 * <p>
+		 * An {@link ArtifactSource#ARTIFACTORY} match is always {@link ArtifactUploadStatus#SKIP},
+		 * regardless of checksum: the plugin never uploads a dependency it doesn't own, so there is
+		 * nothing to compare against. Otherwise, the outcome depends on whether this candidate's own
+		 * checksum matches what was already recorded.
+		 *
+		 * @param existing what is already known about this candidate's coordinates, can't be {@literal null}.
+		 * @return the resolved upload status, never {@literal null}.
+		 */
+		private ArtifactUploadStatus resolveStatus(ExistingArtifact existing) {
+			if (existing.source() == ArtifactSource.ARTIFACTORY) {
+				return ArtifactUploadStatus.SKIP;
+			}
+			return Objects.equals(artifact().checksum(), existing.checksum()) ?
+					ArtifactUploadStatus.SKIP : ArtifactUploadStatus.UPLOAD_REQUIRED;
+		}
+
+		/**
+		 * Resolves the checksum that should be persisted to {@code service_artifacts.checksum} for
+		 * this candidate, given its resolved {@code status}.
+		 * <p>
+		 * {@literal null} is the "not yet uploaded" signal for a {@link ArtifactSource#LOCAL} row, so
+		 * it must only be replaced with a real value once a matching, already-uploaded checksum is
+		 * confirmed, i.e. {@code status} is {@link ArtifactUploadStatus#SKIP} and {@code existing} is
+		 * {@link ArtifactSource#LOCAL}. Every other outcome persists {@literal null}: an
+		 * {@link ArtifactSource#ARTIFACTORY} row has no local upload to checksum in the first place,
+		 * and anything that isn't {@code SKIP} still needs to be uploaded, so carrying over its old or
+		 * unrelated checksum would wrongly read back as already settled.
+		 *
+		 * @param status the resolved upload status for this candidate, can't be {@literal null}.
+		 * @param existing what is already known about this candidate's coordinates, can't be {@literal null}.
+		 * @return the checksum to persist, or {@literal null} when nothing settled should be recorded.
+		 */
+		private String resolveChecksum(ArtifactUploadStatus status, ExistingArtifact existing) {
+			return status == ArtifactUploadStatus.SKIP && existing.source() == ArtifactSource.LOCAL
+					? existing.checksum()
+					: null;
+		}
+	}
+
+	/**
+	 * A previously recorded {@code service_artifacts} row for a single coordinate within a release.
+	 */
 	private record ExistingArtifact(String checksum, ArtifactSource source) {
+
+		private ExistingArtifact(Publication publication) {
+			this(publication.checksum(), ArtifactSource.ARTIFACTORY);
+		}
+
+		private ExistingArtifact(String checksum, String source) {
+			this(checksum, ArtifactSource.valueOf(source));
+		}
+
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestConfiguration.java
@@ -1,0 +1,20 @@
+package com.konfigyr.namespace.manifest;
+
+import com.konfigyr.artifactory.Artifactory;
+import lombok.RequiredArgsConstructor;
+import org.jooq.DSLContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@RequiredArgsConstructor
+@Configuration(proxyBeanMethods = false)
+public class ServiceManifestConfiguration {
+
+	private final DSLContext context;
+
+	@Bean
+	ServiceManifests serviceManifests(Artifactory artifactory) {
+		return new DefaultServiceManifests(context, artifactory);
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
@@ -210,6 +210,7 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 		final var unknownArtifact = ArtifactCoordinates.parse("com.konfigyr:konfigyr-unknown:1.0.0");
 
 		assertThat(artifactory.existing(List.of(existing, alsoExisting, unknownVersion, unknownArtifact)))
+				.extracting(ArtifactCoordinates::of)
 				.containsExactlyInAnyOrder(existing, alsoExisting);
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -1,0 +1,263 @@
+package com.konfigyr.namespace.controller;
+
+import com.konfigyr.artifactory.ArtifactSource;
+import com.konfigyr.artifactory.ArtifactUploadStatus;
+import com.konfigyr.artifactory.ServiceRelease;
+import com.konfigyr.artifactory.ServiceReleaseCandidate;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.test.AbstractControllerTest;
+import com.konfigyr.test.TestPrincipals;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+
+class ServiceManifestControllerTest extends AbstractControllerTest {
+
+	@Autowired
+	DSLContext context;
+
+	@Test
+	@Transactional
+	@DisplayName("should open a new release when the service has none")
+	void shouldOpenNewRelease() {
+		final var request = new ServiceManifestController.ResolveReleaseRequest(List.of(
+				ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1"),
+				ServiceReleaseCandidate.of("com.acme", "other-service", "2.0.0", "checksum-2")
+		));
+
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(request))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.returns(com.konfigyr.artifactory.ReleaseState.PENDING, ServiceRelease::state)
+				.satisfies(release -> assertThat(release.artifacts())
+						.hasSize(2)
+						.allSatisfy(entry -> assertThat(entry.status()).isEqualTo(ArtifactUploadStatus.UPLOAD_REQUIRED))
+				);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should skip an artifact that is already indexed in the Artifactory")
+	void shouldSkipIndexedArtifact() {
+		final var request = new ServiceManifestController.ResolveReleaseRequest(List.of(
+				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-crypto-api", "1.0.0", "irrelevant-checksum")
+		));
+
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(request))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.satisfies(release -> assertThat(release.artifacts())
+						.hasSize(1)
+						.first()
+						.returns(ArtifactUploadStatus.SKIP, entry -> entry.status())
+				);
+
+		assertThat(context.select(SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
+				.from(SERVICE_ARTIFACTS)
+				.where(SERVICE_ARTIFACTS.GROUP_ID.eq("com.konfigyr"))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq("konfigyr-crypto-api"))
+				.and(SERVICE_ARTIFACTS.VERSION.eq("1.0.0"))
+				.fetchOne())
+				.satisfies(record -> {
+					assertThat(record.get(SERVICE_ARTIFACTS.SOURCE)).isEqualTo(ArtifactSource.ARTIFACTORY.name());
+					assertThat(record.get(SERVICE_ARTIFACTS.CHECKSUM)).isNull();
+				});
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should take over an existing release and skip artifacts with a matching checksum")
+	void shouldTakeOverExistingRelease() {
+		final var request = new ServiceManifestController.ResolveReleaseRequest(List.of(
+				ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1")
+		));
+
+		final ServiceRelease first = mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(request))
+				.exchange()
+				.assertThat()
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.actual();
+
+		// simulate T8's upload() having already recorded this checksum for the artifact
+		markUploaded("com.acme", "my-service", "1.2.0", "checksum-1");
+
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(request))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.returns(first.id(), ServiceRelease::id)
+				.satisfies(release -> assertThat(release.artifacts())
+						.hasSize(1)
+						.first()
+						.returns(ArtifactUploadStatus.SKIP, entry -> entry.status())
+				);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should mark an artifact upload required when its checksum changed")
+	void shouldRequireUploadWhenChecksumChanged() {
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
+						ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1")
+				))))
+				.exchange()
+				.assertThat()
+				.hasStatusOk();
+
+		// simulate T8's upload() having already recorded the old checksum for the artifact
+		markUploaded("com.acme", "my-service", "1.2.0", "checksum-1");
+
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
+						ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-2")
+				))))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.satisfies(release -> assertThat(release.artifacts())
+						.hasSize(1)
+						.first()
+						.returns(ArtifactUploadStatus.UPLOAD_REQUIRED, entry -> entry.status())
+				);
+	}
+
+	private void markUploaded(String groupId, String artifactId, String version, String checksum) {
+		final int updated = context.update(SERVICE_ARTIFACTS)
+				.set(SERVICE_ARTIFACTS.CHECKSUM, checksum)
+				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(groupId))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(artifactId))
+				.and(SERVICE_ARTIFACTS.VERSION.eq(version))
+				.execute();
+
+		assertThat(updated).as("Expected an existing service_artifacts row to update").isOne();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should prune artifacts that are no longer declared")
+	void shouldPruneStaleArtifacts() {
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
+						ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1"),
+						ServiceReleaseCandidate.of("com.acme", "other-service", "2.0.0", "checksum-2")
+				))))
+				.exchange()
+				.assertThat()
+				.hasStatusOk();
+
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
+						ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1")
+				))))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.satisfies(release -> assertThat(release.artifacts()).hasSize(1));
+
+		assertThat(context.fetchExists(SERVICE_ARTIFACTS,
+				SERVICE_ARTIFACTS.GROUP_ID.eq("com.acme").and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq("other-service"))
+		)).isFalse();
+	}
+
+	@Test
+	@DisplayName("should not resolve a release when user is not a member of the namespace")
+	void shouldRejectWhenNotAMember() {
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of())))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should not resolve a release when the publish-manifests scope is not present")
+	void shouldRejectWithoutScope() {
+		mvc.post().uri("/namespaces/konfigyr/services/konfigyr-id/releases")
+				.with(authentication(TestPrincipals.john()))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of())))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.PUBLISH_MANIFESTS));
+	}
+
+	@Test
+	@DisplayName("should fail to resolve a release for an unknown service")
+	void shouldRejectUnknownService() {
+		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of())))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound("unknown-service"));
+	}
+
+	@Test
+	@DisplayName("should fail to resolve a release for an unknown namespace")
+	void shouldRejectUnknownNamespace() {
+		mvc.post().uri("/namespaces/unknown-namespace/services/unknown-service/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of())))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(namespaceNotFound("unknown-namespace"));
+	}
+
+}

--- a/konfigyr-data/src/main/resources/migrations/namespaces/namespaces-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/namespaces/namespaces-1.0.0.xml
@@ -366,6 +366,12 @@
 				referencedColumnNames="id"
 				onDelete="CASCADE"
 		/>
+
+		<addUniqueConstraint
+				tableName="service_artifacts"
+				columnNames="release_id, group_id, artifact_id, version"
+				constraintName="unique_service_artifact"
+		/>
 	</changeSet>
 
 	<changeSet author="vspasic" id="1.0.0-create-service-configuration-catalog-table" context="api">


### PR DESCRIPTION
## Summary
Introduces `DefaultServiceManifests.open()`: upserts the single `service_releases` row for a service to `PENDING` (taking over any in-progress or previously-released build), resolves each declared artifact's status by checking previously-uploaded checksums first, then the Artifactory index, then falls back to `UPLOAD_REQUIRED`, and prunes `service_artifacts` rows no longer declared.

Wires it behind `POST /namespaces/{ns}/services/{svc}/releases` in a new `ServiceManifestController`, authorized the same way the rest of `ServicesController` is (`@PreAuthorize("isMember(#namespace)")` + `@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)`).