### PR TITLE
Add artifact metadata upload endpoint for service manifests

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
@@ -15,11 +15,13 @@ import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -50,11 +52,12 @@ class ServiceManifestController {
 	}
 
 	@PostMapping("/{id}/artifacts")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@PreAuthorize("isMember(#namespace)")
 	void upload(
 			@PathVariable String namespace,
 			@PathVariable String slug,
-			@PathVariable String id,
+			@PathVariable EntityId id,
 			@RequestBody ArtifactMetadata metadata
 	) {
 		final Namespace ns = lookupNamespace(namespace);
@@ -62,7 +65,7 @@ class ServiceManifestController {
 				() -> new ServiceNotFoundException(namespace, slug)
 		);
 
-		manifests.upload(service, EntityId.from(id), metadata);
+		manifests.upload(service, id, metadata);
 	}
 
 	@NonNull

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
@@ -13,11 +13,9 @@ import com.konfigyr.namespace.Services;
 import com.konfigyr.namespace.manifest.ServiceManifests;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
-import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,14 +39,14 @@ class ServiceManifestController {
 	ServiceRelease resolve(
 			@PathVariable String namespace,
 			@PathVariable String slug,
-			@RequestBody @Validated ResolveReleaseRequest request
+			@RequestBody List<ServiceReleaseCandidate> candidates
 	) {
 		final Namespace ns = lookupNamespace(namespace);
 		final Service service = services.get(ns, slug).orElseThrow(
 				() -> new ServiceNotFoundException(namespace, slug)
 		);
 
-		return manifests.open(service, request.artifacts());
+		return manifests.open(service, candidates);
 	}
 
 	@PostMapping("/{id}/artifacts")
@@ -70,10 +68,6 @@ class ServiceManifestController {
 	@NonNull
 	Namespace lookupNamespace(@NonNull String slug) {
 		return namespaces.findBySlug(slug).orElseThrow(() -> new NamespaceNotFoundException(slug));
-	}
-
-	record ResolveReleaseRequest(@NotNull List<@NotNull ServiceReleaseCandidate> artifacts) {
-
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
@@ -1,7 +1,9 @@
 package com.konfigyr.namespace.controller;
 
+import com.konfigyr.artifactory.ArtifactMetadata;
 import com.konfigyr.artifactory.ServiceRelease;
 import com.konfigyr.artifactory.ServiceReleaseCandidate;
+import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.Namespace;
 import com.konfigyr.namespace.NamespaceManager;
 import com.konfigyr.namespace.NamespaceNotFoundException;
@@ -47,6 +49,22 @@ class ServiceManifestController {
 		);
 
 		return manifests.open(service, request.artifacts());
+	}
+
+	@PostMapping("/{id}/artifacts")
+	@PreAuthorize("isMember(#namespace)")
+	void upload(
+			@PathVariable String namespace,
+			@PathVariable String slug,
+			@PathVariable String id,
+			@RequestBody ArtifactMetadata metadata
+	) {
+		final Namespace ns = lookupNamespace(namespace);
+		final Service service = services.get(ns, slug).orElseThrow(
+				() -> new ServiceNotFoundException(namespace, slug)
+		);
+
+		manifests.upload(service, EntityId.from(id), metadata);
 	}
 
 	@NonNull

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
@@ -19,6 +19,7 @@ import java.time.OffsetDateTime;
 import java.util.*;
 
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
+import static com.konfigyr.data.tables.ServiceConfigurationCatalog.SERVICE_CONFIGURATION_CATALOG;
 import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
 
 /**
@@ -69,9 +70,11 @@ class DefaultServiceManifests implements ServiceManifests {
 	private static final String VERSION = "latest";
 
 	private final Marker RELEASE_OPENED = MarkerFactory.getMarker("SERVICE_RELEASE_OPENED");
+	private final Marker ARTIFACT_UPLOADED = MarkerFactory.getMarker("SERVICE_ARTIFACT_UPLOADED");
 
 	private final DSLContext context;
 	private final Artifactory artifactory;
+	private final ArtifactoryConverters converters;
 
 	@Override
 	@Transactional(label = "service-manifest.open")
@@ -292,30 +295,105 @@ class DefaultServiceManifests implements ServiceManifests {
 	}
 
 	/**
-	 * Not yet implemented. Notes for whoever picks this up:
-	 * <ul>
-	 *     <li>Reject the call if there is no {@code LOCAL} {@code service_artifacts} row for this
-	 *     release matching the given {@code metadata}'s coordinates — an upload for a coordinate that
-	 *     was never declared via {@link #open} should not be accepted.</li>
-	 *     <li>Reject the call if the release is not currently {@link ReleaseState#PENDING} — once a
-	 *     release is {@code RELEASED}, the plugin must call {@link #open} again to start a new build
-	 *     before uploading anything.</li>
-	 *     <li>Explode {@code metadata.properties()} into {@code service_configuration_catalog} rows
-	 *     for this coordinate, replacing whatever rows already exist there for it (a re-upload of the
-	 *     same coordinate should overwrite, not duplicate).</li>
-	 *     <li>Update the matching {@code service_artifacts} row's {@code checksum} to
-	 *     {@code metadata.checksum()} — this is what turns it from "declared" into "uploaded", see
-	 *     this class's own Javadoc for why that column doubles as that signal.</li>
-	 *     <li>Log the outcome, matching the {@code log.info(...)} call at the top of {@link #open}.</li>
-	 * </ul>
+	 * Uploads the configuration property metadata for a single artifact that was previously declared
+	 * for this release via {@link #open}.
+	 * <p>
+	 * The given {@code metadata}'s coordinates must match a {@code LOCAL} {@code service_artifacts} row
+	 * already recorded for this release; anything else — a coordinate never declared, or one declared
+	 * as {@code ARTIFACTORY} rather than {@code LOCAL} — is rejected with an
+	 * {@link UndeclaredArtifactException}. The release must also still be {@link ReleaseState#PENDING},
+	 * otherwise a {@link ReleaseNotPendingException} is thrown: once a release is {@code RELEASED}, the
+	 * plugin must call {@link #open} again to start a new build before uploading anything.
+	 * <p>
+	 * {@code metadata.properties()} is exploded into {@code service_configuration_catalog} rows for
+	 * this coordinate, replacing whatever rows already exist there for it, so a re-upload of the same
+	 * coordinate overwrites rather than duplicates. The matching {@code service_artifacts} row's
+	 * {@code checksum} is then updated to {@code metadata.checksum()} — this is what turns it from
+	 * "declared" into "uploaded", see this class's own Javadoc for why that column doubles as that
+	 * signal.
 	 *
 	 * @param service the service the release belongs to, can't be {@literal null}.
 	 * @param releaseId the entity identifier of the release the upload belongs to, can't be {@literal null}.
 	 * @param metadata the uploaded artifact metadata, can't be {@literal null}.
+	 * @throws UndeclaredArtifactException if the metadata's coordinates were not declared for this
+	 *         release as a {@code LOCAL} artifact.
+	 * @throws ReleaseNotPendingException if the release is not currently {@link ReleaseState#PENDING}.
 	 */
 	@Override
+	@Transactional(label = "service-manifest.upload")
 	public void upload(Service service, EntityId releaseId, ArtifactMetadata metadata) {
-		throw new UnsupportedOperationException("Not yet implemented");
+		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(metadata);
+
+		log.debug("Attempting to upload artifact metadata for {} to release {} for service {}",
+				coordinates, releaseId, service);
+
+		final ReleaseState state = context.select(SERVICE_RELEASES.STATE)
+				.from(SERVICE_ARTIFACTS)
+				.join(SERVICE_RELEASES).on(SERVICE_RELEASES.ID.eq(SERVICE_ARTIFACTS.RELEASE_ID))
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()))
+				.and(SERVICE_RELEASES.SERVICE_ID.eq(service.id().get()))
+				.and(SERVICE_ARTIFACTS.GROUP_ID.eq(coordinates.groupId()))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()))
+				.and(SERVICE_ARTIFACTS.VERSION.eq(coordinates.version().get()))
+				.and(SERVICE_ARTIFACTS.SOURCE.eq(ArtifactSource.LOCAL.name()))
+				.fetchOptional(SERVICE_RELEASES.STATE)
+				.map(ReleaseState::valueOf)
+				.orElseThrow(() -> new UndeclaredArtifactException(coordinates));
+
+		if (state != ReleaseState.PENDING) {
+			throw new ReleaseNotPendingException(releaseId, state);
+		}
+
+		context.deleteFrom(SERVICE_CONFIGURATION_CATALOG)
+				.where(SERVICE_CONFIGURATION_CATALOG.RELEASE_ID.eq(releaseId.get()))
+				.and(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(coordinates.groupId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(coordinates.artifactId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(coordinates.version().get()))
+				.execute();
+
+		var insert = context.insertInto(SERVICE_CONFIGURATION_CATALOG).columns(
+				SERVICE_CONFIGURATION_CATALOG.SERVICE_ID,
+				SERVICE_CONFIGURATION_CATALOG.RELEASE_ID,
+				SERVICE_CONFIGURATION_CATALOG.GROUP_ID,
+				SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID,
+				SERVICE_CONFIGURATION_CATALOG.VERSION,
+				SERVICE_CONFIGURATION_CATALOG.NAME,
+				SERVICE_CONFIGURATION_CATALOG.TYPE_NAME,
+				SERVICE_CONFIGURATION_CATALOG.SCHEMA,
+				SERVICE_CONFIGURATION_CATALOG.DEFAULT_VALUE,
+				SERVICE_CONFIGURATION_CATALOG.DESCRIPTION,
+				SERVICE_CONFIGURATION_CATALOG.DEPRECATION
+		);
+
+		for (PropertyDescriptor property : metadata.properties()) {
+			insert = insert.values(
+					service.id().get(),
+					releaseId.get(),
+					coordinates.groupId(),
+					coordinates.artifactId(),
+					coordinates.version().get(),
+					property.name(),
+					property.typeName(),
+					converters.schema().to(property.schema()),
+					property.defaultValue(),
+					property.description(),
+					converters.deprecation().to(property.deprecation())
+			);
+		}
+
+		if (!metadata.properties().isEmpty()) {
+			insert.execute();
+		}
+
+		context.update(SERVICE_ARTIFACTS)
+				.set(SERVICE_ARTIFACTS.CHECKSUM, metadata.checksum())
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()))
+				.and(SERVICE_ARTIFACTS.GROUP_ID.eq(coordinates.groupId()))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()))
+				.and(SERVICE_ARTIFACTS.VERSION.eq(coordinates.version().get()))
+				.execute();
+
+		log.info(ARTIFACT_UPLOADED, "Successfully uploaded artifact metadata for {} to release {}", coordinates, releaseId);
 	}
 
 	/**

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ReleaseNotPendingException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ReleaseNotPendingException.java
@@ -1,0 +1,55 @@
+package com.konfigyr.namespace.manifest;
+
+import com.konfigyr.artifactory.ReleaseState;
+import com.konfigyr.entity.EntityId;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown when artifact metadata is uploaded via {@link ServiceManifests#upload} for a
+ * release that is not currently {@link ReleaseState#PENDING}. A new build must be started through
+ * {@link ServiceManifests#open} before any further metadata can be uploaded.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ **/
+public class ReleaseNotPendingException extends ServiceManifestException {
+
+	@Serial
+	private static final long serialVersionUID = 8014237154920064582L;
+
+	private final EntityId releaseId;
+	private final ReleaseState state;
+
+	/**
+	 * Create new instance of the {@link ReleaseNotPendingException} for the given release and its
+	 * current, non-{@link ReleaseState#PENDING} state.
+	 *
+	 * @param releaseId the entity identifier of the release, can't be {@literal null}
+	 * @param state the current state of the release, can't be {@literal null}
+	 */
+	public ReleaseNotPendingException(@NonNull EntityId releaseId, @NonNull ReleaseState state) {
+		super(HttpStatus.CONFLICT, "Release %s is not pending, current state is: %s".formatted(releaseId.serialize(), state));
+		this.releaseId = releaseId;
+		this.state = state;
+	}
+
+	@Override
+	public Object @Nullable [] getDetailMessageArguments() {
+		return new Object[] { releaseId.serialize(), state };
+	}
+
+	@NonNull
+	public EntityId getReleaseId() {
+		return releaseId;
+	}
+
+	@NonNull
+	public ReleaseState getState() {
+		return state;
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestConfiguration.java
@@ -1,6 +1,7 @@
 package com.konfigyr.namespace.manifest;
 
 import com.konfigyr.artifactory.Artifactory;
+import com.konfigyr.artifactory.ArtifactoryConverters;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.springframework.context.annotation.Bean;
@@ -13,8 +14,8 @@ public class ServiceManifestConfiguration {
 	private final DSLContext context;
 
 	@Bean
-	ServiceManifests serviceManifests(Artifactory artifactory) {
-		return new DefaultServiceManifests(context, artifactory);
+	ServiceManifests serviceManifests(Artifactory artifactory, ArtifactoryConverters converters) {
+		return new DefaultServiceManifests(context, artifactory, converters);
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestException.java
@@ -1,0 +1,56 @@
+package com.konfigyr.namespace.manifest;
+
+import com.konfigyr.namespace.NamespaceException;
+import org.springframework.http.HttpStatusCode;
+
+/**
+ * Exception type that would usually be thrown when interacting with {@link ServiceManifests}.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ **/
+public class ServiceManifestException extends NamespaceException {
+
+	/**
+	 * Create a new instance of {@link ServiceManifestException} with the specified error message.
+	 *
+	 * @param message the error message
+	 */
+	public ServiceManifestException(String message) {
+		super(message);
+	}
+
+	/**
+	 * Create a new instance of {@link ServiceManifestException} with the specified error message and HTTP status code.
+	 *
+	 * @param statusCode HTTP status code
+	 * @param message the error message
+	 */
+	public ServiceManifestException(HttpStatusCode statusCode, String message) {
+		super(statusCode, message);
+	}
+
+	/**
+	 * Create a new instance of {@link ServiceManifestException} with the specified error message and
+	 * the exception that caused it.
+	 *
+	 * @param message the error message
+	 * @param cause the exception cause, or {@literal null} if none
+	 */
+	public ServiceManifestException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	/**
+	 * Create a new instance of {@link ServiceManifestException} with the specified error message, HTTP status code
+	 * and the exception that caused it.
+	 *
+	 * @param statusCode HTTP status code
+	 * @param message the error message
+	 * @param cause the exception cause, or {@literal null} if none
+	 */
+	public ServiceManifestException(HttpStatusCode statusCode, String message, Throwable cause) {
+		super(statusCode, message, cause);
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/UndeclaredArtifactException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/UndeclaredArtifactException.java
@@ -1,0 +1,45 @@
+package com.konfigyr.namespace.manifest;
+
+import com.konfigyr.artifactory.ArtifactCoordinates;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown when artifact metadata is uploaded via {@link ServiceManifests#upload} for
+ * {@link ArtifactCoordinates coordinates} that were never declared for the release through a prior
+ * {@link ServiceManifests#open} call.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ **/
+public class UndeclaredArtifactException extends ServiceManifestException {
+
+	@Serial
+	private static final long serialVersionUID = -1092134450472819547L;
+
+	private final ArtifactCoordinates coordinates;
+
+	/**
+	 * Create new instance of the {@link UndeclaredArtifactException} for the given {@link ArtifactCoordinates}.
+	 *
+	 * @param coordinates the coordinates that were not declared for the release, can't be {@literal null}
+	 */
+	public UndeclaredArtifactException(@NonNull ArtifactCoordinates coordinates) {
+		super(HttpStatus.NOT_FOUND, "Artifact was not declared for this release: " + coordinates.format());
+		this.coordinates = coordinates;
+	}
+
+	@Override
+	public Object @Nullable [] getDetailMessageArguments() {
+		return new Object[] { coordinates.format() };
+	}
+
+	@NonNull
+	public ArtifactCoordinates getCoordinates() {
+		return coordinates;
+	}
+
+}

--- a/konfigyr-api/src/main/resources/messages/problem-detail.properties
+++ b/konfigyr-api/src/main/resources/messages/problem-detail.properties
@@ -302,3 +302,13 @@ problemDetail.com.konfigyr.artifactory.ArtifactVersionNotFoundException=Could no
 problemDetail.title.com.konfigyr.artifactory.ArtifactVersionExistsException=Artifact already exists
 problemDetail.com.konfigyr.artifactory.ArtifactVersionExistsException=You attempted to create a new artifact with \
   coordinates ''{0}'' that already exists. Please use a different release version and try again.
+
+## Service manifest module exceptions ##
+
+problemDetail.title.com.konfigyr.namespace.manifest.UndeclaredArtifactException=Artifact not declared for this release
+problemDetail.com.konfigyr.namespace.manifest.UndeclaredArtifactException=The artifact with coordinates ''{0}'' was not \
+  declared for this release. Resolve the release again to declare it before uploading its metadata.
+
+problemDetail.title.com.konfigyr.namespace.manifest.ReleaseNotPendingException=Release is not pending
+problemDetail.com.konfigyr.namespace.manifest.ReleaseNotPendingException=Release is no longer pending. \
+  Resolve the release again to declare it before uploading its metadata.

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -348,7 +348,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	void shouldRejectUnknownServiceForArtifactUpload() {
 		final var metadata = metadata(konfigyrCryptoApiArtifact, "crypto-checksum");
 
-		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases/release/artifacts")
+		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases/{id}/artifacts", EntityId.from(999).serialize())
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(metadata))

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -2,12 +2,14 @@ package com.konfigyr.namespace.controller;
 
 import com.konfigyr.artifactory.*;
 import com.konfigyr.entity.EntityId;
+import com.konfigyr.io.ByteArray;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.test.AbstractControllerTest;
 import com.konfigyr.test.TestPrincipals;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.assertj.core.api.ObjectAssert;
 import org.jooq.DSLContext;
+import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MvcTestResultAssert;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
@@ -161,7 +164,9 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				PropertyDescriptor.builder()
 						.name("com.konfigyr.konfigyr-artifactory.enabled")
 						.typeName("java.lang.Boolean")
-						.schema(StringSchema.instance())
+						.schema(BooleanSchema.instance())
+						.description("Enables the artifact metadata upload")
+						.defaultValue("true")
 						.build()
 		));
 
@@ -183,16 +188,30 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.containsEntry(SERVICE_ARTIFACTS.SOURCE.getName(), ArtifactSource.LOCAL.name())
 				.containsEntry(SERVICE_ARTIFACTS.CHECKSUM.getName(), metadata.checksum());
 
-		assertThat(context.select(SERVICE_CONFIGURATION_CATALOG.NAME, SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR)
+		final var properties = context.select(SERVICE_CONFIGURATION_CATALOG.fields())
 				.from(SERVICE_CONFIGURATION_CATALOG)
 				.where(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(metadata.groupId()))
 				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(metadata.artifactId()))
 				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(metadata.version()))
-				.fetch())
-				.hasSize(metadata.properties().size())
-				.allSatisfy(it -> assertThat(it.get(SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR)).isNotNull())
-				.extracting(it -> it.get(SERVICE_CONFIGURATION_CATALOG.NAME))
-				.containsExactlyInAnyOrderElementsOf(metadata.properties().stream().map(PropertyDescriptor::name).toList());
+				.fetch(Record::intoMap);
+
+		assertThat(properties)
+				.hasSize(1)
+				.first(InstanceOfAssertFactories.map(String.class, Object.class))
+				.containsEntry(SERVICE_CONFIGURATION_CATALOG.NAME.getName(), "com.konfigyr.konfigyr-artifactory.enabled")
+				.containsEntry(SERVICE_CONFIGURATION_CATALOG.TYPE_NAME.getName(), "java.lang.Boolean")
+				.containsEntry(SERVICE_CONFIGURATION_CATALOG.DEFAULT_VALUE.getName(), "true")
+				.containsEntry(SERVICE_CONFIGURATION_CATALOG.DESCRIPTION.getName(), "Enables the artifact metadata upload")
+				.containsEntry(SERVICE_CONFIGURATION_CATALOG.DEPRECATION.getName(), null)
+				.hasEntrySatisfying(SERVICE_CONFIGURATION_CATALOG.SCHEMA.getName(), it -> assertThat(it)
+						.isNotNull()
+						.isInstanceOf(ByteArray.class)
+						.asInstanceOf(InstanceOfAssertFactories.type(ByteArray.class))
+						.returns("{\"type\":\"boolean\"}", bytes -> bytes.toString(StandardCharsets.UTF_8))
+				)
+				.hasEntrySatisfying(SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR.getName(), it -> assertThat(it)
+						.isNotNull()
+				);
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -14,12 +14,16 @@ import org.jooq.impl.DSL;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.assertj.MvcTestResultAssert;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.List;
 
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
@@ -104,7 +108,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 		// checksum-1 is what the plugin already declared for this coordinate above, so uploading
 		// metadata carrying that same checksum is what settles it as "already uploaded"
 		assertThatUpload(first.id(), metadata)
-				.hasStatusOk();
+				.hasStatus(HttpStatus.NO_CONTENT);
 
 		assertThatRelease(ServiceReleaseCandidate.of(metadata))
 				.returns(first.id(), ServiceRelease::id)
@@ -127,7 +131,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 		// `initial-checksum` is what the plugin already declared for this coordinate above, so uploading
 		// metadata carrying that same checksum is what settles it as "already uploaded"
 		assertThatUpload(release.id(), metadata)
-				.hasStatusOk();
+				.hasStatus(HttpStatus.NO_CONTENT);
 
 		assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "different-checksum"))
 				.returns(release.id(), ServiceRelease::id)
@@ -175,7 +179,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.actual();
 
 		assertThatUpload(release.id(), metadata)
-				.hasStatusOk();
+				.hasStatus(HttpStatus.NO_CONTENT);
 
 		final var record = context.select(SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
 				.from(SERVICE_ARTIFACTS)
@@ -216,6 +220,37 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 
 	@Test
 	@Transactional
+	@DisplayName("should upload artifact metadata containing a large number of properties")
+	void shouldUploadLargeArtifactMetadata() throws IOException {
+		final ArtifactMetadata metadata = jsonMapper.readValue(
+				new ClassPathResource("fixtures/org.springframework.boot-spring-boot-autoconfigure-3.5.7.json").getInputStream(),
+				ArtifactMetadata.class
+		);
+
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(metadata))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
+
+		final Instant start = Instant.now();
+
+		assertThatUpload(release.id(), metadata)
+				.hasStatus(HttpStatus.NO_CONTENT);
+
+		// loose sanity bound, not a precise perf assertion: catches a genuine regression
+		// (e.g. row-by-row inserts instead of a bulk insert) without flaking on CI noise
+		assertThat(Duration.between(start, Instant.now()))
+				.as("Uploading a large artifact metadata payload should complete quickly")
+				.isLessThan(Duration.ofSeconds(5));
+
+		assertThat(context.fetchCount(SERVICE_CONFIGURATION_CATALOG,
+				SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(metadata.groupId())
+						.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(metadata.artifactId()))
+						.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(metadata.version()))
+		)).isEqualTo(metadata.properties().size());
+	}
+
+	@Test
+	@Transactional
 	@DisplayName("should replace catalog rows and update the checksum when the same coordinate is uploaded again")
 	void shouldReplaceCatalogRowsOnReupload() {
 		final var metadata = konfigyrArtifactoryArtifact.toMetadata(List.of(
@@ -231,7 +266,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.actual();
 
 		assertThatUpload(release.id(), metadata)
-				.hasStatusOk();
+				.hasStatus(HttpStatus.NO_CONTENT);
 
 		assertThat(context.select(SERVICE_CONFIGURATION_CATALOG.NAME)
 				.from(SERVICE_CONFIGURATION_CATALOG)
@@ -306,6 +341,21 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.assertThat()
 				.apply(log())
 				.hasStatus(HttpStatus.BAD_REQUEST);
+	}
+
+	@Test
+	@DisplayName("should fail to upload an artifact for an unknown service")
+	void shouldRejectUnknownServiceForArtifactUpload() {
+		final var metadata = metadata(konfigyrCryptoApiArtifact, "crypto-checksum");
+
+		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases/release/artifacts")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(metadata))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound("unknown-service"));
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -41,8 +41,8 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@DisplayName("should open a new release when the service has none")
 	void shouldOpenNewRelease() {
 		final var request = new ServiceManifestController.ResolveReleaseRequest(List.of(
-				ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1"),
-				ServiceReleaseCandidate.of("com.acme", "other-service", "2.0.0", "checksum-2")
+				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1"),
+				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-crypto", "2.0.0", "checksum-2")
 		));
 
 		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
@@ -103,7 +103,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@DisplayName("should take over an existing release and skip artifacts with a matching checksum")
 	void shouldTakeOverExistingRelease() {
 		final var request = new ServiceManifestController.ResolveReleaseRequest(List.of(
-				ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1")
+				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1")
 		));
 
 		final ServiceRelease first = mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
@@ -118,7 +118,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.actual();
 
 		// simulate T8's upload() having already recorded this checksum for the artifact
-		markUploaded("com.acme", "my-service", "1.2.0", "checksum-1");
+		markUploaded("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1");
 
 		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
@@ -146,20 +146,20 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1")
+						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1")
 				))))
 				.exchange()
 				.assertThat()
 				.hasStatusOk();
 
 		// simulate T8's upload() having already recorded the old checksum for the artifact
-		markUploaded("com.acme", "my-service", "1.2.0", "checksum-1");
+		markUploaded("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1");
 
 		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-2")
+						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-2")
 				))))
 				.exchange()
 				.assertThat()
@@ -193,8 +193,8 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1"),
-						ServiceReleaseCandidate.of("com.acme", "other-service", "2.0.0", "checksum-2")
+						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1"),
+						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-crypto", "2.0.0", "checksum-2")
 				))))
 				.exchange()
 				.assertThat()
@@ -204,7 +204,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of("com.acme", "my-service", "1.2.0", "checksum-1")
+						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1")
 				))))
 				.exchange()
 				.assertThat()
@@ -215,7 +215,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.satisfies(release -> assertThat(release.artifacts()).hasSize(1));
 
 		assertThat(context.fetchExists(SERVICE_ARTIFACTS,
-				SERVICE_ARTIFACTS.GROUP_ID.eq("com.acme").and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq("other-service"))
+				SERVICE_ARTIFACTS.GROUP_ID.eq("com.konfigyr").and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq("konfigyr-crypto"))
 		)).isFalse();
 	}
 
@@ -223,7 +223,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should upload artifact metadata for a declared coordinate")
 	void shouldUploadArtifactMetadata() {
-		final var coordinates = ArtifactCoordinates.of("com.acme", "my-service", "1.2.0");
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
 		final String id = openRelease(coordinates);
 		final ArtifactMetadata metadata = TestArtifacts.metadata(coordinates);
 
@@ -259,13 +259,13 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should replace catalog rows and update the checksum when the same coordinate is uploaded again")
 	void shouldReplaceCatalogRowsOnReupload() {
-		final var coordinates = ArtifactCoordinates.of("com.acme", "my-service", "1.2.0");
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
 		final String id = openRelease(coordinates);
 
 		uploadArtifact(id, TestArtifacts.metadata(coordinates)).assertThat().hasStatusOk();
 
 		final ArtifactMetadata metadata = TestArtifacts.metadata(coordinates, PropertyDescriptor.builder()
-				.name("com.acme.my-service.enabled")
+				.name("com.konfigyr.konfigyr-artifactory.enabled")
 				.typeName("java.lang.Boolean")
 				.schema(StringSchema.instance())
 				.build());
@@ -281,7 +281,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(coordinates.artifactId()))
 				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(coordinates.version().get()))
 				.fetch(SERVICE_CONFIGURATION_CATALOG.NAME))
-				.containsExactly("com.acme.my-service.enabled");
+				.containsExactly("com.konfigyr.konfigyr-artifactory.enabled");
 
 		assertThat(context.select(SERVICE_ARTIFACTS.CHECKSUM)
 				.from(SERVICE_ARTIFACTS)
@@ -296,7 +296,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should reject an artifact upload when the release is not pending")
 	void shouldRejectUploadForNotPendingRelease() {
-		final var coordinates = ArtifactCoordinates.of("com.acme", "my-service", "1.2.0");
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
 		final String id = openRelease(coordinates);
 
 		final int updated = context.update(SERVICE_RELEASES)
@@ -319,14 +319,14 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should reject an artifact upload for a coordinate that was not declared for the release")
 	void shouldRejectUploadForUndeclaredCoordinate() {
-		final String id = openRelease(ArtifactCoordinates.of("com.acme", "my-service", "1.2.0"));
+		final String id = openRelease(ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0"));
 
-		uploadArtifact(id, TestArtifacts.metadata(ArtifactCoordinates.of("com.acme", "other-service", "1.0.0")))
+		uploadArtifact(id, TestArtifacts.metadata(ArtifactCoordinates.of("com.konfigyr", "konfigyr-crypto", "1.0.0")))
 				.assertThat()
 				.apply(log())
 				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
 						.hasTitle("Artifact not declared for this release")
-						.hasDetailContaining("com.acme:other-service:1.0.0")
+						.hasDetailContaining("com.konfigyr:konfigyr-crypto:1.0.0")
 				));
 	}
 
@@ -334,7 +334,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should reject a malformed artifact metadata payload")
 	void shouldRejectMalformedUploadPayload() {
-		final String id = openRelease(ArtifactCoordinates.of("com.acme", "my-service", "1.2.0"));
+		final String id = openRelease(ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0"));
 
 		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", id)
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -309,7 +309,10 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 		uploadArtifact(id, TestArtifacts.metadata(coordinates))
 				.assertThat()
 				.apply(log())
-				.hasStatus(HttpStatus.CONFLICT);
+				.satisfies(problemDetailFor(HttpStatus.CONFLICT, problem -> problem
+						.hasTitle("Release is not pending")
+						.hasDetailContaining("Release is no longer pending")
+				));
 	}
 
 	@Test
@@ -321,7 +324,10 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 		uploadArtifact(id, TestArtifacts.metadata(ArtifactCoordinates.of("com.acme", "other-service", "1.0.0")))
 				.assertThat()
 				.apply(log())
-				.hasStatus(HttpStatus.NOT_FOUND);
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitle("Artifact not declared for this release")
+						.hasDetailContaining("com.acme:other-service:1.0.0")
+				));
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -1,9 +1,16 @@
 package com.konfigyr.namespace.controller;
 
+import com.konfigyr.artifactory.ArtifactCoordinates;
+import com.konfigyr.artifactory.ArtifactMetadata;
 import com.konfigyr.artifactory.ArtifactSource;
 import com.konfigyr.artifactory.ArtifactUploadStatus;
+import com.konfigyr.artifactory.PropertyDescriptor;
+import com.konfigyr.artifactory.ReleaseState;
 import com.konfigyr.artifactory.ServiceRelease;
 import com.konfigyr.artifactory.ServiceReleaseCandidate;
+import com.konfigyr.artifactory.StringSchema;
+import com.konfigyr.artifactory.TestArtifacts;
+import com.konfigyr.entity.EntityId;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.test.AbstractControllerTest;
 import com.konfigyr.test.TestPrincipals;
@@ -11,12 +18,16 @@ import org.jooq.DSLContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.assertj.MvcTestResult;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
+import static com.konfigyr.data.tables.ServiceConfigurationCatalog.SERVICE_CONFIGURATION_CATALOG;
+import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 
@@ -206,6 +217,151 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 		assertThat(context.fetchExists(SERVICE_ARTIFACTS,
 				SERVICE_ARTIFACTS.GROUP_ID.eq("com.acme").and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq("other-service"))
 		)).isFalse();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should upload artifact metadata for a declared coordinate")
+	void shouldUploadArtifactMetadata() {
+		final var coordinates = ArtifactCoordinates.of("com.acme", "my-service", "1.2.0");
+		final String id = openRelease(coordinates);
+		final ArtifactMetadata metadata = TestArtifacts.metadata(coordinates);
+
+		uploadArtifact(id, metadata)
+				.assertThat()
+				.apply(log())
+				.hasStatusOk();
+
+		assertThat(context.select(SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
+				.from(SERVICE_ARTIFACTS)
+				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(coordinates.groupId()))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()))
+				.and(SERVICE_ARTIFACTS.VERSION.eq(coordinates.version().get()))
+				.fetchOne())
+				.satisfies(record -> {
+					assertThat(record.get(SERVICE_ARTIFACTS.SOURCE)).isEqualTo(ArtifactSource.LOCAL.name());
+					assertThat(record.get(SERVICE_ARTIFACTS.CHECKSUM)).isEqualTo(metadata.checksum());
+				});
+
+		assertThat(context.select(SERVICE_CONFIGURATION_CATALOG.NAME, SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR)
+				.from(SERVICE_CONFIGURATION_CATALOG)
+				.where(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(coordinates.groupId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(coordinates.artifactId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(coordinates.version().get()))
+				.fetch())
+				.hasSize(metadata.properties().size())
+				.allSatisfy(record -> assertThat(record.get(SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR)).isNotNull())
+				.extracting(record -> record.get(SERVICE_CONFIGURATION_CATALOG.NAME))
+				.containsExactlyInAnyOrderElementsOf(metadata.properties().stream().map(PropertyDescriptor::name).toList());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should replace catalog rows and update the checksum when the same coordinate is uploaded again")
+	void shouldReplaceCatalogRowsOnReupload() {
+		final var coordinates = ArtifactCoordinates.of("com.acme", "my-service", "1.2.0");
+		final String id = openRelease(coordinates);
+
+		uploadArtifact(id, TestArtifacts.metadata(coordinates)).assertThat().hasStatusOk();
+
+		final ArtifactMetadata metadata = TestArtifacts.metadata(coordinates, PropertyDescriptor.builder()
+				.name("com.acme.my-service.enabled")
+				.typeName("java.lang.Boolean")
+				.schema(StringSchema.instance())
+				.build());
+
+		uploadArtifact(id, metadata)
+				.assertThat()
+				.apply(log())
+				.hasStatusOk();
+
+		assertThat(context.select(SERVICE_CONFIGURATION_CATALOG.NAME)
+				.from(SERVICE_CONFIGURATION_CATALOG)
+				.where(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(coordinates.groupId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(coordinates.artifactId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(coordinates.version().get()))
+				.fetch(SERVICE_CONFIGURATION_CATALOG.NAME))
+				.containsExactly("com.acme.my-service.enabled");
+
+		assertThat(context.select(SERVICE_ARTIFACTS.CHECKSUM)
+				.from(SERVICE_ARTIFACTS)
+				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(coordinates.groupId()))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()))
+				.and(SERVICE_ARTIFACTS.VERSION.eq(coordinates.version().get()))
+				.fetchOne(SERVICE_ARTIFACTS.CHECKSUM))
+				.isEqualTo(metadata.checksum());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should reject an artifact upload when the release is not pending")
+	void shouldRejectUploadForNotPendingRelease() {
+		final var coordinates = ArtifactCoordinates.of("com.acme", "my-service", "1.2.0");
+		final String id = openRelease(coordinates);
+
+		final int updated = context.update(SERVICE_RELEASES)
+				.set(SERVICE_RELEASES.STATE, ReleaseState.RELEASED.name())
+				.where(SERVICE_RELEASES.ID.eq(EntityId.from(id).get()))
+				.execute();
+
+		assertThat(updated).as("Expected an existing service_releases row to update").isOne();
+
+		uploadArtifact(id, TestArtifacts.metadata(coordinates))
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.CONFLICT);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should reject an artifact upload for a coordinate that was not declared for the release")
+	void shouldRejectUploadForUndeclaredCoordinate() {
+		final String id = openRelease(ArtifactCoordinates.of("com.acme", "my-service", "1.2.0"));
+
+		uploadArtifact(id, TestArtifacts.metadata(ArtifactCoordinates.of("com.acme", "other-service", "1.0.0")))
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should reject a malformed artifact metadata payload")
+	void shouldRejectMalformedUploadPayload() {
+		final String id = openRelease(ArtifactCoordinates.of("com.acme", "my-service", "1.2.0"));
+
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", id)
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{not-valid-json")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST);
+	}
+
+	private String openRelease(ArtifactCoordinates coordinates) {
+		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
+						ServiceReleaseCandidate.of(coordinates.groupId(), coordinates.artifactId(), coordinates.version().get(), "irrelevant-checksum")
+				))))
+				.exchange()
+				.assertThat()
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.actual()
+				.id();
+	}
+
+	private MvcTestResult uploadArtifact(String id, ArtifactMetadata metadata) {
+		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", id)
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(metadata))
+				.exchange();
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -1,26 +1,20 @@
 package com.konfigyr.namespace.controller;
 
-import com.konfigyr.artifactory.ArtifactCoordinates;
-import com.konfigyr.artifactory.ArtifactMetadata;
-import com.konfigyr.artifactory.ArtifactSource;
-import com.konfigyr.artifactory.ArtifactUploadStatus;
-import com.konfigyr.artifactory.PropertyDescriptor;
-import com.konfigyr.artifactory.ReleaseState;
-import com.konfigyr.artifactory.ServiceRelease;
-import com.konfigyr.artifactory.ServiceReleaseCandidate;
-import com.konfigyr.artifactory.StringSchema;
-import com.konfigyr.artifactory.TestArtifacts;
+import com.konfigyr.artifactory.*;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.test.AbstractControllerTest;
 import com.konfigyr.test.TestPrincipals;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.assertj.core.api.ObjectAssert;
 import org.jooq.DSLContext;
+import org.jooq.impl.DSL;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.test.web.servlet.assertj.MvcTestResult;
+import org.springframework.test.web.servlet.assertj.MvcTestResultAssert;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -33,6 +27,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 
 class ServiceManifestControllerTest extends AbstractControllerTest {
 
+	static Artifact konfigyrArtifactoryArtifact = Artifact.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
+	static Artifact konfigyrCryptoApiArtifact = Artifact.of("com.konfigyr", "konfigyr-crypto-api", "1.1.0");
+
 	@Autowired
 	DSLContext context;
 
@@ -40,25 +37,27 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should open a new release when the service has none")
 	void shouldOpenNewRelease() {
-		final var request = new ServiceManifestController.ResolveReleaseRequest(List.of(
-				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1"),
-				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-crypto", "2.0.0", "checksum-2")
-		));
+		final var candidates = List.of(
+				ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum-1"),
+				ServiceReleaseCandidate.of(konfigyrCryptoApiArtifact, "checksum-2")
+		);
 
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(request))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(ServiceRelease.class)
+		assertThatRelease(candidates)
 				.returns(com.konfigyr.artifactory.ReleaseState.PENDING, ServiceRelease::state)
 				.satisfies(release -> assertThat(release.artifacts())
 						.hasSize(2)
-						.allSatisfy(entry -> assertThat(entry.status()).isEqualTo(ArtifactUploadStatus.UPLOAD_REQUIRED))
+						.satisfiesExactlyInAnyOrder(
+								entry -> assertThat(entry)
+										.returns(konfigyrArtifactoryArtifact.groupId(), Artifact::groupId)
+										.returns(konfigyrArtifactoryArtifact.artifactId(), Artifact::artifactId)
+										.returns(konfigyrArtifactoryArtifact.version(), Artifact::version)
+										.returns(ArtifactUploadStatus.UPLOAD_REQUIRED, ServiceReleaseEntry::status),
+								entry -> assertThat(entry)
+										.returns(konfigyrCryptoApiArtifact.groupId(), Artifact::groupId)
+										.returns(konfigyrCryptoApiArtifact.artifactId(), Artifact::artifactId)
+										.returns(konfigyrCryptoApiArtifact.version(), Artifact::version)
+										.returns(ArtifactUploadStatus.UPLOAD_REQUIRED, ServiceReleaseEntry::status)
+						)
 				);
 	}
 
@@ -66,192 +65,133 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should skip an artifact that is already indexed in the Artifactory")
 	void shouldSkipIndexedArtifact() {
-		final var request = new ServiceManifestController.ResolveReleaseRequest(List.of(
-				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-crypto-api", "1.0.0", "irrelevant-checksum")
-		));
-
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(request))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(ServiceRelease.class)
+		assertThatRelease(ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-crypto-api", "1.0.0", "checksum"))
 				.satisfies(release -> assertThat(release.artifacts())
 						.hasSize(1)
 						.first()
-						.returns(ArtifactUploadStatus.SKIP, entry -> entry.status())
+						.returns("com.konfigyr", Artifact::groupId)
+						.returns("konfigyr-crypto-api", Artifact::artifactId)
+						.returns("1.0.0", Artifact::version)
+						.returns(ArtifactUploadStatus.SKIP, ServiceReleaseEntry::status)
 				);
 
-		assertThat(context.select(SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
+		// assert that artifact is added to the release artifacts with the matching source
+		final var record = context.select(SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
 				.from(SERVICE_ARTIFACTS)
 				.where(SERVICE_ARTIFACTS.GROUP_ID.eq("com.konfigyr"))
 				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq("konfigyr-crypto-api"))
 				.and(SERVICE_ARTIFACTS.VERSION.eq("1.0.0"))
-				.fetchOne())
-				.satisfies(record -> {
-					assertThat(record.get(SERVICE_ARTIFACTS.SOURCE)).isEqualTo(ArtifactSource.ARTIFACTORY.name());
-					assertThat(record.get(SERVICE_ARTIFACTS.CHECKSUM)).isNull();
-				});
+				.fetchOneMap();
+
+		assertThat(record)
+				.containsEntry(SERVICE_ARTIFACTS.SOURCE.getName(), ArtifactSource.ARTIFACTORY.name())
+				.containsEntry(SERVICE_ARTIFACTS.CHECKSUM.getName(), null);
 	}
 
 	@Test
 	@Transactional
 	@DisplayName("should take over an existing release and skip artifacts with a matching checksum")
 	void shouldTakeOverExistingRelease() {
-		final var request = new ServiceManifestController.ResolveReleaseRequest(List.of(
-				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1")
-		));
+		final var metadata = metadata(konfigyrArtifactoryArtifact, "checksum-1");
 
-		final ServiceRelease first = mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(request))
-				.exchange()
-				.assertThat()
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(ServiceRelease.class)
+		final ServiceRelease first = assertThatRelease(ServiceReleaseCandidate.of(metadata))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
 				.actual();
 
-		// simulate T8's upload() having already recorded this checksum for the artifact
-		markUploaded("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1");
+		// checksum-1 is what the plugin already declared for this coordinate above, so uploading
+		// metadata carrying that same checksum is what settles it as "already uploaded"
+		assertThatUpload(first.id(), metadata)
+				.hasStatusOk();
 
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(request))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(ServiceRelease.class)
+		assertThatRelease(ServiceReleaseCandidate.of(metadata))
 				.returns(first.id(), ServiceRelease::id)
-				.satisfies(release -> assertThat(release.artifacts())
-						.hasSize(1)
-						.first()
-						.returns(ArtifactUploadStatus.SKIP, entry -> entry.status())
-				);
+				.extracting(ServiceRelease::artifacts, InstanceOfAssertFactories.iterable(ServiceReleaseEntry.class))
+				.hasSize(1)
+				.first()
+				.returns(ArtifactUploadStatus.SKIP, ServiceReleaseEntry::status);
 	}
 
 	@Test
 	@Transactional
 	@DisplayName("should mark an artifact upload required when its checksum changed")
 	void shouldRequireUploadWhenChecksumChanged() {
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1")
-				))))
-				.exchange()
-				.assertThat()
+		final var metadata = metadata(konfigyrArtifactoryArtifact, "initial-checksum");
+
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(metadata))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
+
+		// `initial-checksum` is what the plugin already declared for this coordinate above, so uploading
+		// metadata carrying that same checksum is what settles it as "already uploaded"
+		assertThatUpload(release.id(), metadata)
 				.hasStatusOk();
 
-		// simulate T8's upload() having already recorded the old checksum for the artifact
-		markUploaded("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1");
-
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-2")
-				))))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(ServiceRelease.class)
-				.satisfies(release -> assertThat(release.artifacts())
-						.hasSize(1)
-						.first()
-						.returns(ArtifactUploadStatus.UPLOAD_REQUIRED, entry -> entry.status())
-				);
-	}
-
-	private void markUploaded(String groupId, String artifactId, String version, String checksum) {
-		final int updated = context.update(SERVICE_ARTIFACTS)
-				.set(SERVICE_ARTIFACTS.CHECKSUM, checksum)
-				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(groupId))
-				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(artifactId))
-				.and(SERVICE_ARTIFACTS.VERSION.eq(version))
-				.execute();
-
-		assertThat(updated).as("Expected an existing service_artifacts row to update").isOne();
+		assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "different-checksum"))
+				.returns(release.id(), ServiceRelease::id)
+				.extracting(ServiceRelease::artifacts, InstanceOfAssertFactories.iterable(ServiceReleaseEntry.class))
+				.hasSize(1)
+				.first()
+				.returns(ArtifactUploadStatus.UPLOAD_REQUIRED, ServiceReleaseEntry::status);
 	}
 
 	@Test
 	@Transactional
 	@DisplayName("should prune artifacts that are no longer declared")
 	void shouldPruneStaleArtifacts() {
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1"),
-						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-crypto", "2.0.0", "checksum-2")
-				))))
-				.exchange()
-				.assertThat()
-				.hasStatusOk();
+		assertThatRelease(List.of(
+				ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum-1"),
+				ServiceReleaseCandidate.of(konfigyrCryptoApiArtifact, "checksum-2")
+		)).satisfies(release -> assertThat(release.artifacts()).hasSize(2));
 
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-artifactory", "1.2.0", "checksum-1")
-				))))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(ServiceRelease.class)
+		assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum-1"))
 				.satisfies(release -> assertThat(release.artifacts()).hasSize(1));
 
-		assertThat(context.fetchExists(SERVICE_ARTIFACTS,
-				SERVICE_ARTIFACTS.GROUP_ID.eq("com.konfigyr").and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq("konfigyr-crypto"))
-		)).isFalse();
+		assertThat(context.fetchExists(SERVICE_ARTIFACTS, DSL.and(
+				SERVICE_ARTIFACTS.GROUP_ID.eq(konfigyrCryptoApiArtifact.groupId()),
+				SERVICE_ARTIFACTS.ARTIFACT_ID.eq(konfigyrCryptoApiArtifact.artifactId()),
+				SERVICE_ARTIFACTS.VERSION.eq(konfigyrCryptoApiArtifact.version())
+		))).isFalse();
 	}
 
 	@Test
 	@Transactional
 	@DisplayName("should upload artifact metadata for a declared coordinate")
 	void shouldUploadArtifactMetadata() {
-		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
-		final String id = openRelease(coordinates);
-		final ArtifactMetadata metadata = TestArtifacts.metadata(coordinates);
+		final var metadata = konfigyrArtifactoryArtifact.toMetadata(List.of(
+				PropertyDescriptor.builder()
+						.name("com.konfigyr.konfigyr-artifactory.enabled")
+						.typeName("java.lang.Boolean")
+						.schema(StringSchema.instance())
+						.build()
+		));
 
-		uploadArtifact(id, metadata)
-				.assertThat()
-				.apply(log())
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(metadata))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
+
+		assertThatUpload(release.id(), metadata)
 				.hasStatusOk();
 
-		assertThat(context.select(SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
+		final var record = context.select(SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
 				.from(SERVICE_ARTIFACTS)
-				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(coordinates.groupId()))
-				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()))
-				.and(SERVICE_ARTIFACTS.VERSION.eq(coordinates.version().get()))
-				.fetchOne())
-				.satisfies(record -> {
-					assertThat(record.get(SERVICE_ARTIFACTS.SOURCE)).isEqualTo(ArtifactSource.LOCAL.name());
-					assertThat(record.get(SERVICE_ARTIFACTS.CHECKSUM)).isEqualTo(metadata.checksum());
-				});
+				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(konfigyrArtifactoryArtifact.groupId()))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(konfigyrArtifactoryArtifact.artifactId()))
+				.and(SERVICE_ARTIFACTS.VERSION.eq(konfigyrArtifactoryArtifact.version()))
+				.fetchOneMap();
+
+		assertThat(record)
+				.containsEntry(SERVICE_ARTIFACTS.SOURCE.getName(), ArtifactSource.LOCAL.name())
+				.containsEntry(SERVICE_ARTIFACTS.CHECKSUM.getName(), metadata.checksum());
 
 		assertThat(context.select(SERVICE_CONFIGURATION_CATALOG.NAME, SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR)
 				.from(SERVICE_CONFIGURATION_CATALOG)
-				.where(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(coordinates.groupId()))
-				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(coordinates.artifactId()))
-				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(coordinates.version().get()))
+				.where(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(metadata.groupId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(metadata.artifactId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(metadata.version()))
 				.fetch())
 				.hasSize(metadata.properties().size())
-				.allSatisfy(record -> assertThat(record.get(SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR)).isNotNull())
-				.extracting(record -> record.get(SERVICE_CONFIGURATION_CATALOG.NAME))
+				.allSatisfy(it -> assertThat(it.get(SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR)).isNotNull())
+				.extracting(it -> it.get(SERVICE_CONFIGURATION_CATALOG.NAME))
 				.containsExactlyInAnyOrderElementsOf(metadata.properties().stream().map(PropertyDescriptor::name).toList());
 	}
 
@@ -259,35 +199,34 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should replace catalog rows and update the checksum when the same coordinate is uploaded again")
 	void shouldReplaceCatalogRowsOnReupload() {
-		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
-		final String id = openRelease(coordinates);
+		final var metadata = konfigyrArtifactoryArtifact.toMetadata(List.of(
+				PropertyDescriptor.builder()
+						.name("com.konfigyr.konfigyr-artifactory.enabled")
+						.typeName("java.lang.Boolean")
+						.schema(StringSchema.instance())
+						.build()
+		));
 
-		uploadArtifact(id, TestArtifacts.metadata(coordinates)).assertThat().hasStatusOk();
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(metadata))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
 
-		final ArtifactMetadata metadata = TestArtifacts.metadata(coordinates, PropertyDescriptor.builder()
-				.name("com.konfigyr.konfigyr-artifactory.enabled")
-				.typeName("java.lang.Boolean")
-				.schema(StringSchema.instance())
-				.build());
-
-		uploadArtifact(id, metadata)
-				.assertThat()
-				.apply(log())
+		assertThatUpload(release.id(), metadata)
 				.hasStatusOk();
 
 		assertThat(context.select(SERVICE_CONFIGURATION_CATALOG.NAME)
 				.from(SERVICE_CONFIGURATION_CATALOG)
-				.where(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(coordinates.groupId()))
-				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(coordinates.artifactId()))
-				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(coordinates.version().get()))
+				.where(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(metadata.groupId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(metadata.artifactId()))
+				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(metadata.version()))
 				.fetch(SERVICE_CONFIGURATION_CATALOG.NAME))
 				.containsExactly("com.konfigyr.konfigyr-artifactory.enabled");
 
 		assertThat(context.select(SERVICE_ARTIFACTS.CHECKSUM)
 				.from(SERVICE_ARTIFACTS)
-				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(coordinates.groupId()))
-				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()))
-				.and(SERVICE_ARTIFACTS.VERSION.eq(coordinates.version().get()))
+				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(metadata.groupId()))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(metadata.artifactId()))
+				.and(SERVICE_ARTIFACTS.VERSION.eq(metadata.version()))
 				.fetchOne(SERVICE_ARTIFACTS.CHECKSUM))
 				.isEqualTo(metadata.checksum());
 	}
@@ -296,19 +235,20 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should reject an artifact upload when the release is not pending")
 	void shouldRejectUploadForNotPendingRelease() {
-		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
-		final String id = openRelease(coordinates);
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum"))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
 
 		final int updated = context.update(SERVICE_RELEASES)
 				.set(SERVICE_RELEASES.STATE, ReleaseState.RELEASED.name())
-				.where(SERVICE_RELEASES.ID.eq(EntityId.from(id).get()))
+				.where(SERVICE_RELEASES.ID.eq(EntityId.from(release.id()).get()))
 				.execute();
 
-		assertThat(updated).as("Expected an existing service_releases row to update").isOne();
+		assertThat(updated)
+				.as("Expected an existing service_releases row to update")
+				.isOne();
 
-		uploadArtifact(id, TestArtifacts.metadata(coordinates))
-				.assertThat()
-				.apply(log())
+		assertThatUpload(release.id(), metadata(konfigyrArtifactoryArtifact, "checksum"))
 				.satisfies(problemDetailFor(HttpStatus.CONFLICT, problem -> problem
 						.hasTitle("Release is not pending")
 						.hasDetailContaining("Release is no longer pending")
@@ -319,14 +259,15 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should reject an artifact upload for a coordinate that was not declared for the release")
 	void shouldRejectUploadForUndeclaredCoordinate() {
-		final String id = openRelease(ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0"));
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum"))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
 
-		uploadArtifact(id, TestArtifacts.metadata(ArtifactCoordinates.of("com.konfigyr", "konfigyr-crypto", "1.0.0")))
-				.assertThat()
-				.apply(log())
+		assertThatUpload(release.id(), metadata(konfigyrCryptoApiArtifact, "crypto-checksum"))
 				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
 						.hasTitle("Artifact not declared for this release")
-						.hasDetailContaining("com.konfigyr:konfigyr-crypto:1.0.0")
+						.hasDetailContaining("The artifact with coordinates '%s' was not declared for this release",
+								ArtifactCoordinates.of(konfigyrCryptoApiArtifact).format())
 				));
 	}
 
@@ -334,9 +275,11 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should reject a malformed artifact metadata payload")
 	void shouldRejectMalformedUploadPayload() {
-		final String id = openRelease(ArtifactCoordinates.of("com.konfigyr", "konfigyr-artifactory", "1.2.0"));
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum"))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
 
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", id)
+		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", release.id())
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{not-valid-json")
@@ -346,37 +289,13 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.hasStatus(HttpStatus.BAD_REQUEST);
 	}
 
-	private String openRelease(ArtifactCoordinates coordinates) {
-		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of(
-						ServiceReleaseCandidate.of(coordinates.groupId(), coordinates.artifactId(), coordinates.version().get(), "irrelevant-checksum")
-				))))
-				.exchange()
-				.assertThat()
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(ServiceRelease.class)
-				.actual()
-				.id();
-	}
-
-	private MvcTestResult uploadArtifact(String id, ArtifactMetadata metadata) {
-		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", id)
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(metadata))
-				.exchange();
-	}
-
 	@Test
 	@DisplayName("should not resolve a release when user is not a member of the namespace")
 	void shouldRejectWhenNotAMember() {
 		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
 				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of())))
+				.content("[]")
 				.exchange()
 				.assertThat()
 				.apply(log())
@@ -389,7 +308,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 		mvc.post().uri("/namespaces/konfigyr/services/konfigyr-id/releases")
 				.with(authentication(TestPrincipals.john()))
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of())))
+				.content("[]")
 				.exchange()
 				.assertThat()
 				.apply(log())
@@ -402,7 +321,7 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases")
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of())))
+				.content("[]")
 				.exchange()
 				.assertThat()
 				.apply(log())
@@ -415,11 +334,53 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 		mvc.post().uri("/namespaces/unknown-namespace/services/unknown-service/releases")
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(jsonMapper.writeValueAsBytes(new ServiceManifestController.ResolveReleaseRequest(List.of())))
+				.content("[]")
 				.exchange()
 				.assertThat()
 				.apply(log())
 				.satisfies(namespaceNotFound("unknown-namespace"));
+	}
+
+	private ObjectAssert<ServiceRelease> assertThatRelease(ServiceReleaseCandidate... candidates) {
+		return assertThatRelease(List.of(candidates));
+	}
+
+	private ObjectAssert<ServiceRelease> assertThatRelease(List<ServiceReleaseCandidate> candidates) {
+		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(candidates))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.asInstanceOf(InstanceOfAssertFactories.type(ServiceRelease.class));
+	}
+
+	private MvcTestResultAssert assertThatUpload(String id, ArtifactMetadata metadata) {
+		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", id)
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(metadata))
+				.exchange()
+				.assertThat()
+				.apply(log());
+	}
+
+	private static ArtifactMetadata metadata(Artifact artifact, String checksum) {
+		return ArtifactMetadata.builder()
+				.groupId(artifact.groupId())
+				.artifactId(artifact.artifactId())
+				.version(artifact.version())
+				.checksum(checksum)
+				.property(PropertyDescriptor.builder()
+						.name("some.property")
+						.typeName("java.lang.String")
+						.schema(StringSchema.instance())
+						.build())
+				.build();
 	}
 
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/manifest/ServiceManifestsTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/manifest/ServiceManifestsTest.java
@@ -1,0 +1,124 @@
+package com.konfigyr.namespace.manifest;
+
+import com.konfigyr.artifactory.*;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.namespace.Namespace;
+import com.konfigyr.namespace.NamespaceManager;
+import com.konfigyr.namespace.Service;
+import com.konfigyr.namespace.Services;
+import com.konfigyr.test.AbstractIntegrationTest;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
+import static com.konfigyr.data.tables.ServiceConfigurationCatalog.SERVICE_CONFIGURATION_CATALOG;
+import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class ServiceManifestsTest extends AbstractIntegrationTest {
+
+	static Artifact konfigyrArtifactoryArtifact = Artifact.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
+
+	@Autowired
+	ServiceManifests manifests;
+
+	@Autowired
+	NamespaceManager namespaces;
+
+	@Autowired
+	Services services;
+
+	@Autowired
+	DSLContext context;
+
+	Service service;
+
+	@BeforeEach
+	void setUp() {
+		final Namespace namespace = namespaces.findBySlug("konfigyr").orElseThrow();
+		service = services.get(namespace, "konfigyr-id").orElseThrow();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should open a release and upload artifact metadata for a declared coordinate")
+	void shouldOpenAndUploadArtifactMetadata() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact);
+		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(metadata)));
+
+		assertThat(release.state())
+				.isEqualTo(ReleaseState.PENDING);
+
+		assertThat(release.artifacts())
+				.hasSize(1)
+				.first()
+				.returns(ArtifactUploadStatus.UPLOAD_REQUIRED, ServiceReleaseEntry::status);
+
+		manifests.upload(service, EntityId.from(release.id()), metadata);
+
+		assertThat(context.select(SERVICE_ARTIFACTS.SOURCE, SERVICE_ARTIFACTS.CHECKSUM)
+				.from(SERVICE_ARTIFACTS)
+				.where(SERVICE_ARTIFACTS.GROUP_ID.eq(metadata.groupId()))
+				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(metadata.artifactId()))
+				.and(SERVICE_ARTIFACTS.VERSION.eq(metadata.version()))
+				.fetchOneMap())
+				.containsEntry(SERVICE_ARTIFACTS.SOURCE.getName(), ArtifactSource.LOCAL.name())
+				.containsEntry(SERVICE_ARTIFACTS.CHECKSUM.getName(), metadata.checksum());
+
+		assertThat(context.fetchCount(SERVICE_CONFIGURATION_CATALOG,
+				SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(metadata.groupId())
+						.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(metadata.artifactId()))
+						.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(metadata.version()))
+		)).isEqualTo(metadata.properties().size());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to upload artifact metadata for a coordinate that was not declared for the release")
+	void shouldRejectUploadForUndeclaredCoordinate() {
+		final var declared = metadata(konfigyrArtifactoryArtifact);
+		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(declared)));
+
+		final var undeclared = metadata(Artifact.of("com.konfigyr", "konfigyr-crypto-api", "1.1.0"));
+
+		assertThatExceptionOfType(UndeclaredArtifactException.class)
+				.isThrownBy(() -> manifests.upload(service, EntityId.from(release.id()), undeclared))
+				.returns(ArtifactCoordinates.of(undeclared), UndeclaredArtifactException::getCoordinates);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to upload artifact metadata when the release is no longer pending")
+	void shouldRejectUploadForNotPendingRelease() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact);
+		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(metadata)));
+
+		context.update(SERVICE_RELEASES)
+				.set(SERVICE_RELEASES.STATE, ReleaseState.RELEASED.name())
+				.where(SERVICE_RELEASES.ID.eq(EntityId.from(release.id()).get()))
+				.execute();
+
+		assertThatExceptionOfType(ReleaseNotPendingException.class)
+				.isThrownBy(() -> manifests.upload(service, EntityId.from(release.id()), metadata))
+				.returns(ReleaseState.RELEASED, ReleaseNotPendingException::getState)
+				.returns(EntityId.from(release.id()), ReleaseNotPendingException::getReleaseId);
+	}
+
+	private static ArtifactMetadata metadata(Artifact artifact) {
+		return artifact.toMetadata(List.of(
+				PropertyDescriptor.builder()
+						.name("some.property")
+						.typeName("java.lang.String")
+						.schema(StringSchema.instance())
+						.build()
+		));
+	}
+
+}

--- a/konfigyr-api/src/test/resources/fixtures/org.springframework.boot-spring-boot-autoconfigure-3.5.7.json
+++ b/konfigyr-api/src/test/resources/fixtures/org.springframework.boot-spring-boot-autoconfigure-3.5.7.json
@@ -1,0 +1,16768 @@
+{
+  "groupId": "org.springframework.boot",
+  "artifactId": "spring-boot-autoconfigure",
+  "version": "3.5.7",
+  "checksum": "05rE2xyRSahSOmleWm/Kz93vDKRG1rH8MAAIbsIYs+Y=",
+  "properties": [
+    {
+      "name": "server.address",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.net.InetAddress",
+      "description": "Network address to which the server should bind."
+    },
+    {
+      "name": "server.compression.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether response compression is enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.compression.excluded-user-agents",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Comma-separated list of user agents for which responses should not be compressed."
+    },
+    {
+      "name": "server.compression.mime-types",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Comma-separated list of MIME types that should be compressed.",
+      "defaultValue": "text/html, text/xml, text/plain, text/css, text/javascript, application/javascript, application/json, application/xml"
+    },
+    {
+      "name": "server.compression.min-response-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Minimum \"Content-Length\" value that is required for compression to be performed.",
+      "defaultValue": "2KB"
+    },
+    {
+      "name": "server.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "reason": "Each server behaves differently. Use server specific properties instead."
+      }
+    },
+    {
+      "name": "server.error.include-binding-errors",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "NEVER",
+          "ON_PARAM"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.ErrorProperties$IncludeAttribute",
+      "description": "When to include \"errors\" attribute.",
+      "defaultValue": "never"
+    },
+    {
+      "name": "server.error.include-exception",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Include the \"exception\" attribute.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.error.include-message",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "NEVER",
+          "ON_PARAM"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.ErrorProperties$IncludeAttribute",
+      "description": "When to include \"message\" attribute.",
+      "defaultValue": "never"
+    },
+    {
+      "name": "server.error.include-path",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "NEVER",
+          "ON_PARAM"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.ErrorProperties$IncludeAttribute",
+      "description": "When to include \"path\" attribute.",
+      "defaultValue": "always"
+    },
+    {
+      "name": "server.error.include-stacktrace",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "NEVER",
+          "ON_PARAM"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.ErrorProperties$IncludeAttribute",
+      "description": "When to include the \"trace\" attribute.",
+      "defaultValue": "never"
+    },
+    {
+      "name": "server.error.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path of the error controller.",
+      "defaultValue": "/error"
+    },
+    {
+      "name": "server.error.whitelabel.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the default error page displayed in browsers in case of a server error.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.forward-headers-strategy",
+      "schema": {
+        "enum": [
+          "FRAMEWORK",
+          "NATIVE",
+          "NONE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.ServerProperties$ForwardHeadersStrategy",
+      "description": "Strategy for handling X-Forwarded-* headers."
+    },
+    {
+      "name": "server.http2.enabled",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether to enable HTTP/2 support, if the current environment supports it.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.jetty.accesslog.append",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Append to log.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.jetty.accesslog.custom-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Custom log format, see org.eclipse.jetty.server.CustomRequestLog. If defined, overrides the \"format\" configuration key."
+    },
+    {
+      "name": "server.jetty.accesslog.date-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "server.jetty.accesslog.custom-format"
+      }
+    },
+    {
+      "name": "server.jetty.accesslog.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Enable access log.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.jetty.accesslog.extended-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "server.jetty.accesslog.format"
+      }
+    },
+    {
+      "name": "server.jetty.accesslog.file-date-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Date format to place in log file name."
+    },
+    {
+      "name": "server.jetty.accesslog.filename",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Log filename. If not specified, logs redirect to \"System.err\"."
+    },
+    {
+      "name": "server.jetty.accesslog.format",
+      "schema": {
+        "enum": [
+          "EXTENDED_NCSA",
+          "NCSA"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.ServerProperties$Jetty$Accesslog$Format",
+      "description": "Log format.",
+      "defaultValue": "ncsa"
+    },
+    {
+      "name": "server.jetty.accesslog.ignore-paths",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Request paths that should not be logged."
+    },
+    {
+      "name": "server.jetty.accesslog.locale",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "server.jetty.accesslog.custom-format"
+      }
+    },
+    {
+      "name": "server.jetty.accesslog.log-cookies",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "server.jetty.accesslog.custom-format"
+      }
+    },
+    {
+      "name": "server.jetty.accesslog.log-latency",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "server.jetty.accesslog.custom-format"
+      }
+    },
+    {
+      "name": "server.jetty.accesslog.log-server",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "server.jetty.accesslog.custom-format"
+      }
+    },
+    {
+      "name": "server.jetty.accesslog.retention-period",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of days before rotated log files are deleted.",
+      "defaultValue": "31"
+    },
+    {
+      "name": "server.jetty.accesslog.time-zone",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "server.jetty.accesslog.custom-format"
+      }
+    },
+    {
+      "name": "server.jetty.connection-idle-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time that the connection can be idle before it is closed."
+    },
+    {
+      "name": "server.jetty.max-connections",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of connections that the server accepts and processes at any given time.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "server.jetty.max-form-keys",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of form keys.",
+      "defaultValue": "1000"
+    },
+    {
+      "name": "server.jetty.max-http-form-post-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of the form content in any HTTP post request.",
+      "defaultValue": "200000B"
+    },
+    {
+      "name": "server.jetty.max-http-post-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "deprecation": {
+        "replacement": "server.jetty.max-http-form-post-size"
+      }
+    },
+    {
+      "name": "server.jetty.max-http-response-header-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of the HTTP response header.",
+      "defaultValue": "8KB"
+    },
+    {
+      "name": "server.jetty.threads.acceptors",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of acceptor threads to use. When the value is -1, the default, the number of acceptors is derived from the operating environment.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "server.jetty.threads.idle-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum thread idle time.",
+      "defaultValue": "60000ms"
+    },
+    {
+      "name": "server.jetty.threads.max",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of threads. Doesn't have an effect if virtual threads are enabled.",
+      "defaultValue": "200"
+    },
+    {
+      "name": "server.jetty.threads.max-queue-capacity",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum capacity of the thread pool's backing queue. A default is computed based on the threading configuration."
+    },
+    {
+      "name": "server.jetty.threads.min",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Minimum number of threads. Doesn't have an effect if virtual threads are enabled.",
+      "defaultValue": "8"
+    },
+    {
+      "name": "server.jetty.threads.selectors",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of selector threads to use. When the value is -1, the default, the number of selectors is derived from the operating environment.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "server.max-http-header-size",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "server.max-http-request-header-size"
+      }
+    },
+    {
+      "name": "server.max-http-post-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum size in bytes of the HTTP post content.",
+      "defaultValue": "0",
+      "deprecation": {
+        "reason": "Use dedicated property for each container."
+      }
+    },
+    {
+      "name": "server.max-http-request-header-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of the HTTP request header. Refer to the documentation for your chosen embedded server for details of exactly how this limit is applied. For example, Netty applies the limit separately to each individual header in the request whereas Tomcat applies the limit to the combined size of the request line and all of the header names and values in the request.",
+      "defaultValue": "8KB"
+    },
+    {
+      "name": "server.netty.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Connection timeout of the Netty channel."
+    },
+    {
+      "name": "server.netty.h2c-max-content-length",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum content length of an H2C upgrade request.",
+      "defaultValue": "0B"
+    },
+    {
+      "name": "server.netty.idle-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Idle timeout of the Netty channel. When not specified, an infinite timeout is used."
+    },
+    {
+      "name": "server.netty.initial-buffer-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Initial buffer size for HTTP request decoding.",
+      "defaultValue": "128B"
+    },
+    {
+      "name": "server.netty.max-chunk-size",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "Deprecated for removal in Reactor Netty."
+      }
+    },
+    {
+      "name": "server.netty.max-initial-line-length",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum length that can be decoded for an HTTP request's initial line.",
+      "defaultValue": "4KB"
+    },
+    {
+      "name": "server.netty.max-keep-alive-requests",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of requests that can be made per connection. By default, a connection serves unlimited number of requests."
+    },
+    {
+      "name": "server.netty.validate-headers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to validate headers when decoding requests.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Server HTTP port.",
+      "defaultValue": "8080"
+    },
+    {
+      "name": "server.reactive.session.cookie.domain",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Domain for the cookie."
+    },
+    {
+      "name": "server.reactive.session.cookie.http-only",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use \"HttpOnly\" cookies for the cookie."
+    },
+    {
+      "name": "server.reactive.session.cookie.max-age",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum age of the cookie. If a duration suffix is not specified, seconds will be used. A positive value indicates when the cookie expires relative to the current time. A value of 0 means the cookie should expire immediately. A negative value means no \"Max-Age\"."
+    },
+    {
+      "name": "server.reactive.session.cookie.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name for the cookie."
+    },
+    {
+      "name": "server.reactive.session.cookie.partitioned",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the generated cookie carries the Partitioned attribute."
+    },
+    {
+      "name": "server.reactive.session.cookie.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path of the cookie."
+    },
+    {
+      "name": "server.reactive.session.cookie.same-site",
+      "schema": {
+        "enum": [
+          "LAX",
+          "NONE",
+          "OMITTED",
+          "STRICT"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.web.server.Cookie$SameSite",
+      "description": "SameSite setting for the cookie."
+    },
+    {
+      "name": "server.reactive.session.cookie.secure",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to always mark the cookie as secure."
+    },
+    {
+      "name": "server.reactive.session.max-sessions",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of sessions that can be stored.",
+      "defaultValue": "10000"
+    },
+    {
+      "name": "server.reactive.session.timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Session timeout. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "30m"
+    },
+    {
+      "name": "server.server-header",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Value to use for the Server response header (if empty, no header is sent)."
+    },
+    {
+      "name": "server.servlet.application-display-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Display name of the application.",
+      "defaultValue": "application"
+    },
+    {
+      "name": "server.servlet.context-parameters",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Servlet context init parameters."
+    },
+    {
+      "name": "server.servlet.context-path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Context path of the application."
+    },
+    {
+      "name": "server.servlet.encoding.charset",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Charset of HTTP requests and responses. Added to the \"Content-Type\" header if not set explicitly.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "server.servlet.encoding.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable http encoding support.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.servlet.encoding.force",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to force the encoding to the configured charset on HTTP requests and responses."
+    },
+    {
+      "name": "server.servlet.encoding.force-request",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to force the encoding to the configured charset on HTTP requests. Defaults to true when \"force\" has not been specified."
+    },
+    {
+      "name": "server.servlet.encoding.force-response",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to force the encoding to the configured charset on HTTP responses."
+    },
+    {
+      "name": "server.servlet.encoding.mapping",
+      "schema": {
+        "additionalProperties": {
+          "format": "charset",
+          "type": "string"
+        },
+        "propertyNames": {
+          "format": "language",
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.util.Locale,java.nio.charset.Charset>",
+      "description": "Mapping of locale to charset for response encoding."
+    },
+    {
+      "name": "server.servlet.jsp.class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Class name of the servlet to use for JSPs. If registered is true and this class\n\t * is on the classpath then it will be registered.",
+      "defaultValue": "org.apache.jasper.servlet.JspServlet"
+    },
+    {
+      "name": "server.servlet.jsp.init-parameters",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Init parameters used to configure the JSP servlet."
+    },
+    {
+      "name": "server.servlet.jsp.registered",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the JSP servlet is registered.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.servlet.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path of the main dispatcher servlet.",
+      "defaultValue": "/",
+      "deprecation": {
+        "replacement": "spring.mvc.servlet.path"
+      }
+    },
+    {
+      "name": "server.servlet.register-default-servlet",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to register the default Servlet with the container.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.servlet.session.cookie.comment",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Comment for the cookie.",
+      "deprecation": {}
+    },
+    {
+      "name": "server.servlet.session.cookie.domain",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Domain for the cookie."
+    },
+    {
+      "name": "server.servlet.session.cookie.http-only",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether to use \"HttpOnly\" cookies for the cookie."
+    },
+    {
+      "name": "server.servlet.session.cookie.max-age",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Maximum age of the cookie. If a duration suffix is not specified, seconds will be used. A positive value indicates when the cookie expires relative to the current time. A value of 0 means the cookie should expire immediately. A negative value means no \"Max-Age\"."
+    },
+    {
+      "name": "server.servlet.session.cookie.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the cookie."
+    },
+    {
+      "name": "server.servlet.session.cookie.partitioned",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether the generated cookie carries the Partitioned attribute."
+    },
+    {
+      "name": "server.servlet.session.cookie.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path of the cookie."
+    },
+    {
+      "name": "server.servlet.session.cookie.same-site",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SameSite setting for the cookie."
+    },
+    {
+      "name": "server.servlet.session.cookie.secure",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether to always mark the cookie as secure."
+    },
+    {
+      "name": "server.servlet.session.persistent",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether to persist session data between restarts.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.servlet.session.store-dir",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Directory used to store session data."
+    },
+    {
+      "name": "server.servlet.session.timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Session timeout. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "30m"
+    },
+    {
+      "name": "server.servlet.session.tracking-modes",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Session tracking modes."
+    },
+    {
+      "name": "server.shutdown",
+      "schema": {
+        "enum": [
+          "GRACEFUL",
+          "IMMEDIATE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.web.server.Shutdown",
+      "description": "Type of shutdown that the server will support.",
+      "defaultValue": "graceful"
+    },
+    {
+      "name": "server.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of a configured SSL bundle."
+    },
+    {
+      "name": "server.ssl.certificate",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to a PEM-encoded SSL certificate file."
+    },
+    {
+      "name": "server.ssl.certificate-private-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to a PEM-encoded private key file for the SSL certificate."
+    },
+    {
+      "name": "server.ssl.ciphers",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Supported SSL ciphers."
+    },
+    {
+      "name": "server.ssl.client-auth",
+      "schema": {
+        "enum": [
+          "NEED",
+          "NONE",
+          "WANT"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.web.server.Ssl$ClientAuth",
+      "description": "Client authentication mode. Requires a trust store."
+    },
+    {
+      "name": "server.ssl.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable SSL support.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.ssl.enabled-protocols",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Enabled SSL protocols."
+    },
+    {
+      "name": "server.ssl.key-alias",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Alias that identifies the key in the key store."
+    },
+    {
+      "name": "server.ssl.key-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the key in the key store."
+    },
+    {
+      "name": "server.ssl.key-store",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the key store that holds the SSL certificate (typically a jks file)."
+    },
+    {
+      "name": "server.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the key store."
+    },
+    {
+      "name": "server.ssl.key-store-provider",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Provider for the key store."
+    },
+    {
+      "name": "server.ssl.key-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the key store."
+    },
+    {
+      "name": "server.ssl.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL protocol to use.",
+      "defaultValue": "TLS"
+    },
+    {
+      "name": "server.ssl.server-name-bundles",
+      "schema": {
+        "items": {
+          "properties": {
+            "serverName": {
+              "type": "string"
+            },
+            "bundle": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<org.springframework.boot.web.server.Ssl$ServerNameSslBundle>",
+      "description": "Mapping of host names to SSL bundles for SNI configuration."
+    },
+    {
+      "name": "server.ssl.trust-certificate",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to a PEM-encoded SSL certificate authority file."
+    },
+    {
+      "name": "server.ssl.trust-certificate-private-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to a PEM-encoded private key file for the SSL certificate authority."
+    },
+    {
+      "name": "server.ssl.trust-store",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trust store that holds SSL certificates."
+    },
+    {
+      "name": "server.ssl.trust-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the trust store."
+    },
+    {
+      "name": "server.ssl.trust-store-provider",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Provider for the trust store."
+    },
+    {
+      "name": "server.ssl.trust-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the trust store."
+    },
+    {
+      "name": "server.tomcat.accept-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum queue length for incoming connection requests when all possible request processing threads are in use.",
+      "defaultValue": "100"
+    },
+    {
+      "name": "server.tomcat.accesslog.buffered",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to buffer output such that it is flushed only periodically.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.tomcat.accesslog.check-exists",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to check for log file existence so it can be recreated if an external process has renamed it.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.tomcat.accesslog.condition-if",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether logging of the request will only be enabled if \"ServletRequest.getAttribute(conditionIf)\" does not yield null."
+    },
+    {
+      "name": "server.tomcat.accesslog.condition-unless",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether logging of the request will only be enabled if \"ServletRequest.getAttribute(conditionUnless)\" yield null."
+    },
+    {
+      "name": "server.tomcat.accesslog.directory",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Directory in which log files are created. Can be absolute or relative to the Tomcat base dir.",
+      "defaultValue": "logs"
+    },
+    {
+      "name": "server.tomcat.accesslog.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Enable access log.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.tomcat.accesslog.encoding",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Character set used by the log file. Default to the system default character set."
+    },
+    {
+      "name": "server.tomcat.accesslog.file-date-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Date format to place in the log file name.",
+      "defaultValue": ".yyyy-MM-dd"
+    },
+    {
+      "name": "server.tomcat.accesslog.ipv6-canonical",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use IPv6 canonical representation format as defined by RFC 5952.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.tomcat.accesslog.locale",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Locale used to format timestamps in log entries and in log file name suffix. Default to the default locale of the Java process."
+    },
+    {
+      "name": "server.tomcat.accesslog.max-days",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of days to retain the access log files before they are removed.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "server.tomcat.accesslog.pattern",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Format pattern for access logs.",
+      "defaultValue": "common"
+    },
+    {
+      "name": "server.tomcat.accesslog.prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Log file name prefix.",
+      "defaultValue": "access_log"
+    },
+    {
+      "name": "server.tomcat.accesslog.rename-on-rotate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to defer inclusion of the date stamp in the file name until rotate time.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.tomcat.accesslog.request-attributes-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Set request attributes for the IP address, Hostname, protocol, and port used for the request.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.tomcat.accesslog.rotate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable access log rotation.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.tomcat.accesslog.suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Log file name suffix.",
+      "defaultValue": ".log"
+    },
+    {
+      "name": "server.tomcat.additional-tld-skip-patterns",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of additional patterns that match jars to ignore for TLD scanning. The special '?' and '*' characters can be used in the pattern to match one and only one character and zero or more characters respectively."
+    },
+    {
+      "name": "server.tomcat.background-processor-delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Delay between the invocation of backgroundProcess methods. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "server.tomcat.basedir",
+      "schema": {
+        "format": "uri",
+        "type": "string"
+      },
+      "typeName": "java.io.File",
+      "description": "Tomcat base directory. If not specified, a temporary directory is used."
+    },
+    {
+      "name": "server.tomcat.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Amount of time the connector will wait, after accepting a connection, for the request URI line to be presented."
+    },
+    {
+      "name": "server.tomcat.keep-alive-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time to wait for another HTTP request before the connection is closed. When not set the connectionTimeout is used. When set to -1 there will be no timeout."
+    },
+    {
+      "name": "server.tomcat.max-connections",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of connections that the server accepts and processes at any given time. Once the limit has been reached, the operating system may still accept connections based on the \"acceptCount\" property.",
+      "defaultValue": "8192"
+    },
+    {
+      "name": "server.tomcat.max-http-form-post-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of the form content in any HTTP post request.",
+      "defaultValue": "2MB"
+    },
+    {
+      "name": "server.tomcat.max-http-post-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "deprecation": {
+        "replacement": "server.tomcat.max-http-form-post-size"
+      }
+    },
+    {
+      "name": "server.tomcat.max-http-response-header-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of the HTTP response header.",
+      "defaultValue": "8KB"
+    },
+    {
+      "name": "server.tomcat.max-keep-alive-requests",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of HTTP requests that can be pipelined before the connection is closed. When set to 0 or 1, keep-alive and pipelining are disabled. When set to -1, an unlimited number of pipelined or keep-alive requests are allowed.",
+      "defaultValue": "100"
+    },
+    {
+      "name": "server.tomcat.max-parameter-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of parameters (GET plus POST) that will be automatically parsed by the container. A value of less than 0 means no limit.",
+      "defaultValue": "10000"
+    },
+    {
+      "name": "server.tomcat.max-part-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum total number of parts permitted in a multipart/form-data request. Requests that exceed this limit will be rejected. A value of less than 0 means no limit.",
+      "defaultValue": "50"
+    },
+    {
+      "name": "server.tomcat.max-part-header-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum per-part header size permitted in a multipart/form-data request. Requests that exceed this limit will be rejected. A value of less than 0 means no limit.",
+      "defaultValue": "512B"
+    },
+    {
+      "name": "server.tomcat.max-swallow-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum amount of request body to swallow.",
+      "defaultValue": "2MB"
+    },
+    {
+      "name": "server.tomcat.mbeanregistry.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether Tomcat's MBean Registry should be enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.tomcat.processor-cache",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of idle processors that will be retained in the cache and reused with a subsequent request. When set to -1 the cache will be unlimited with a theoretical maximum size equal to the maximum number of connections.",
+      "defaultValue": "200"
+    },
+    {
+      "name": "server.tomcat.redirect-context-root",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether requests to the context root should be redirected by appending a / to the path. When using SSL terminated at a proxy, this property should be set to false.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.tomcat.reject-illegal-header",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {}
+    },
+    {
+      "name": "server.tomcat.relaxed-path-chars",
+      "schema": {
+        "items": {
+          "examples": [
+            "<",
+            ">",
+            "[",
+            "\\",
+            "]",
+            "^",
+            "`",
+            "{",
+            "|",
+            "}"
+          ],
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.Character>",
+      "description": "List of additional unencoded characters that should be allowed in URI paths. Only \"< > [ \\ ] ^ ` { | }\" are allowed."
+    },
+    {
+      "name": "server.tomcat.relaxed-query-chars",
+      "schema": {
+        "items": {
+          "examples": [
+            "<",
+            ">",
+            "[",
+            "\\",
+            "]",
+            "^",
+            "`",
+            "{",
+            "|",
+            "}"
+          ],
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.Character>",
+      "description": "List of additional unencoded characters that should be allowed in URI query strings. Only \"< > [ \\ ] ^ ` { | }\" are allowed."
+    },
+    {
+      "name": "server.tomcat.remoteip.host-header",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the HTTP header from which the remote host is extracted.",
+      "defaultValue": "X-Forwarded-Host"
+    },
+    {
+      "name": "server.tomcat.remoteip.internal-proxies",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Regular expression that matches proxies that are to be trusted.",
+      "defaultValue": "10\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|192\\.168\\.\\d{1,3}\\.\\d{1,3}|169\\.254\\.\\d{1,3}\\.\\d{1,3}|127\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}|100\\.6[4-9]{1}\\.\\d{1,3}\\.\\d{1,3}|100\\.[7-9]{1}\\d{1}\\.\\d{1,3}\\.\\d{1,3}|100\\.1[0-1]{1}\\d{1}\\.\\d{1,3}\\.\\d{1,3}|100\\.12[0-7]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.1[6-9]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.2[0-9]{1}\\.\\d{1,3}\\.\\d{1,3}|172\\.3[0-1]{1}\\.\\d{1,3}\\.\\d{1,3}|0:0:0:0:0:0:0:1|::1|fe[89ab]\\p{XDigit}:.*|f[cd]\\p{XDigit}{2}+:.*"
+    },
+    {
+      "name": "server.tomcat.remoteip.port-header",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the HTTP header used to override the original port value.",
+      "defaultValue": "X-Forwarded-Port"
+    },
+    {
+      "name": "server.tomcat.remoteip.protocol-header",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Header that holds the incoming protocol, usually named \"X-Forwarded-Proto\"."
+    },
+    {
+      "name": "server.tomcat.remoteip.protocol-header-https-value",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Value of the protocol header indicating whether the incoming request uses SSL.",
+      "defaultValue": "https"
+    },
+    {
+      "name": "server.tomcat.remoteip.remote-ip-header",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the HTTP header from which the remote IP is extracted. For instance, 'X-FORWARDED-FOR'."
+    },
+    {
+      "name": "server.tomcat.remoteip.trusted-proxies",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Regular expression defining proxies that are trusted when they appear in the \"remote-ip-header\" header."
+    },
+    {
+      "name": "server.tomcat.resource.allow-caching",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether static resource caching is permitted for this web application.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.tomcat.resource.cache-ttl",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time-to-live of the static resource cache.",
+      "defaultValue": "5s"
+    },
+    {
+      "name": "server.tomcat.threads.max",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum amount of worker threads. Doesn't have an effect if virtual threads are enabled.",
+      "defaultValue": "200"
+    },
+    {
+      "name": "server.tomcat.threads.max-queue-capacity",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum capacity of the thread pool's backing queue. This setting only has an effect if the value is greater than 0.",
+      "defaultValue": "2147483647"
+    },
+    {
+      "name": "server.tomcat.threads.min-spare",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Minimum amount of worker threads. Doesn't have an effect if virtual threads are enabled.",
+      "defaultValue": "10"
+    },
+    {
+      "name": "server.tomcat.uri-encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Character encoding to use to decode the URI.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "server.tomcat.use-apr",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "NEVER",
+          "WHEN_AVAILABLE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.ServerProperties$Tomcat$UseApr",
+      "description": "Whether to use APR.",
+      "defaultValue": "never"
+    },
+    {
+      "name": "server.tomcat.use-relative-redirects",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether HTTP 1.1 and later location headers generated by a call to sendRedirect will use relative or absolute redirects.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.undertow.accesslog.dir",
+      "schema": {
+        "format": "uri",
+        "type": "string"
+      },
+      "typeName": "java.io.File",
+      "description": "Undertow access log directory."
+    },
+    {
+      "name": "server.undertow.accesslog.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the access log.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.undertow.accesslog.pattern",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Format pattern for access logs.",
+      "defaultValue": "common"
+    },
+    {
+      "name": "server.undertow.accesslog.prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Log file name prefix.",
+      "defaultValue": "access_log."
+    },
+    {
+      "name": "server.undertow.accesslog.rotate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable access log rotation.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.undertow.accesslog.suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Log file name suffix.",
+      "defaultValue": "log"
+    },
+    {
+      "name": "server.undertow.allow-encoded-slash",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the server should decode percent encoded slash characters. Enabling encoded slashes can have security implications due to different servers interpreting the slash differently. Only enable this if you have a legacy application that requires it. Has no effect when server.undertow.decode-slash is set.",
+      "defaultValue": "false",
+      "deprecation": {
+        "replacement": "server.undertow.decode-slash"
+      }
+    },
+    {
+      "name": "server.undertow.always-set-keep-alive",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the 'Connection: keep-alive' header should be added to all responses, even if not required by the HTTP specification.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.undertow.buffer-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Size of each buffer. The default is derived from the maximum amount of memory that is available to the JVM."
+    },
+    {
+      "name": "server.undertow.buffers-per-region",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of buffer per region.",
+      "deprecation": {}
+    },
+    {
+      "name": "server.undertow.decode-slash",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether encoded slash characters (%2F) should be decoded. Decoding can cause security problems if a front-end proxy does not perform the same decoding. Only enable this if you have a legacy application that requires it. When set, server.undertow.allow-encoded-slash has no effect."
+    },
+    {
+      "name": "server.undertow.decode-url",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the URL should be decoded. When disabled, percent-encoded characters in the URL will be left as-is.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.undertow.direct-buffers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to allocate buffers outside the Java heap. The default is derived from the maximum amount of memory that is available to the JVM."
+    },
+    {
+      "name": "server.undertow.eager-filter-init",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether servlet filters should be initialized on startup.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "server.undertow.max-cookies",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of cookies that are allowed. This limit exists to prevent hash collision based DOS attacks.",
+      "defaultValue": "200"
+    },
+    {
+      "name": "server.undertow.max-headers",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of headers that are allowed. This limit exists to prevent hash collision based DOS attacks."
+    },
+    {
+      "name": "server.undertow.max-http-post-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of the HTTP post content. When the value is -1, the default, the size is unlimited.",
+      "defaultValue": "-1B"
+    },
+    {
+      "name": "server.undertow.max-parameters",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of query or path parameters that are allowed. This limit exists to prevent hash collision based DOS attacks."
+    },
+    {
+      "name": "server.undertow.no-request-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Amount of time a connection can sit idle without processing a request, before it is closed by the server."
+    },
+    {
+      "name": "server.undertow.options.server",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Server options as defined in io.undertow.UndertowOptions."
+    },
+    {
+      "name": "server.undertow.options.socket",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Socket options as defined in org.xnio.Options."
+    },
+    {
+      "name": "server.undertow.preserve-path-on-forward",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to preserve the path of a request when it is forwarded.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "server.undertow.threads.io",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of I/O threads to create for the worker. The default is derived from the number of available processors."
+    },
+    {
+      "name": "server.undertow.threads.worker",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of worker threads. The default is 8 times the number of I/O threads."
+    },
+    {
+      "name": "server.undertow.url-charset",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Charset used to decode URLs.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "server.use-forward-headers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "reason": "Replaced to support additional strategies.",
+        "replacement": "server.forward-headers-strategy"
+      }
+    },
+    {
+      "name": "spring.activemq.broker-url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "URL of the ActiveMQ broker. Auto-generated by default."
+    },
+    {
+      "name": "spring.activemq.close-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time to wait before considering a close complete.",
+      "defaultValue": "15s"
+    },
+    {
+      "name": "spring.activemq.embedded.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable embedded mode if the ActiveMQ Broker is available.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.activemq.non-blocking-redelivery",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to stop message delivery before re-delivering messages from a rolled back transaction. This implies that message order is not preserved when this is enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.activemq.packages.trust-all",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to trust all packages."
+    },
+    {
+      "name": "spring.activemq.packages.trusted",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of specific packages to trust (when not trusting all packages)."
+    },
+    {
+      "name": "spring.activemq.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the broker."
+    },
+    {
+      "name": "spring.activemq.pool.block-if-full",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to block when a connection is requested and the pool is full. Set it to false to throw a \"JMSException\" instead.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.activemq.pool.block-if-full-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Blocking period before throwing an exception if the pool is still full.",
+      "defaultValue": "-1ms"
+    },
+    {
+      "name": "spring.activemq.pool.create-connection-on-startup",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to create a connection on startup. Can be used to warm up the pool on startup.",
+      "defaultValue": "true",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.activemq.pool.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether a JmsPoolConnectionFactory should be created, instead of a regular ConnectionFactory.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.activemq.pool.expiry-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Connection expiration timeout.",
+      "defaultValue": "0ms",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.activemq.pool.idle-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Connection idle timeout.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.activemq.pool.max-connections",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of pooled connections.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.activemq.pool.max-sessions-per-connection",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of pooled sessions per connection in the pool.",
+      "defaultValue": "500"
+    },
+    {
+      "name": "spring.activemq.pool.maximum-active-session-per-connection",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.activemq.pool.max-sessions-per-connection"
+      }
+    },
+    {
+      "name": "spring.activemq.pool.reconnect-on-exception",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Reset the connection when a \"JMSException\" occurs.",
+      "defaultValue": "true",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.activemq.pool.time-between-expiration-check",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time to sleep between runs of the idle connection eviction thread. When negative, no idle connection eviction thread runs.",
+      "defaultValue": "-1ms"
+    },
+    {
+      "name": "spring.activemq.pool.use-anonymous-producers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use only one anonymous \"MessageProducer\" instance. Set it to false to create one \"MessageProducer\" every time one is required.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.activemq.send-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time to wait on message sends for a response. Set it to 0 to wait forever.",
+      "defaultValue": "0ms"
+    },
+    {
+      "name": "spring.activemq.user",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the broker."
+    },
+    {
+      "name": "spring.aop.auto",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Add @EnableAspectJAutoProxy.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.aop.proxy-target-class",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether subclass-based (CGLIB) proxies are to be created (true), as opposed to standard Java interface-based proxies (false).",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.application.admin.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable admin features for the application.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.application.admin.jmx-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JMX name of the application admin MBean.",
+      "defaultValue": "org.springframework.boot:type=Admin,name=SpringApplication"
+    },
+    {
+      "name": "spring.artemis.broker-url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Artemis broker url.",
+      "defaultValue": "tcp://localhost:61616"
+    },
+    {
+      "name": "spring.artemis.embedded.cluster-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Cluster password. Randomly generated on startup by default."
+    },
+    {
+      "name": "spring.artemis.embedded.data-directory",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Journal file directory. Not necessary if persistence is turned off."
+    },
+    {
+      "name": "spring.artemis.embedded.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable embedded mode if the Artemis server APIs are available.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.artemis.embedded.persistent",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable persistent store.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.artemis.embedded.queues",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "List of queues to create on startup."
+    },
+    {
+      "name": "spring.artemis.embedded.server-id",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Server ID. By default, an auto-incremented counter is used."
+    },
+    {
+      "name": "spring.artemis.embedded.topics",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "List of topics to create on startup."
+    },
+    {
+      "name": "spring.artemis.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.artemis.broker-url"
+      }
+    },
+    {
+      "name": "spring.artemis.mode",
+      "schema": {
+        "enum": [
+          "EMBEDDED",
+          "NATIVE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.jms.artemis.ArtemisMode",
+      "description": "Artemis deployment mode, auto-detected by default."
+    },
+    {
+      "name": "spring.artemis.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the broker."
+    },
+    {
+      "name": "spring.artemis.pool.block-if-full",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to block when a connection is requested and the pool is full. Set it to false to throw a \"JMSException\" instead.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.artemis.pool.block-if-full-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Blocking period before throwing an exception if the pool is still full.",
+      "defaultValue": "-1ms"
+    },
+    {
+      "name": "spring.artemis.pool.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether a JmsPoolConnectionFactory should be created, instead of a regular ConnectionFactory.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.artemis.pool.idle-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Connection idle timeout.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.artemis.pool.max-connections",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of pooled connections.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.artemis.pool.max-sessions-per-connection",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of pooled sessions per connection in the pool.",
+      "defaultValue": "500"
+    },
+    {
+      "name": "spring.artemis.pool.maximum-active-session-per-connection",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.artemis.pool.max-sessions-per-connection"
+      }
+    },
+    {
+      "name": "spring.artemis.pool.time-between-expiration-check",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time to sleep between runs of the idle connection eviction thread. When negative, no idle connection eviction thread runs.",
+      "defaultValue": "-1ms"
+    },
+    {
+      "name": "spring.artemis.pool.use-anonymous-producers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use only one anonymous \"MessageProducer\" instance. Set it to false to create one \"MessageProducer\" every time one is required.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.artemis.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.artemis.broker-url"
+      }
+    },
+    {
+      "name": "spring.artemis.user",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the broker."
+    },
+    {
+      "name": "spring.autoconfigure.exclude",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.Class>",
+      "description": "Auto-configuration classes to exclude."
+    },
+    {
+      "name": "spring.batch.initialize-schema",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "EMBEDDED",
+          "NEVER"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.sql.init.DatabaseInitializationMode",
+      "deprecation": {
+        "replacement": "spring.batch.jdbc.initialize-schema"
+      }
+    },
+    {
+      "name": "spring.batch.initializer.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Create the required batch tables on startup if necessary. Enabled automatically\n if no custom table prefix is set or if a custom schema is configured.",
+      "deprecation": {
+        "replacement": "spring.batch.jdbc.initialize-schema"
+      }
+    },
+    {
+      "name": "spring.batch.jdbc.initialize-schema",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "EMBEDDED",
+          "NEVER"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.sql.init.DatabaseInitializationMode",
+      "description": "Database schema initialization mode.",
+      "defaultValue": "embedded"
+    },
+    {
+      "name": "spring.batch.jdbc.isolation-level-for-create",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.transaction.annotation.Isolation",
+      "description": "Transaction isolation level to use when creating job meta-data for new jobs."
+    },
+    {
+      "name": "spring.batch.jdbc.platform",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Platform to use in initialization scripts if the @@platform@@ placeholder is used. Auto-detected by default."
+    },
+    {
+      "name": "spring.batch.jdbc.schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the SQL file to use to initialize the database schema.",
+      "defaultValue": "classpath:org/springframework/batch/core/schema-@@platform@@.sql"
+    },
+    {
+      "name": "spring.batch.jdbc.table-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Table prefix for all the batch meta-data tables."
+    },
+    {
+      "name": "spring.batch.jdbc.validate-transaction-state",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to validate the transaction state.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.batch.job.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to execute a Spring Batch job on startup. When multiple jobs are present in the context, set spring.batch.job.name to identify the job to execute.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.batch.job.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Job name to execute on startup. Must be specified if multiple Jobs are found in the context."
+    },
+    {
+      "name": "spring.batch.schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.batch.jdbc.schema"
+      }
+    },
+    {
+      "name": "spring.batch.table-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.batch.jdbc.table-prefix"
+      }
+    },
+    {
+      "name": "spring.cache.cache-names",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of cache names to create if supported by the underlying cache manager. Usually, this disables the ability to create additional caches on-the-fly."
+    },
+    {
+      "name": "spring.cache.caffeine.spec",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "The spec to use to create caches. See CaffeineSpec for more details on the spec format."
+    },
+    {
+      "name": "spring.cache.couchbase.expiration",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Entry expiration. By default the entries never expire. Note that this value is ultimately converted to seconds."
+    },
+    {
+      "name": "spring.cache.infinispan.config",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "The location of the configuration file to use to initialize Infinispan."
+    },
+    {
+      "name": "spring.cache.jcache.config",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "The location of the configuration file to use to initialize the cache manager. The configuration file is dependent of the underlying cache implementation."
+    },
+    {
+      "name": "spring.cache.jcache.provider",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Fully qualified name of the CachingProvider implementation to use to retrieve the JSR-107 compliant cache manager. Needed only if more than one JSR-107 implementation is available on the classpath."
+    },
+    {
+      "name": "spring.cache.redis.cache-null-values",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Allow caching null values.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.cache.redis.enable-statistics",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable cache statistics.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.cache.redis.key-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Key prefix."
+    },
+    {
+      "name": "spring.cache.redis.time-to-live",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Entry expiration. By default the entries never expire."
+    },
+    {
+      "name": "spring.cache.redis.use-key-prefix",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use the key prefix when writing to Redis.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.cache.type",
+      "schema": {
+        "enum": [
+          "CACHE2K",
+          "CAFFEINE",
+          "COUCHBASE",
+          "GENERIC",
+          "HAZELCAST",
+          "INFINISPAN",
+          "JCACHE",
+          "NONE",
+          "REDIS",
+          "SIMPLE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.cache.CacheType",
+      "description": "Cache type. By default, auto-detected according to the environment."
+    },
+    {
+      "name": "spring.cassandra.compression",
+      "schema": {
+        "enum": [
+          "LZ4",
+          "NONE",
+          "SNAPPY"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.cassandra.CassandraProperties$Compression",
+      "description": "Compression supported by the Cassandra binary protocol.",
+      "defaultValue": "none"
+    },
+    {
+      "name": "spring.cassandra.config",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the configuration file to use."
+    },
+    {
+      "name": "spring.cassandra.connection.connect-timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "5s"
+    },
+    {
+      "name": "spring.cassandra.connection.init-query-timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "5s"
+    },
+    {
+      "name": "spring.cassandra.contact-points",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Cluster node addresses in the form 'host:port', or a simple 'host' to use the configured port.",
+      "defaultValue": "127.0.0.1:9042"
+    },
+    {
+      "name": "spring.cassandra.controlconnection.timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "5s"
+    },
+    {
+      "name": "spring.cassandra.keyspace-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Keyspace name to use."
+    },
+    {
+      "name": "spring.cassandra.local-datacenter",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Datacenter that is considered \"local\". Contact points should be from this datacenter."
+    },
+    {
+      "name": "spring.cassandra.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the server."
+    },
+    {
+      "name": "spring.cassandra.pool.heartbeat-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Heartbeat interval after which a message is sent on an idle connection to make sure it's still alive.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.cassandra.pool.idle-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Idle timeout before an idle connection is removed.",
+      "defaultValue": "5s"
+    },
+    {
+      "name": "spring.cassandra.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Port to use if a contact point does not specify one.",
+      "defaultValue": "9042"
+    },
+    {
+      "name": "spring.cassandra.request.consistency",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "com.datastax.oss.driver.api.core.DefaultConsistencyLevel",
+      "description": "Queries consistency level."
+    },
+    {
+      "name": "spring.cassandra.request.page-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "How many rows will be retrieved simultaneously in a single network round-trip.",
+      "defaultValue": "5000"
+    },
+    {
+      "name": "spring.cassandra.request.serial-consistency",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "com.datastax.oss.driver.api.core.DefaultConsistencyLevel",
+      "description": "Queries serial consistency level."
+    },
+    {
+      "name": "spring.cassandra.request.throttler.drain-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "How often the throttler attempts to dequeue requests. Set this high enough that each attempt will process multiple entries in the queue, but not delay requests too much."
+    },
+    {
+      "name": "spring.cassandra.request.throttler.max-concurrent-requests",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of requests that are allowed to execute in parallel."
+    },
+    {
+      "name": "spring.cassandra.request.throttler.max-queue-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of requests that can be enqueued when the throttling threshold is exceeded."
+    },
+    {
+      "name": "spring.cassandra.request.throttler.max-requests-per-second",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum allowed request rate."
+    },
+    {
+      "name": "spring.cassandra.request.throttler.type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "none"
+    },
+    {
+      "name": "spring.cassandra.request.timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "How long the driver waits for a request to complete.",
+      "defaultValue": "2s"
+    },
+    {
+      "name": "spring.cassandra.schema-action",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Schema action to take at startup.",
+      "defaultValue": "none"
+    },
+    {
+      "name": "spring.cassandra.session-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the Cassandra session."
+    },
+    {
+      "name": "spring.cassandra.ssl",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.cassandra.ssl.enabled"
+      }
+    },
+    {
+      "name": "spring.cassandra.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle name."
+    },
+    {
+      "name": "spring.cassandra.ssl.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable SSL support."
+    },
+    {
+      "name": "spring.cassandra.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the server."
+    },
+    {
+      "name": "spring.codec.log-request-details",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to log form data at DEBUG level, and headers at TRACE level.",
+      "defaultValue": "false",
+      "deprecation": {
+        "replacement": "spring.http.codecs.log-request-details"
+      }
+    },
+    {
+      "name": "spring.codec.max-in-memory-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Limit on the number of bytes that can be buffered whenever the input stream needs to be aggregated. This applies only to the auto-configured WebFlux server and WebClient instances. By default this is not set, in which case individual codec defaults apply. Most codecs are limited to 256K by default.",
+      "deprecation": {
+        "replacement": "spring.http.codecs.max-in-memory-size"
+      }
+    },
+    {
+      "name": "spring.couchbase.authentication.jks.location",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Java KeyStore location for certificate-based cluster authentication."
+    },
+    {
+      "name": "spring.couchbase.authentication.jks.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Java KeyStore password for certificate-based cluster authentication."
+    },
+    {
+      "name": "spring.couchbase.authentication.pem.certificates",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "PEM-formatted certificates for certificate-based cluster authentication."
+    },
+    {
+      "name": "spring.couchbase.authentication.pem.private-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "PEM-formatted private key for certificate-based cluster authentication."
+    },
+    {
+      "name": "spring.couchbase.authentication.pem.private-key-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Private key password for certificate-based cluster authentication."
+    },
+    {
+      "name": "spring.couchbase.bootstrap-hosts",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Couchbase nodes (host or IP address) to bootstrap from.",
+      "deprecation": {
+        "replacement": "spring.couchbase.connection-string"
+      }
+    },
+    {
+      "name": "spring.couchbase.bucket.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the bucket to connect to.",
+      "deprecation": {
+        "reason": "A bucket is no longer auto-configured."
+      }
+    },
+    {
+      "name": "spring.couchbase.bucket.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password of the bucket.",
+      "deprecation": {
+        "reason": "A bucket is no longer auto-configured."
+      }
+    },
+    {
+      "name": "spring.couchbase.connection-string",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Connection string used to locate the Couchbase cluster."
+    },
+    {
+      "name": "spring.couchbase.env.bootstrap.http-direct-port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Port for the HTTP bootstrap.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.couchbase.env.bootstrap.http-ssl-port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Port for the HTTPS bootstrap.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.couchbase.env.endpoints.key-value",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of sockets per node against the key/value service.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.couchbase.env.endpoints.query",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of sockets per node against the query (N1QL) service.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.couchbase.env.endpoints.queryservice.max-endpoints",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of sockets per node.",
+      "deprecation": {
+        "replacement": "spring.couchbase.env.io.max-endpoints"
+      }
+    },
+    {
+      "name": "spring.couchbase.env.endpoints.queryservice.min-endpoints",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Minimum number of sockets per node.",
+      "deprecation": {
+        "replacement": "spring.couchbase.env.io.min-endpoints"
+      }
+    },
+    {
+      "name": "spring.couchbase.env.endpoints.view",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of sockets per node against the view service.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.couchbase.env.endpoints.viewservice.max-endpoints",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of sockets per node.",
+      "deprecation": {
+        "replacement": "spring.couchbase.env.io.max-endpoints"
+      }
+    },
+    {
+      "name": "spring.couchbase.env.endpoints.viewservice.min-endpoints",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Minimum number of sockets per node.",
+      "deprecation": {
+        "replacement": "spring.couchbase.env.io.min-endpoints"
+      }
+    },
+    {
+      "name": "spring.couchbase.env.io.idle-http-connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Length of time an HTTP connection may remain idle before it is closed and removed from the pool.",
+      "defaultValue": "1s"
+    },
+    {
+      "name": "spring.couchbase.env.io.max-endpoints",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of sockets per node.",
+      "defaultValue": "12"
+    },
+    {
+      "name": "spring.couchbase.env.io.min-endpoints",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Minimum number of sockets per node.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.couchbase.env.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle name."
+    },
+    {
+      "name": "spring.couchbase.env.ssl.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable SSL support. Enabled automatically if a \"bundle\" is provided unless specified otherwise."
+    },
+    {
+      "name": "spring.couchbase.env.ssl.key-store",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the JVM key store that holds the certificates.",
+      "deprecation": {
+        "replacement": "spring.couchbase.env.ssl.bundle"
+      }
+    },
+    {
+      "name": "spring.couchbase.env.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the key store.",
+      "deprecation": {
+        "replacement": "spring.couchbase.env.ssl.bundle"
+      }
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.analytics",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for the analytics service.",
+      "defaultValue": "75s"
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.connect",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Bucket connect timeout.",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.disconnect",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Bucket disconnect timeout.",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.key-value",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for operations on a specific key-value.",
+      "defaultValue": "2500ms"
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.key-value-durable",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for operations on a specific key-value with a durability level.",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.management",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for the management operations.",
+      "defaultValue": "75s"
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.query",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "N1QL query operations timeout.",
+      "defaultValue": "75s"
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.search",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for the search service.",
+      "defaultValue": "75s"
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.socket-connect",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Socket connect connections timeout.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.couchbase.env.timeouts.view",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Regular and geospatial view operations timeout.",
+      "defaultValue": "75s"
+    },
+    {
+      "name": "spring.couchbase.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Cluster password."
+    },
+    {
+      "name": "spring.couchbase.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Cluster username."
+    },
+    {
+      "name": "spring.dao.exceptiontranslation.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the PersistenceExceptionTranslationPostProcessor.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.data.cassandra.compression",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "none",
+      "deprecation": {
+        "replacement": "spring.cassandra.compression"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.config",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "deprecation": {
+        "replacement": "spring.cassandra.config"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.connection.connect-timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "5s",
+      "deprecation": {
+        "replacement": "spring.cassandra.connection.connect-timeout"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.connection.init-query-timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "5s",
+      "deprecation": {
+        "replacement": "spring.cassandra.connection.init-query-timeout"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.contact-points",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "127.0.0.1:9042",
+      "deprecation": {
+        "replacement": "spring.cassandra.contact-points"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.controlconnection.timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "5s",
+      "deprecation": {
+        "replacement": "spring.cassandra.controlconnection.timeout"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.jmx-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable JMX reporting. Default to false as Cassandra JMX reporting is not compatible with Dropwizard Metrics.",
+      "deprecation": {
+        "reason": "Cassandra no longer provides JMX metrics."
+      }
+    },
+    {
+      "name": "spring.data.cassandra.keyspace-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.cassandra.keyspace-name"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.load-balancing-policy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class",
+      "description": "Class name of the load balancing policy. The class must have a default constructor.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.data.cassandra.local-datacenter",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.cassandra.local-datacenter"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.cassandra.password"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.pool.heartbeat-interval",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "30s",
+      "deprecation": {
+        "replacement": "spring.cassandra.pool.heartbeat-interval"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.pool.idle-timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "5s",
+      "deprecation": {
+        "replacement": "spring.cassandra.pool.idle-timeout"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.pool.max-queue-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.throttler.max-queue-size"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.pool.pool-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Pool timeout when trying to acquire a connection from a host's pool.",
+      "deprecation": {
+        "reason": "No longer available."
+      }
+    },
+    {
+      "name": "spring.data.cassandra.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.cassandra.port"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.reconnection-policy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class",
+      "description": "Class name of the reconnection policy. The class must have a default constructor.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.data.cassandra.repositories.type",
+      "schema": {
+        "enum": [
+          "AUTO",
+          "IMPERATIVE",
+          "NONE",
+          "REACTIVE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.data.RepositoryType",
+      "description": "Type of Cassandra repositories to enable.",
+      "defaultValue": "auto"
+    },
+    {
+      "name": "spring.data.cassandra.request.consistency",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "com.datastax.oss.driver.api.core.DefaultConsistencyLevel",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.consistency"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.request.page-size",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "5000",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.page-size"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.request.serial-consistency",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "com.datastax.oss.driver.api.core.DefaultConsistencyLevel",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.serial-consistency"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.request.throttler.drain-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.throttler.drain-interval"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.request.throttler.max-concurrent-requests",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.throttler.max-concurrent-requests"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.request.throttler.max-queue-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.throttler.max-queue-size"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.request.throttler.max-requests-per-second",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.throttler.max-requests-per-second"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.request.throttler.type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "none",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.throttler.type"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.request.timeout",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "2s",
+      "deprecation": {
+        "replacement": "spring.cassandra.request.timeout"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.retry-policy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class",
+      "description": "Class name of the retry policy. The class must have a default constructor.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.data.cassandra.schema-action",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.cassandra.schema-action"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.session-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.cassandra.session-name"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.ssl",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.cassandra.ssl.enabled"
+      }
+    },
+    {
+      "name": "spring.data.cassandra.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.cassandra.username"
+      }
+    },
+    {
+      "name": "spring.data.couchbase.auto-index",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Automatically create views and indexes. Use the meta-data provided by \"@ViewIndexed\", \"@N1qlPrimaryIndexed\" and \"@N1qlSecondaryIndexed\".",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.data.couchbase.bucket-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the bucket to connect to."
+    },
+    {
+      "name": "spring.data.couchbase.consistency",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.data.couchbase.core.query.Consistency",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.data.couchbase.field-naming-strategy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class<?>",
+      "description": "Fully qualified name of the FieldNamingStrategy to use."
+    },
+    {
+      "name": "spring.data.couchbase.repositories.type",
+      "schema": {
+        "enum": [
+          "AUTO",
+          "IMPERATIVE",
+          "NONE",
+          "REACTIVE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.data.RepositoryType",
+      "description": "Type of Couchbase repositories to enable.",
+      "defaultValue": "auto"
+    },
+    {
+      "name": "spring.data.couchbase.scope-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the scope used for all collection access."
+    },
+    {
+      "name": "spring.data.couchbase.type-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the field that stores the type information for complex types when using \"MappingCouchbaseConverter\".",
+      "defaultValue": "_class"
+    },
+    {
+      "name": "spring.data.elasticsearch.cluster-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Elasticsearch cluster name.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.data.elasticsearch.cluster-nodes",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Comma-separated list of cluster node addresses.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.data.elasticsearch.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional properties used to configure the client.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.data.elasticsearch.repositories.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Elasticsearch repositories.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.data.jdbc.dialect",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.data.jdbc.JdbcDatabaseDialect",
+      "description": "Dialect to use. By default, the dialect is determined by inspecting the database connection."
+    },
+    {
+      "name": "spring.data.jdbc.repositories.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable JDBC repositories.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.data.jpa.repositories.bootstrap-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.data.repository.config.BootstrapMode",
+      "description": "Bootstrap mode for JPA repositories.",
+      "defaultValue": "default"
+    },
+    {
+      "name": "spring.data.jpa.repositories.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable JPA repositories.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.data.ldap.repositories.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable LDAP repositories.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.data.mongodb.additional-hosts",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Additional server hosts. Ignored if 'uri' is set or if 'host' is omitted. Additional hosts will use the default mongo port of 27017. If you want to use a different port you can use the \"host:port\" syntax."
+    },
+    {
+      "name": "spring.data.mongodb.authentication-database",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authentication database name."
+    },
+    {
+      "name": "spring.data.mongodb.auto-index-creation",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable auto-index creation."
+    },
+    {
+      "name": "spring.data.mongodb.database",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Database name. Overrides database in URI."
+    },
+    {
+      "name": "spring.data.mongodb.field-naming-strategy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class<?>",
+      "description": "Fully qualified name of the FieldNamingStrategy to use."
+    },
+    {
+      "name": "spring.data.mongodb.grid-fs-database",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.mongodb.gridfs.database"
+      }
+    },
+    {
+      "name": "spring.data.mongodb.gridfs.bucket",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "GridFS bucket name."
+    },
+    {
+      "name": "spring.data.mongodb.gridfs.database",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "GridFS database name."
+    },
+    {
+      "name": "spring.data.mongodb.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Mongo server host. Ignored if 'uri' is set."
+    },
+    {
+      "name": "spring.data.mongodb.password",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.Character[]",
+      "description": "Login password of the mongo server. Ignored if 'uri' is set."
+    },
+    {
+      "name": "spring.data.mongodb.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Mongo server port. Ignored if 'uri' is set."
+    },
+    {
+      "name": "spring.data.mongodb.protocol",
+      "schema": {
+        "examples": [
+          "mongodb",
+          "mongodb+srv"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Protocol to be used for the MongoDB connection. Ignored if 'uri' is set.",
+      "defaultValue": "mongodb"
+    },
+    {
+      "name": "spring.data.mongodb.replica-set-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Required replica set name for the cluster. Ignored if 'uri' is set."
+    },
+    {
+      "name": "spring.data.mongodb.repositories.type",
+      "schema": {
+        "enum": [
+          "AUTO",
+          "IMPERATIVE",
+          "NONE",
+          "REACTIVE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.data.RepositoryType",
+      "description": "Type of Mongo repositories to enable.",
+      "defaultValue": "auto"
+    },
+    {
+      "name": "spring.data.mongodb.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle name."
+    },
+    {
+      "name": "spring.data.mongodb.ssl.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable SSL support. Enabled automatically if \"bundle\" is provided unless specified otherwise."
+    },
+    {
+      "name": "spring.data.mongodb.uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Mongo database URI. Overrides host, port, username, and password.",
+      "defaultValue": "mongodb://localhost/test"
+    },
+    {
+      "name": "spring.data.mongodb.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the mongo server. Ignored if 'uri' is set."
+    },
+    {
+      "name": "spring.data.mongodb.uuid-representation",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.bson.UuidRepresentation",
+      "description": "Representation to use when converting a UUID to a BSON binary value.",
+      "defaultValue": "java-legacy"
+    },
+    {
+      "name": "spring.data.neo4j.auto-index",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Auto index mode.",
+      "defaultValue": "none",
+      "deprecation": {
+        "reason": "Automatic index creation is no longer supported."
+      }
+    },
+    {
+      "name": "spring.data.neo4j.database",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Database name to use. By default, the server decides the default database to use."
+    },
+    {
+      "name": "spring.data.neo4j.embedded.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable embedded mode if the embedded driver is available.",
+      "deprecation": {
+        "reason": "Embedded mode is no longer supported, please use Testcontainers instead."
+      }
+    },
+    {
+      "name": "spring.data.neo4j.open-in-view",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Register OpenSessionInViewInterceptor that binds a Neo4j Session to the thread for the entire processing of the request.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.data.neo4j.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the server.",
+      "deprecation": {
+        "replacement": "spring.neo4j.authentication.password"
+      }
+    },
+    {
+      "name": "spring.data.neo4j.repositories.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Neo4j repositories.",
+      "defaultValue": "true",
+      "deprecation": {
+        "replacement": "spring.data.neo4j.repositories.type"
+      }
+    },
+    {
+      "name": "spring.data.neo4j.repositories.type",
+      "schema": {
+        "enum": [
+          "AUTO",
+          "IMPERATIVE",
+          "NONE",
+          "REACTIVE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.data.RepositoryType",
+      "description": "Type of Neo4j repositories to enable.",
+      "defaultValue": "auto"
+    },
+    {
+      "name": "spring.data.neo4j.uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "URI used by the driver. Auto-detected by default.",
+      "deprecation": {
+        "replacement": "spring.neo4j.uri"
+      }
+    },
+    {
+      "name": "spring.data.neo4j.use-native-types",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use Neo4j native types wherever possible.",
+      "deprecation": {
+        "reason": "Native type support is now built-in."
+      }
+    },
+    {
+      "name": "spring.data.neo4j.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the server.",
+      "deprecation": {
+        "replacement": "spring.neo4j.authentication.username"
+      }
+    },
+    {
+      "name": "spring.data.r2dbc.repositories.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable R2DBC repositories.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.data.redis.client-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Client name to be set on connections with CLIENT SETNAME."
+    },
+    {
+      "name": "spring.data.redis.client-type",
+      "schema": {
+        "enum": [
+          "JEDIS",
+          "LETTUCE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.data.redis.RedisProperties$ClientType",
+      "description": "Type of client to use. By default, auto-detected according to the classpath."
+    },
+    {
+      "name": "spring.data.redis.cluster.max-redirects",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of redirects to follow when executing commands across the cluster."
+    },
+    {
+      "name": "spring.data.redis.cluster.nodes",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of \"host:port\" pairs to bootstrap from. This represents an \"initial\" list of cluster nodes and is required to have at least one entry."
+    },
+    {
+      "name": "spring.data.redis.connect-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Connection timeout."
+    },
+    {
+      "name": "spring.data.redis.database",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Database index used by the connection factory.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.data.redis.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Redis server host.",
+      "defaultValue": "localhost"
+    },
+    {
+      "name": "spring.data.redis.jedis.pool.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the pool. Enabled automatically if \"commons-pool2\" is available. With Jedis, pooling is implicitly enabled in sentinel mode and this setting only applies to single node setup."
+    },
+    {
+      "name": "spring.data.redis.jedis.pool.max-active",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of connections that can be allocated by the pool at a given time. Use a negative value for no limit.",
+      "defaultValue": "8"
+    },
+    {
+      "name": "spring.data.redis.jedis.pool.max-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of \"idle\" connections in the pool. Use a negative value to indicate an unlimited number of idle connections.",
+      "defaultValue": "8"
+    },
+    {
+      "name": "spring.data.redis.jedis.pool.max-wait",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum amount of time a connection allocation should block before throwing an exception when the pool is exhausted. Use a negative value to block indefinitely.",
+      "defaultValue": "-1ms"
+    },
+    {
+      "name": "spring.data.redis.jedis.pool.min-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Target for the minimum number of idle connections to maintain in the pool. This setting only has an effect if both it and time between eviction runs are positive.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.data.redis.jedis.pool.time-between-eviction-runs",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time between runs of the idle object evictor thread. When positive, the idle object evictor thread starts, otherwise no idle object eviction is performed."
+    },
+    {
+      "name": "spring.data.redis.lettuce.cluster.refresh.adaptive",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether adaptive topology refreshing using all available refresh triggers should be used.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.data.redis.lettuce.cluster.refresh.dynamic-refresh-sources",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to discover and query all cluster nodes for obtaining the cluster topology. When set to false, only the initial seed nodes are used as sources for topology discovery.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.data.redis.lettuce.cluster.refresh.period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Cluster topology refresh period."
+    },
+    {
+      "name": "spring.data.redis.lettuce.pool.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the pool. Enabled automatically if \"commons-pool2\" is available. With Jedis, pooling is implicitly enabled in sentinel mode and this setting only applies to single node setup."
+    },
+    {
+      "name": "spring.data.redis.lettuce.pool.max-active",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of connections that can be allocated by the pool at a given time. Use a negative value for no limit.",
+      "defaultValue": "8"
+    },
+    {
+      "name": "spring.data.redis.lettuce.pool.max-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of \"idle\" connections in the pool. Use a negative value to indicate an unlimited number of idle connections.",
+      "defaultValue": "8"
+    },
+    {
+      "name": "spring.data.redis.lettuce.pool.max-wait",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum amount of time a connection allocation should block before throwing an exception when the pool is exhausted. Use a negative value to block indefinitely.",
+      "defaultValue": "-1ms"
+    },
+    {
+      "name": "spring.data.redis.lettuce.pool.min-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Target for the minimum number of idle connections to maintain in the pool. This setting only has an effect if both it and time between eviction runs are positive.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.data.redis.lettuce.pool.time-between-eviction-runs",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time between runs of the idle object evictor thread. When positive, the idle object evictor thread starts, otherwise no idle object eviction is performed."
+    },
+    {
+      "name": "spring.data.redis.lettuce.read-from",
+      "schema": {
+        "examples": [
+          "any",
+          "any-replica",
+          "lowest-latency",
+          "regex:",
+          "replica",
+          "replica-preferred",
+          "subnet:",
+          "upstream",
+          "upstream-preferred"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Defines from which Redis nodes data is read."
+    },
+    {
+      "name": "spring.data.redis.lettuce.shutdown-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Shutdown timeout.",
+      "defaultValue": "100ms"
+    },
+    {
+      "name": "spring.data.redis.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the redis server."
+    },
+    {
+      "name": "spring.data.redis.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Redis server port.",
+      "defaultValue": "6379"
+    },
+    {
+      "name": "spring.data.redis.repositories.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Redis repositories.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.data.redis.sentinel.master",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the Redis server."
+    },
+    {
+      "name": "spring.data.redis.sentinel.nodes",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of \"host:port\" pairs."
+    },
+    {
+      "name": "spring.data.redis.sentinel.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password for authenticating with sentinel(s)."
+    },
+    {
+      "name": "spring.data.redis.sentinel.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login username for authenticating with sentinel(s)."
+    },
+    {
+      "name": "spring.data.redis.ssl",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.data.redis.ssl.enabled"
+      }
+    },
+    {
+      "name": "spring.data.redis.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle name."
+    },
+    {
+      "name": "spring.data.redis.ssl.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable SSL support. Enabled automatically if \"bundle\" is provided unless specified otherwise."
+    },
+    {
+      "name": "spring.data.redis.timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Read timeout."
+    },
+    {
+      "name": "spring.data.redis.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Connection URL. Overrides host, port, username, password, and database. Example: redis://user:password@example.com:6379/8"
+    },
+    {
+      "name": "spring.data.redis.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login username of the redis server."
+    },
+    {
+      "name": "spring.data.rest.base-path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Base path to be used by Spring Data REST to expose repository resources."
+    },
+    {
+      "name": "spring.data.rest.default-media-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.http.MediaType",
+      "description": "Content type to use as a default when none is specified."
+    },
+    {
+      "name": "spring.data.rest.default-page-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Default size of pages."
+    },
+    {
+      "name": "spring.data.rest.detection-strategy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.data.rest.core.mapping.RepositoryDetectionStrategy$RepositoryDetectionStrategies",
+      "description": "Strategy to use to determine which repositories get exposed.",
+      "defaultValue": "default"
+    },
+    {
+      "name": "spring.data.rest.enable-enum-translation",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable enum value translation through the Spring Data REST default resource bundle."
+    },
+    {
+      "name": "spring.data.rest.limit-param-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the URL query string parameter that indicates how many results to return at once."
+    },
+    {
+      "name": "spring.data.rest.max-page-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum size of pages."
+    },
+    {
+      "name": "spring.data.rest.page-param-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the URL query string parameter that indicates what page to return."
+    },
+    {
+      "name": "spring.data.rest.return-body-on-create",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to return a response body after creating an entity."
+    },
+    {
+      "name": "spring.data.rest.return-body-on-update",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to return a response body after updating an entity."
+    },
+    {
+      "name": "spring.data.rest.sort-param-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the URL query string parameter that indicates what direction to sort results."
+    },
+    {
+      "name": "spring.data.web.pageable.default-page-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Default page size.",
+      "defaultValue": "20"
+    },
+    {
+      "name": "spring.data.web.pageable.max-page-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum page size to be accepted.",
+      "defaultValue": "2000"
+    },
+    {
+      "name": "spring.data.web.pageable.one-indexed-parameters",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to expose and assume 1-based page number indexes. Defaults to \"false\", meaning a page number of 0 in the request equals the first page.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.data.web.pageable.page-parameter",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Page index parameter name.",
+      "defaultValue": "page"
+    },
+    {
+      "name": "spring.data.web.pageable.prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "General prefix to be prepended to the page number and page size parameters."
+    },
+    {
+      "name": "spring.data.web.pageable.qualifier-delimiter",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Delimiter to be used between the qualifier and the actual page number and size properties.",
+      "defaultValue": "_"
+    },
+    {
+      "name": "spring.data.web.pageable.serialization-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.data.web.config.EnableSpringDataWebSupport$PageSerializationMode",
+      "description": "Configures how to render Spring Data Pageable instances.",
+      "defaultValue": "direct"
+    },
+    {
+      "name": "spring.data.web.pageable.size-parameter",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Page size parameter name.",
+      "defaultValue": "size"
+    },
+    {
+      "name": "spring.data.web.sort.sort-parameter",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Sort parameter name.",
+      "defaultValue": "sort"
+    },
+    {
+      "name": "spring.datasource.continue-on-error",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.sql.init.continue-on-error"
+      }
+    },
+    {
+      "name": "spring.datasource.data",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "deprecation": {
+        "replacement": "spring.sql.init.data-locations"
+      }
+    },
+    {
+      "name": "spring.datasource.data-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.sql.init.password"
+      }
+    },
+    {
+      "name": "spring.datasource.data-username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.sql.init.username"
+      }
+    },
+    {
+      "name": "spring.datasource.dbcp2.abandoned-usage-tracking",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.access-to-underlying-connection-allowed",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.auto-commit-on-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.cache-state",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.clear-statement-pool-on-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.connection-factory-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.connection-init-sqls",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>"
+    },
+    {
+      "name": "spring.datasource.dbcp2.default-auto-commit",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.default-catalog",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.default-query-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.dbcp2.default-read-only",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.default-schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.default-transaction-isolation",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.dbcp2.disconnection-ignore-sql-codes",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.Set<java.lang.String>"
+    },
+    {
+      "name": "spring.datasource.dbcp2.disconnection-sql-codes",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.Set<java.lang.String>"
+    },
+    {
+      "name": "spring.datasource.dbcp2.driver-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.duration-between-eviction-runs",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration"
+    },
+    {
+      "name": "spring.datasource.dbcp2.enable-auto-commit-on-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.dbcp2.eviction-policy-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.fast-fail-validation",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.initial-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.dbcp2.jmx-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.lifo",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.log-abandoned",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.log-expired-connections",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.login-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.dbcp2.max-conn-lifetime-millis",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.dbcp2.max-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.dbcp2.max-open-prepared-statements",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.dbcp2.max-total",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.dbcp2.max-wait-millis",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.dbcp2.min-evictable-idle-time-millis",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.dbcp2.min-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.dbcp2.num-tests-per-eviction-run",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.dbcp2.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.pool-prepared-statements",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.remove-abandoned-on-borrow",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.remove-abandoned-on-maintenance",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.remove-abandoned-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.dbcp2.rollback-on-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.soft-min-evictable-idle-time-millis",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.dbcp2.test-on-borrow",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.test-on-create",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.test-on-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.test-while-idle",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.dbcp2.time-between-eviction-runs-millis",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.dbcp2.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.validation-query",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.dbcp2.validation-query-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.driver-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Fully qualified name of the JDBC driver. Auto-detected based on the URL by default."
+    },
+    {
+      "name": "spring.datasource.embedded-database-connection",
+      "schema": {
+        "enum": [
+          "DERBY",
+          "H2",
+          "HSQLDB",
+          "NONE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.jdbc.EmbeddedDatabaseConnection",
+      "description": "Connection details for an embedded database. Defaults to the most suitable embedded database that is available on the classpath."
+    },
+    {
+      "name": "spring.datasource.generate-unique-name",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to generate a random datasource name.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.datasource.hikari.allow-pool-suspension",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.hikari.auto-commit",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.hikari.catalog",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.connection-init-sql",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.connection-test-query",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.connection-timeout",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.hikari.data-source-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.data-source-j-n-d-i",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.data-source-properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Properties"
+    },
+    {
+      "name": "spring.datasource.hikari.driver-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.exception-override-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.health-check-properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Properties"
+    },
+    {
+      "name": "spring.datasource.hikari.idle-timeout",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.hikari.initialization-fail-timeout",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.hikari.isolate-internal-queries",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.hikari.jdbc-url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.keepalive-time",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.hikari.leak-detection-threshold",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.hikari.login-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.hikari.max-lifetime",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.hikari.maximum-pool-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.hikari.minimum-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.hikari.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.pool-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.read-only",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.hikari.register-mbeans",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.hikari.schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.transaction-isolation",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.hikari.validation-timeout",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.initialization-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.jdbc.DataSourceInitializationMode",
+      "deprecation": {
+        "replacement": "spring.sql.init.mode"
+      }
+    },
+    {
+      "name": "spring.datasource.jmx-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable JMX support (if provided by the underlying pool).",
+      "defaultValue": "false",
+      "deprecation": {
+        "replacement": "spring.datasource.tomcat.jmx-enabled"
+      }
+    },
+    {
+      "name": "spring.datasource.jndi-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JNDI location of the datasource. Class, url, username and password are ignored when set."
+    },
+    {
+      "name": "spring.datasource.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Datasource name to use if \"generate-unique-name\" is false. Defaults to \"testdb\" when using an embedded database, otherwise null."
+    },
+    {
+      "name": "spring.datasource.oracleucp.abandoned-connection-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.commit-on-connection-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-factory-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-factory-properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Properties"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-harvest-max-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-harvest-trigger-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-labeling-high-cost",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-pool-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Properties"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-repurpose-threshold",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-validation-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-wait-duration",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration"
+    },
+    {
+      "name": "spring.datasource.oracleucp.connection-wait-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.datasource.oracleucp.create-connection-in-borrow-thread",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.oracleucp.data-source-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.database-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.description",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.fast-connection-failover-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.oracleucp.high-cost-connection-reuse-threshold",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.inactive-connection-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.initial-pool-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.login-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.max-connection-reuse-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.max-connection-reuse-time",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.oracleucp.max-connections-per-shard",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.max-idle-time",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.max-pool-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.max-statements",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.min-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.min-pool-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.network-protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.o-n-s-configuration",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.pdb-roles",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Properties"
+    },
+    {
+      "name": "spring.datasource.oracleucp.port-number",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.property-cycle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.query-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.read-only-instance-allowed",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.oracleucp.role-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.s-q-l-for-validate-connection",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.seconds-to-trust-idle-connection",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.server-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.sharding-mode",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.oracleucp.time-to-live-connection-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.timeout-check-interval",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.oracleucp.u-r-l",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.user",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.oracleucp.validate-connection-on-borrow",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the database."
+    },
+    {
+      "name": "spring.datasource.platform",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.sql.init.platform"
+      }
+    },
+    {
+      "name": "spring.datasource.schema",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "deprecation": {
+        "replacement": "spring.sql.init.schema-locations"
+      }
+    },
+    {
+      "name": "spring.datasource.schema-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.sql.init.password"
+      }
+    },
+    {
+      "name": "spring.datasource.schema-username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.sql.init.username"
+      }
+    },
+    {
+      "name": "spring.datasource.separator",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.sql.init.separator"
+      }
+    },
+    {
+      "name": "spring.datasource.sql-script-encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "deprecation": {
+        "replacement": "spring.sql.init.encoding"
+      }
+    },
+    {
+      "name": "spring.datasource.tomcat.abandon-when-percentage-full",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.access-to-underlying-connection-allowed",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.alternate-username-allowed",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.commit-on-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.connection-properties",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.data-source-j-n-d-i",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.db-properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Properties"
+    },
+    {
+      "name": "spring.datasource.tomcat.default-auto-commit",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.default-catalog",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.default-read-only",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.default-transaction-isolation",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.driver-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.fair-queue",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.ignore-exception-on-pre-load",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.init-s-q-l",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.initial-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.jdbc-interceptors",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.jmx-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.log-abandoned",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.log-validation-errors",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.login-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.max-active",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.max-age",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.tomcat.max-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.max-wait",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.min-evictable-idle-time-millis",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.min-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.num-tests-per-eviction-run",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.propagate-interrupt-state",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.remove-abandoned",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.remove-abandoned-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.rollback-on-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.suspect-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.test-on-borrow",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.test-on-connect",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.test-on-return",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.test-while-idle",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.time-between-eviction-runs-millis",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.use-disposable-connection-facade",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.use-equals",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.use-lock",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.use-statement-facade",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean"
+    },
+    {
+      "name": "spring.datasource.tomcat.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.validation-interval",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long"
+    },
+    {
+      "name": "spring.datasource.tomcat.validation-query",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.tomcat.validation-query-timeout",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer"
+    },
+    {
+      "name": "spring.datasource.tomcat.validator-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String"
+    },
+    {
+      "name": "spring.datasource.type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class<? extends javax.sql.DataSource>",
+      "description": "Fully qualified name of the DataSource implementation to use. By default, a connection pool implementation is auto-detected from the classpath."
+    },
+    {
+      "name": "spring.datasource.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JDBC URL of the database."
+    },
+    {
+      "name": "spring.datasource.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login username of the database."
+    },
+    {
+      "name": "spring.datasource.xa.data-source-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "XA datasource fully qualified name."
+    },
+    {
+      "name": "spring.datasource.xa.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Properties to pass to the XA data source."
+    },
+    {
+      "name": "spring.elasticsearch.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Connection timeout used when communicating with Elasticsearch.",
+      "defaultValue": "1s"
+    },
+    {
+      "name": "spring.elasticsearch.jest.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Connection timeout.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.elasticsearch.jest.multi-threaded",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable connection requests from multiple execution threads.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.elasticsearch.jest.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.elasticsearch.jest.proxy.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Proxy host the HTTP client should use.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.elasticsearch.jest.proxy.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Proxy port the HTTP client should use.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.elasticsearch.jest.read-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Read timeout.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.elasticsearch.jest.uris",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Comma-separated list of the Elasticsearch instances to use.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.elasticsearch.jest.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login username.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.elasticsearch.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password for authentication with Elasticsearch."
+    },
+    {
+      "name": "spring.elasticsearch.path-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix added to the path of every request sent to Elasticsearch."
+    },
+    {
+      "name": "spring.elasticsearch.restclient.sniffer.delay-after-failure",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Delay of a sniff execution scheduled after a failure.",
+      "defaultValue": "1m"
+    },
+    {
+      "name": "spring.elasticsearch.restclient.sniffer.interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Interval between consecutive ordinary sniff executions.",
+      "defaultValue": "5m"
+    },
+    {
+      "name": "spring.elasticsearch.restclient.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle name."
+    },
+    {
+      "name": "spring.elasticsearch.socket-keep-alive",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable socket keep alive between client and Elasticsearch.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.elasticsearch.socket-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Socket timeout used when communicating with Elasticsearch.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.elasticsearch.uris",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "http://localhost:9200"
+    },
+    {
+      "name": "spring.elasticsearch.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Username for authentication with Elasticsearch."
+    },
+    {
+      "name": "spring.elasticsearch.webclient.max-in-memory-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Limit on the number of bytes that can be buffered whenever the input stream needs to be aggregated.",
+      "deprecation": {
+        "reason": "Reactive Elasticsearch client no longer uses WebClient."
+      }
+    },
+    {
+      "name": "spring.flyway.baseline-description",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Description to tag an existing schema with when applying a baseline.",
+      "defaultValue": "<< Flyway Baseline >>"
+    },
+    {
+      "name": "spring.flyway.baseline-migration-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Filename prefix for baseline migrations. Requires Flyway Teams.",
+      "defaultValue": "B",
+      "deprecation": {
+        "reason": "Removed in Flyway 9.0"
+      }
+    },
+    {
+      "name": "spring.flyway.baseline-on-migrate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to automatically call baseline when migrating a non-empty schema.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.baseline-version",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Version to tag an existing schema with when executing baseline.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.flyway.batch",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to batch SQL statements when executing them."
+    },
+    {
+      "name": "spring.flyway.check-location",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.flyway.fail-on-missing-locations"
+      }
+    },
+    {
+      "name": "spring.flyway.cherry-pick",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Migrations that Flyway should consider when migrating or undoing. When empty all available migrations are considered. Requires Flyway Teams.",
+      "deprecation": {
+        "reason": "Removed in Flyway 10"
+      }
+    },
+    {
+      "name": "spring.flyway.clean-disabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to disable cleaning of the database.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.flyway.clean-on-validation-error",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to automatically call clean when a validation error occurs.",
+      "defaultValue": "false",
+      "deprecation": {
+        "reason": "Deprecated in Flyway 10.18 and removed in Flyway 11.0"
+      }
+    },
+    {
+      "name": "spring.flyway.community-db-support-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable community database support.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.connect-retries",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of retries when attempting to connect to the database.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.flyway.connect-retries-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time between retries when attempting to connect to the database. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "120s"
+    },
+    {
+      "name": "spring.flyway.create-schemas",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether Flyway should attempt to create the schemas specified in the schemas property.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.flyway.default-schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Default schema name managed by Flyway (case-sensitive)."
+    },
+    {
+      "name": "spring.flyway.detect-encoding",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to attempt to automatically detect SQL migration file encoding."
+    },
+    {
+      "name": "spring.flyway.driver-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Fully qualified name of the JDBC driver. Auto-detected based on the URL by default."
+    },
+    {
+      "name": "spring.flyway.dry-run-output",
+      "schema": {
+        "format": "uri",
+        "type": "string"
+      },
+      "typeName": "java.io.File",
+      "description": "File to which the SQL statements of a migration dry run should be output. Requires Flyway Teams.",
+      "deprecation": {
+        "reason": "Flyway Teams only."
+      }
+    },
+    {
+      "name": "spring.flyway.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable flyway.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.flyway.encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Encoding of SQL migrations.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.flyway.error-handlers",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.flywaydb.core.api.errorhandler.ErrorHandler[]",
+      "deprecation": {
+        "reason": "Flyway Teams only."
+      }
+    },
+    {
+      "name": "spring.flyway.error-overrides",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Rules for the built-in error handling to override specific SQL states and error codes. Requires Flyway Teams."
+    },
+    {
+      "name": "spring.flyway.execute-in-transaction",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether Flyway should execute SQL within a transaction.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.flyway.fail-on-missing-locations",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to fail if a location of migration scripts doesn't exist.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.group",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to group all pending migrations together in the same transaction when applying them.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.ignore-future-migrations",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to ignore future migrations when reading the schema history table.",
+      "deprecation": {
+        "reason": "Removed in Flyway 9.0",
+        "replacement": "spring.flyway.ignore-migration-patterns"
+      }
+    },
+    {
+      "name": "spring.flyway.ignore-ignored-migrations",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to ignore ignored migrations when reading the schema history table.",
+      "deprecation": {
+        "reason": "Removed in Flyway 9.0",
+        "replacement": "spring.flyway.ignore-migration-patterns"
+      }
+    },
+    {
+      "name": "spring.flyway.ignore-migration-patterns",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of patterns that identify migrations to ignore when performing validation.",
+      "defaultValue": "*:future"
+    },
+    {
+      "name": "spring.flyway.ignore-missing-migrations",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to ignore missing migrations when reading the schema history table.",
+      "deprecation": {
+        "reason": "Removed in Flyway 9.0",
+        "replacement": "spring.flyway.ignore-migration-patterns"
+      }
+    },
+    {
+      "name": "spring.flyway.ignore-pending-migrations",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to ignore pending migrations when reading the schema history table.",
+      "deprecation": {
+        "reason": "Removed in Flyway 9.0",
+        "replacement": "spring.flyway.ignore-migration-patterns"
+      }
+    },
+    {
+      "name": "spring.flyway.init-sqls",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "SQL statements to execute to initialize a connection immediately after obtaining it."
+    },
+    {
+      "name": "spring.flyway.installed-by",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Username recorded in the schema history table as having applied the migration."
+    },
+    {
+      "name": "spring.flyway.jdbc-properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Properties to pass to the JDBC driver."
+    },
+    {
+      "name": "spring.flyway.kerberos-config-file",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path of the Kerberos config file. Requires Flyway Teams."
+    },
+    {
+      "name": "spring.flyway.license-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "License key for Flyway Teams.",
+      "deprecation": {
+        "reason": "Removed in Flyway 10"
+      }
+    },
+    {
+      "name": "spring.flyway.locations",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Locations of migrations scripts. Can contain the special \"{vendor}\" placeholder to use vendor-specific locations.",
+      "defaultValue": "classpath:db/migration"
+    },
+    {
+      "name": "spring.flyway.lock-retry-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of retries when trying to obtain a lock.",
+      "defaultValue": "50"
+    },
+    {
+      "name": "spring.flyway.loggers",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Loggers Flyway should use.",
+      "defaultValue": "slf4j"
+    },
+    {
+      "name": "spring.flyway.mixed",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to allow mixing transactional and non-transactional statements within the same migration.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.oracle-kerberos-cache-file",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.flyway.oracle.kerberos-cache-file"
+      }
+    },
+    {
+      "name": "spring.flyway.oracle-kerberos-config-file",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.flyway.kerberos-config-file"
+      }
+    },
+    {
+      "name": "spring.flyway.oracle-sqlplus",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.flyway.oracle.sqlplus"
+      }
+    },
+    {
+      "name": "spring.flyway.oracle-sqlplus-warn",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.flyway.oracle.sqlplus-warn"
+      }
+    },
+    {
+      "name": "spring.flyway.oracle-wallet-location",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.flyway.oracle.wallet-location"
+      }
+    },
+    {
+      "name": "spring.flyway.oracle.kerberos-cache-file",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path of the Oracle Kerberos cache file. Requires Flyway Teams."
+    },
+    {
+      "name": "spring.flyway.oracle.sqlplus",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable support for Oracle SQL*Plus commands. Requires Flyway Teams."
+    },
+    {
+      "name": "spring.flyway.oracle.sqlplus-warn",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to issue a warning rather than an error when a not-yet-supported Oracle SQL*Plus statement is encountered. Requires Flyway Teams."
+    },
+    {
+      "name": "spring.flyway.oracle.wallet-location",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Location of the Oracle Wallet, used to sign in to the database automatically. Requires Flyway Teams."
+    },
+    {
+      "name": "spring.flyway.out-of-order",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to allow migrations to be run out of order.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.output-query-results",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether Flyway should output a table with the results of queries when executing migrations."
+    },
+    {
+      "name": "spring.flyway.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the database to migrate."
+    },
+    {
+      "name": "spring.flyway.placeholder-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix of placeholders in migration scripts.",
+      "defaultValue": "${"
+    },
+    {
+      "name": "spring.flyway.placeholder-replacement",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Perform placeholder replacement in migration scripts.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.flyway.placeholder-separator",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Separator of default placeholders.",
+      "defaultValue": ":"
+    },
+    {
+      "name": "spring.flyway.placeholder-suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Suffix of placeholders in migration scripts.",
+      "defaultValue": "}"
+    },
+    {
+      "name": "spring.flyway.placeholders",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Placeholders and their replacements to apply to sql migration scripts."
+    },
+    {
+      "name": "spring.flyway.postgresql.transactional-lock",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether transactional advisory locks should be used. If set to false, session-level locks are used instead."
+    },
+    {
+      "name": "spring.flyway.repeatable-sql-migration-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "File name prefix for repeatable SQL migrations.",
+      "defaultValue": "R"
+    },
+    {
+      "name": "spring.flyway.schemas",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Scheme names managed by Flyway (case-sensitive)."
+    },
+    {
+      "name": "spring.flyway.script-placeholder-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix of placeholders in migration scripts.",
+      "defaultValue": "FP__"
+    },
+    {
+      "name": "spring.flyway.script-placeholder-suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Suffix of placeholders in migration scripts.",
+      "defaultValue": "__"
+    },
+    {
+      "name": "spring.flyway.skip-default-callbacks",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to skip default callbacks. If true, only custom callbacks are used.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.skip-default-resolvers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to skip default resolvers. If true, only custom resolvers are used.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.skip-executing-migrations",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether Flyway should skip executing the contents of the migrations and only update the schema history table."
+    },
+    {
+      "name": "spring.flyway.sql-migration-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "File name prefix for SQL migrations.",
+      "defaultValue": "V"
+    },
+    {
+      "name": "spring.flyway.sql-migration-separator",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "File name separator for SQL migrations.",
+      "defaultValue": "__"
+    },
+    {
+      "name": "spring.flyway.sql-migration-suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.flyway.sql-migration-suffixes"
+      }
+    },
+    {
+      "name": "spring.flyway.sql-migration-suffixes",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "File name suffix for SQL migrations.",
+      "defaultValue": ".sql"
+    },
+    {
+      "name": "spring.flyway.sql-server-kerberos-login-file",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.flyway.sqlserver.kerberos-login-file"
+      }
+    },
+    {
+      "name": "spring.flyway.sqlserver.kerberos-login-file",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the SQL Server Kerberos login file. Requires Flyway Teams."
+    },
+    {
+      "name": "spring.flyway.stream",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to stream SQL migrations when executing them."
+    },
+    {
+      "name": "spring.flyway.table",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the schema history table that will be used by Flyway.",
+      "defaultValue": "flyway_schema_history"
+    },
+    {
+      "name": "spring.flyway.tablespace",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Tablespace in which the schema history table is created. Ignored when using a database that does not support tablespaces. Defaults to the default tablespace of the connection used by Flyway."
+    },
+    {
+      "name": "spring.flyway.target",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Target version up to which migrations should be considered.",
+      "defaultValue": "latest"
+    },
+    {
+      "name": "spring.flyway.undo-sql-migration-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "Removed in Flyway 10"
+      }
+    },
+    {
+      "name": "spring.flyway.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JDBC url of the database to migrate. If not set, the primary configured data source is used."
+    },
+    {
+      "name": "spring.flyway.user",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the database to migrate."
+    },
+    {
+      "name": "spring.flyway.validate-migration-naming",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to validate migrations and callbacks whose scripts do not obey the correct naming convention.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.flyway.validate-on-migrate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to automatically call validate when performing a migration.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.flyway.vault-secrets",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "deprecation": {
+        "reason": "Removed in the open source release of Flyway 7.12."
+      }
+    },
+    {
+      "name": "spring.flyway.vault-token",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "Removed in the open source release of Flyway 7.12."
+      }
+    },
+    {
+      "name": "spring.flyway.vault-url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "Removed in the open source release of Flyway 7.12."
+      }
+    },
+    {
+      "name": "spring.freemarker.allow-request-override",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether HttpServletRequest attributes are allowed to override (hide) controller generated model attributes of the same name. Only supported with Spring MVC.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.freemarker.allow-session-override",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether HttpSession attributes are allowed to override (hide) controller generated model attributes of the same name. Only supported with Spring MVC.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.freemarker.cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable template caching. Only supported with Spring MVC.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.freemarker.charset",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Template encoding.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.freemarker.check-template-location",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to check that the templates location exists.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.freemarker.content-type",
+      "schema": {
+        "format": "mime-type",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.MimeType",
+      "description": "Content-Type value. Only supported with Spring MVC.",
+      "defaultValue": "text/html"
+    },
+    {
+      "name": "spring.freemarker.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable MVC view resolution for this technology.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.freemarker.expose-request-attributes",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether all request attributes should be added to the model prior to merging with the template. Only supported with Spring MVC.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.freemarker.expose-session-attributes",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether all HttpSession attributes should be added to the model prior to merging with the template. Only supported with Spring MVC.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.freemarker.expose-spring-macro-helpers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to expose a RequestContext for use by Spring's macro library, under the name \"springMacroRequestContext\". Only supported with Spring MVC.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.freemarker.prefer-file-system-access",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to prefer file system access for template loading to enable hot detection of template changes. When a template path is detected as a directory, templates are loaded from the directory only and other matching classpath locations will not be considered.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.freemarker.prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix that gets prepended to view names when building a URL."
+    },
+    {
+      "name": "spring.freemarker.request-context-attribute",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the RequestContext attribute for all views."
+    },
+    {
+      "name": "spring.freemarker.settings",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Well-known FreeMarker keys which are passed to FreeMarker's Configuration."
+    },
+    {
+      "name": "spring.freemarker.suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Suffix that gets appended to view names when building a URL.",
+      "defaultValue": ".ftlh"
+    },
+    {
+      "name": "spring.freemarker.template-loader-path",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "List of template paths.",
+      "defaultValue": "classpath:/templates/"
+    },
+    {
+      "name": "spring.freemarker.view-names",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "View names that can be resolved."
+    },
+    {
+      "name": "spring.git.properties",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Resource reference to a generated git info properties file.",
+      "deprecation": {
+        "replacement": "spring.info.git.location"
+      }
+    },
+    {
+      "name": "spring.graphql.cors.allow-credentials",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether credentials are supported. When not set, credentials are not supported."
+    },
+    {
+      "name": "spring.graphql.cors.allowed-headers",
+      "schema": {
+        "items": {
+          "examples": [
+            "*"
+          ],
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of HTTP headers to allow in a request. '*' allows all headers."
+    },
+    {
+      "name": "spring.graphql.cors.allowed-methods",
+      "schema": {
+        "items": {
+          "examples": [
+            "*"
+          ],
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of HTTP methods to allow. '*' allows all methods. When not set, defaults to GET."
+    },
+    {
+      "name": "spring.graphql.cors.allowed-origin-patterns",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of origin patterns to allow. Unlike allowed origins which only support '*', origin patterns are more flexible, e.g. 'https://*.example.com', and can be used with allow-credentials. When neither allowed origins nor allowed origin patterns are set, cross-origin requests are effectively disabled."
+    },
+    {
+      "name": "spring.graphql.cors.allowed-origins",
+      "schema": {
+        "items": {
+          "examples": [
+            "*"
+          ],
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of origins to allow with '*' allowing all origins. When allow-credentials is enabled, '*' cannot be used, and setting origin patterns should be considered instead. When neither allowed origins nor allowed origin patterns are set, cross-origin requests are effectively disabled."
+    },
+    {
+      "name": "spring.graphql.cors.exposed-headers",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of headers to include in a response."
+    },
+    {
+      "name": "spring.graphql.cors.max-age",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "How long the response from a pre-flight request can be cached by clients. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "1800s"
+    },
+    {
+      "name": "spring.graphql.graphiql.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the default GraphiQL UI is enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.graphql.graphiql.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the GraphiQL UI endpoint.",
+      "defaultValue": "/graphiql"
+    },
+    {
+      "name": "spring.graphql.http.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path at which to expose a GraphQL request HTTP endpoint.",
+      "defaultValue": "/graphql"
+    },
+    {
+      "name": "spring.graphql.http.sse.keep-alive",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "How frequently keep-alive messages should be sent."
+    },
+    {
+      "name": "spring.graphql.http.sse.timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time required for concurrent handling to complete."
+    },
+    {
+      "name": "spring.graphql.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.graphql.http.path"
+      }
+    },
+    {
+      "name": "spring.graphql.rsocket.mapping",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Mapping of the RSocket message handler."
+    },
+    {
+      "name": "spring.graphql.schema.additional-files",
+      "schema": {
+        "items": {
+          "format": "resource",
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "org.springframework.core.io.Resource[]",
+      "description": "Locations of additional, individual schema files to parse."
+    },
+    {
+      "name": "spring.graphql.schema.file-extensions",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "File extensions for GraphQL schema files.",
+      "defaultValue": ".graphqls,.gqls"
+    },
+    {
+      "name": "spring.graphql.schema.inspection.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether schema should be compared to the application to detect missing mappings.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.graphql.schema.introspection.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether field introspection should be enabled at the schema level.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.graphql.schema.locations",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Locations of GraphQL schema files.",
+      "defaultValue": "classpath:graphql/**/"
+    },
+    {
+      "name": "spring.graphql.schema.printer.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the endpoint that prints the schema is enabled. Schema is available under spring.graphql.http.path + \"/schema\".",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.graphql.sse.timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.graphql.http.sse.timeout"
+      }
+    },
+    {
+      "name": "spring.graphql.websocket.connection-init-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time within which the initial {@code CONNECTION_INIT} type message must be received.",
+      "defaultValue": "60s"
+    },
+    {
+      "name": "spring.graphql.websocket.keep-alive",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum idle period before a server keep-alive ping is sent to client."
+    },
+    {
+      "name": "spring.graphql.websocket.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path of the GraphQL WebSocket subscription endpoint."
+    },
+    {
+      "name": "spring.groovy.template.allow-request-override",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether HttpServletRequest attributes are allowed to override (hide) controller generated model attributes of the same name.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.allow-session-override",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether HttpSession attributes are allowed to override (hide) controller generated model attributes of the same name.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.auto-escape",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether models that are assignable to CharSequence are escaped automatically.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.auto-indent",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether indents are rendered automatically.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.auto-indent-string",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "String used for auto-indents."
+    },
+    {
+      "name": "spring.groovy.template.auto-new-line",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether new lines are rendered automatically.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.base-template-class",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class<? extends groovy.text.markup.BaseTemplate>",
+      "description": "Template base class."
+    },
+    {
+      "name": "spring.groovy.template.cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable template caching.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.charset",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Template encoding.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.groovy.template.check-template-location",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to check that the templates location exists.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.groovy.template.configuration.auto-escape",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.auto-escape"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.auto-indent",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.auto-indent"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.auto-indent-string",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.auto-indent-string"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.auto-new-line",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.auto-new-line"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.base-template-class",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.base-template-class"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.cache-templates",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.cache"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.declaration-encoding",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.declaration-encoding"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.expand-empty-elements",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.expand-empty-elements"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.locale",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.locale"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.new-line-string",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.new-line-string"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.resource-loader-path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.resource-loader-path"
+      }
+    },
+    {
+      "name": "spring.groovy.template.configuration.use-double-quotes",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.groovy.template.use-double-quotes"
+      }
+    },
+    {
+      "name": "spring.groovy.template.content-type",
+      "schema": {
+        "format": "mime-type",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.MimeType",
+      "description": "Content-Type value.",
+      "defaultValue": "text/html"
+    },
+    {
+      "name": "spring.groovy.template.declaration-encoding",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Encoding used to write the declaration heading."
+    },
+    {
+      "name": "spring.groovy.template.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable MVC view resolution for this technology.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.groovy.template.expand-empty-elements",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether elements without a body should be written expanded (&lt;br&gt;&lt;/br&gt;) or not (&lt;br/&gt;).",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.expose-request-attributes",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether all request attributes should be added to the model prior to merging with the template.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.expose-session-attributes",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether all HttpSession attributes should be added to the model prior to merging with the template.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.expose-spring-macro-helpers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to expose a RequestContext for use by Spring's macro library, under the name \"springMacroRequestContext\".",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.groovy.template.locale",
+      "schema": {
+        "format": "language",
+        "type": "string"
+      },
+      "typeName": "java.util.Locale",
+      "description": "Default locale for template resolution."
+    },
+    {
+      "name": "spring.groovy.template.new-line-string",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "String used to write a new line. Defaults to the system's line separator."
+    },
+    {
+      "name": "spring.groovy.template.prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix that gets prepended to view names when building a URL."
+    },
+    {
+      "name": "spring.groovy.template.request-context-attribute",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the RequestContext attribute for all views."
+    },
+    {
+      "name": "spring.groovy.template.resource-loader-path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Template path.",
+      "defaultValue": "classpath:/templates/"
+    },
+    {
+      "name": "spring.groovy.template.suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Suffix that gets appended to view names when building a URL.",
+      "defaultValue": ".tpl"
+    },
+    {
+      "name": "spring.groovy.template.use-double-quotes",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether attributes should use double quotes.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.groovy.template.view-names",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "View names that can be resolved."
+    },
+    {
+      "name": "spring.gson.date-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Format to use when serializing Date objects."
+    },
+    {
+      "name": "spring.gson.disable-html-escaping",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to disable the escaping of HTML characters such as '<', '>', etc."
+    },
+    {
+      "name": "spring.gson.disable-inner-class-serialization",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to exclude inner classes during serialization."
+    },
+    {
+      "name": "spring.gson.enable-complex-map-key-serialization",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable serialization of complex map keys (i.e. non-primitives)."
+    },
+    {
+      "name": "spring.gson.exclude-fields-without-expose-annotation",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to exclude all fields from consideration for serialization or deserialization that do not have the \"Expose\" annotation."
+    },
+    {
+      "name": "spring.gson.field-naming-policy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "com.google.gson.FieldNamingPolicy",
+      "description": "Naming policy that should be applied to an object's field during serialization and deserialization."
+    },
+    {
+      "name": "spring.gson.generate-non-executable-json",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to generate non-executable JSON by prefixing the output with some special text."
+    },
+    {
+      "name": "spring.gson.lenient",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.gson.strictness"
+      }
+    },
+    {
+      "name": "spring.gson.long-serialization-policy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "com.google.gson.LongSerializationPolicy",
+      "description": "Serialization policy for Long and long types."
+    },
+    {
+      "name": "spring.gson.pretty-printing",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to output serialized JSON that fits in a page for pretty printing."
+    },
+    {
+      "name": "spring.gson.serialize-nulls",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to serialize null fields."
+    },
+    {
+      "name": "spring.gson.strictness",
+      "schema": {
+        "enum": [
+          "LEGACY_STRICT",
+          "LENIENT",
+          "STRICT"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.gson.GsonProperties$Strictness",
+      "description": "Sets how strictly the RFC 8259 specification will be enforced when reading and writing JSON."
+    },
+    {
+      "name": "spring.h2.console.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the console.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.h2.console.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path at which the console is available.",
+      "defaultValue": "/h2-console"
+    },
+    {
+      "name": "spring.h2.console.settings.trace",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable trace output.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.h2.console.settings.web-admin-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password to access preferences and tools of H2 Console."
+    },
+    {
+      "name": "spring.h2.console.settings.web-allow-others",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable remote access.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.hateoas.use-hal-as-default-json-media-type",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether application/hal+json responses should be sent to requests that accept application/json.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.hazelcast.config",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "The location of the configuration file to use to initialize Hazelcast."
+    },
+    {
+      "name": "spring.http.client.connect-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Default connect timeout for a client HTTP request."
+    },
+    {
+      "name": "spring.http.client.factory",
+      "schema": {
+        "enum": [
+          "HTTP_COMPONENTS",
+          "JDK",
+          "JETTY",
+          "REACTOR",
+          "SIMPLE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.http.client.AbstractHttpRequestFactoryProperties$Factory",
+      "description": "Default factory used for a client HTTP request."
+    },
+    {
+      "name": "spring.http.client.read-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Default read timeout for a client HTTP request."
+    },
+    {
+      "name": "spring.http.client.redirects",
+      "schema": {
+        "enum": [
+          "DONT_FOLLOW",
+          "FOLLOW",
+          "FOLLOW_WHEN_POSSIBLE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.http.client.HttpRedirects",
+      "description": "Handling for HTTP redirects."
+    },
+    {
+      "name": "spring.http.client.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle to use."
+    },
+    {
+      "name": "spring.http.codecs.log-request-details",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to log form data at DEBUG level, and headers at TRACE level.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.http.codecs.max-in-memory-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Limit on the number of bytes that can be buffered whenever the input stream needs to be aggregated. This applies only to the auto-configured WebFlux server and WebClient instances. By default this is not set, in which case individual codec defaults apply. Most codecs are limited to 256K by default."
+    },
+    {
+      "name": "spring.http.converters.preferred-json-mapper",
+      "schema": {
+        "examples": [
+          "gson",
+          "jackson",
+          "jsonb"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Preferred JSON mapper to use for HTTP message conversion. By default, auto-detected according to the environment. Supported values are 'jackson', 'gson', and 'jsonb'. When other json mapping libraries (such as kotlinx.serialization) are present, use a custom HttpMessageConverters bean to control the preferred mapper.",
+      "defaultValue": "jackson"
+    },
+    {
+      "name": "spring.http.encoding.charset",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Charset of HTTP requests and responses. Added to the Content-Type header if not set explicitly.",
+      "deprecation": {
+        "replacement": "server.servlet.encoding.charset"
+      }
+    },
+    {
+      "name": "spring.http.encoding.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable http encoding support.",
+      "defaultValue": "true",
+      "deprecation": {
+        "replacement": "server.servlet.encoding.enabled"
+      }
+    },
+    {
+      "name": "spring.http.encoding.force",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to force the encoding to the configured charset on HTTP requests and responses.",
+      "defaultValue": "false",
+      "deprecation": {
+        "replacement": "server.servlet.encoding.force"
+      }
+    },
+    {
+      "name": "spring.http.encoding.force-request",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to force the encoding to the configured charset on HTTP requests. Defaults to true when force has not been specified.",
+      "defaultValue": "true",
+      "deprecation": {
+        "replacement": "server.servlet.encoding.force-request"
+      }
+    },
+    {
+      "name": "spring.http.encoding.force-response",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to force the encoding to the configured charset on HTTP responses.",
+      "defaultValue": "false",
+      "deprecation": {
+        "replacement": "server.servlet.encoding.force-response"
+      }
+    },
+    {
+      "name": "spring.http.encoding.mapping",
+      "schema": {
+        "additionalProperties": {
+          "format": "charset",
+          "type": "string"
+        },
+        "propertyNames": {
+          "format": "language",
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.util.Locale,java.nio.charset.Charset>",
+      "description": "Locale in which to encode mapping.",
+      "deprecation": {
+        "replacement": "server.servlet.encoding.mapping"
+      }
+    },
+    {
+      "name": "spring.http.log-request-details",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether logging of (potentially sensitive) request details at DEBUG and TRACE level is allowed.",
+      "defaultValue": "false",
+      "deprecation": {
+        "replacement": "spring.mvc.log-request-details"
+      }
+    },
+    {
+      "name": "spring.http.reactiveclient.connect-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Default connect timeout for a client HTTP request."
+    },
+    {
+      "name": "spring.http.reactiveclient.connector",
+      "schema": {
+        "enum": [
+          "HTTP_COMPONENTS",
+          "JDK",
+          "JETTY",
+          "REACTOR"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.http.client.reactive.AbstractClientHttpConnectorProperties$Connector",
+      "description": "Default connector used for a client HTTP request."
+    },
+    {
+      "name": "spring.http.reactiveclient.read-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Default read timeout for a client HTTP request."
+    },
+    {
+      "name": "spring.http.reactiveclient.redirects",
+      "schema": {
+        "enum": [
+          "DONT_FOLLOW",
+          "FOLLOW",
+          "FOLLOW_WHEN_POSSIBLE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.http.client.HttpRedirects",
+      "description": "Handling for HTTP redirects."
+    },
+    {
+      "name": "spring.http.reactiveclient.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle to use."
+    },
+    {
+      "name": "spring.influx.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "The new InfluxDb Java client provides Spring Boot integration."
+      }
+    },
+    {
+      "name": "spring.influx.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "The new InfluxDb Java client provides Spring Boot integration."
+      }
+    },
+    {
+      "name": "spring.influx.user",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "The new InfluxDb Java client provides Spring Boot integration."
+      }
+    },
+    {
+      "name": "spring.info.build.encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "File encoding.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.info.build.location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the generated build-info.properties file.",
+      "defaultValue": "classpath:META-INF/build-info.properties"
+    },
+    {
+      "name": "spring.info.git.encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "File encoding.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.info.git.location",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "classpath:git.properties"
+    },
+    {
+      "name": "spring.integration.channel.auto-create",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to create input channels if necessary.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.integration.channel.max-broadcast-subscribers",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Default number of subscribers allowed on, for example, a 'PublishSubscribeChannel'."
+    },
+    {
+      "name": "spring.integration.channel.max-unicast-subscribers",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Default number of subscribers allowed on, for example, a 'DirectChannel'."
+    },
+    {
+      "name": "spring.integration.endpoint.default-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Default timeout for blocking operations such as sending or receiving messages.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.integration.endpoint.no-auto-startup",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of endpoint bean names patterns that should not be started automatically during application startup."
+    },
+    {
+      "name": "spring.integration.endpoint.read-only-headers",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of message header names that should not be populated into Message instances during a header copying operation."
+    },
+    {
+      "name": "spring.integration.endpoint.throw-exception-on-late-reply",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to throw an exception when a reply is not expected anymore by a gateway.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.integration.error.ignore-failures",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to ignore failures for one or more of the handlers of the global 'errorChannel'.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.integration.error.require-subscribers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to not silently ignore messages on the global 'errorChannel' when there are no subscribers.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.integration.jdbc.initialize-schema",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "EMBEDDED",
+          "NEVER"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.sql.init.DatabaseInitializationMode",
+      "description": "Database schema initialization mode.",
+      "defaultValue": "embedded"
+    },
+    {
+      "name": "spring.integration.jdbc.platform",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Platform to use in initialization scripts if the @@platform@@ placeholder is used. Auto-detected by default."
+    },
+    {
+      "name": "spring.integration.jdbc.schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the SQL file to use to initialize the database schema.",
+      "defaultValue": "classpath:org/springframework/integration/jdbc/schema-@@platform@@.sql"
+    },
+    {
+      "name": "spring.integration.management.default-logging-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether Spring Integration components should perform logging in the main message flow. When disabled, such logging will be skipped without checking the logging level. When enabled, such logging is controlled as normal by the logging system's log level configuration.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.integration.management.observation-patterns",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of simple patterns to match against the names of Spring Integration components. When matched, observation instrumentation will be performed for the component. Please refer to the javadoc of the smartMatch method of Spring Integration's PatternMatchUtils for details of the pattern syntax."
+    },
+    {
+      "name": "spring.integration.poller.cron",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Cron expression for polling. Mutually exclusive with 'fixedDelay' and 'fixedRate'."
+    },
+    {
+      "name": "spring.integration.poller.fixed-delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Polling delay period. Mutually exclusive with 'cron' and 'fixedRate'."
+    },
+    {
+      "name": "spring.integration.poller.fixed-rate",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Polling rate period. Mutually exclusive with 'fixedDelay' and 'cron'."
+    },
+    {
+      "name": "spring.integration.poller.initial-delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Polling initial delay. Applied for 'fixedDelay' and 'fixedRate'; ignored for 'cron'."
+    },
+    {
+      "name": "spring.integration.poller.max-messages-per-poll",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of messages to poll per polling cycle."
+    },
+    {
+      "name": "spring.integration.poller.receive-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "How long to wait for messages on poll.",
+      "defaultValue": "1s"
+    },
+    {
+      "name": "spring.integration.rsocket.client.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "TCP RSocket server host to connect to."
+    },
+    {
+      "name": "spring.integration.rsocket.client.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "TCP RSocket server port to connect to."
+    },
+    {
+      "name": "spring.integration.rsocket.client.uri",
+      "schema": {
+        "format": "uri",
+        "type": "string"
+      },
+      "typeName": "java.net.URI",
+      "description": "WebSocket RSocket server uri to connect to."
+    },
+    {
+      "name": "spring.integration.rsocket.server.message-mapping-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to handle message mapping for RSocket through Spring Integration.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jackson.constructor-detector",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "default"
+    },
+    {
+      "name": "spring.jackson.datatype.enum",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Jackson on/off features for enums."
+    },
+    {
+      "name": "spring.jackson.datatype.json-node",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.Map<com.fasterxml.jackson.databind.cfg.JsonNodeFeature,java.lang.Boolean>",
+      "description": "Jackson on/off features for JsonNodes."
+    },
+    {
+      "name": "spring.jackson.date-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Date format string or a fully-qualified date format class name. For instance, 'yyyy-MM-dd HH:mm:ss'."
+    },
+    {
+      "name": "spring.jackson.default-leniency",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Global default setting (if any) for leniency."
+    },
+    {
+      "name": "spring.jackson.default-property-inclusion",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "CUSTOM",
+          "NON_ABSENT",
+          "NON_DEFAULT",
+          "NON_EMPTY",
+          "NON_NULL",
+          "USE_DEFAULTS"
+        ],
+        "type": "string"
+      },
+      "typeName": "com.fasterxml.jackson.annotation.JsonInclude$Include",
+      "description": "Controls the inclusion of properties during serialization. Configured with one of the values in Jackson's JsonInclude.Include enumeration."
+    },
+    {
+      "name": "spring.jackson.deserialization",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.Map<com.fasterxml.jackson.databind.DeserializationFeature,java.lang.Boolean>",
+      "description": "Jackson on/off features that affect the way Java objects are deserialized."
+    },
+    {
+      "name": "spring.jackson.generator",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.Map<com.fasterxml.jackson.core.JsonGenerator$Feature,java.lang.Boolean>",
+      "description": "Jackson on/off features for generators."
+    },
+    {
+      "name": "spring.jackson.joda-date-time-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Joda date time format string. If not configured, \"date-format\" is used as a fallback if it is configured with a format string.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.jackson.locale",
+      "schema": {
+        "format": "language",
+        "type": "string"
+      },
+      "typeName": "java.util.Locale",
+      "description": "Locale used for formatting."
+    },
+    {
+      "name": "spring.jackson.mapper",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.Map<com.fasterxml.jackson.databind.MapperFeature,java.lang.Boolean>",
+      "description": "Jackson general purpose on/off features."
+    },
+    {
+      "name": "spring.jackson.parser",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.Map<com.fasterxml.jackson.core.JsonParser$Feature,java.lang.Boolean>",
+      "description": "Jackson on/off features for parsers."
+    },
+    {
+      "name": "spring.jackson.property-naming-strategy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "One of the constants on Jackson's PropertyNamingStrategies. Can also be a fully-qualified class name of a PropertyNamingStrategy implementation."
+    },
+    {
+      "name": "spring.jackson.serialization",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.Map<com.fasterxml.jackson.databind.SerializationFeature,java.lang.Boolean>",
+      "description": "Jackson on/off features that affect the way Java objects are serialized."
+    },
+    {
+      "name": "spring.jackson.time-zone",
+      "schema": {
+        "format": "time-zone",
+        "type": "string"
+      },
+      "typeName": "java.util.TimeZone",
+      "description": "Time zone used when formatting dates. For instance, \"America/Los_Angeles\" or \"GMT+10\"."
+    },
+    {
+      "name": "spring.jackson.visibility",
+      "schema": {
+        "additionalProperties": {
+          "enum": [
+            "ANY",
+            "DEFAULT",
+            "NONE",
+            "NON_PRIVATE",
+            "PROTECTED_AND_PUBLIC",
+            "PUBLIC_ONLY"
+          ],
+          "type": "string"
+        },
+        "propertyNames": {
+          "enum": [
+            "ALL",
+            "CREATOR",
+            "FIELD",
+            "GETTER",
+            "IS_GETTER",
+            "NONE",
+            "SCALAR_CONSTRUCTOR",
+            "SETTER"
+          ],
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<com.fasterxml.jackson.annotation.PropertyAccessor,com.fasterxml.jackson.annotation.JsonAutoDetect$Visibility>",
+      "description": "Jackson visibility thresholds that can be used to limit which methods (and fields) are auto-detected."
+    },
+    {
+      "name": "spring.jdbc.template.fetch-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of rows that should be fetched from the database when more rows are needed. Use -1 to use the JDBC driver's default configuration.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "spring.jdbc.template.ignore-warnings",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to ignore JDBC statement warnings (SQLWarning). When set to false, throw an SQLWarningException instead.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.jdbc.template.max-rows",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of rows. Use -1 to use the JDBC driver's default configuration.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "spring.jdbc.template.query-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Query timeout. Default is to use the JDBC driver's default configuration. If a duration suffix is not specified, seconds will be used."
+    },
+    {
+      "name": "spring.jdbc.template.results-map-case-insensitive",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether execution of a CallableStatement will return the results in a Map that uses case-insensitive names for the parameters.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jdbc.template.skip-results-processing",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether results processing should be skipped. Can be used to optimize callable statement processing when we know that no results are being passed back.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jdbc.template.skip-undeclared-results",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether undeclared results should be skipped.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jersey.application-path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path that serves as the base URI for the application. If specified, overrides the value of \"@ApplicationPath\"."
+    },
+    {
+      "name": "spring.jersey.filter.order",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Jersey filter chain order.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.jersey.init",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Init parameters to pass to Jersey through the servlet or filter."
+    },
+    {
+      "name": "spring.jersey.servlet.load-on-startup",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Load on startup priority of the Jersey servlet.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "spring.jersey.type",
+      "schema": {
+        "enum": [
+          "FILTER",
+          "SERVLET"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.jersey.JerseyProperties$Type",
+      "description": "Jersey integration type.",
+      "defaultValue": "servlet"
+    },
+    {
+      "name": "spring.jms.cache.consumers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to cache message consumers.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jms.cache.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to cache sessions.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.jms.cache.producers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to cache message producers.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.jms.cache.session-cache-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Size of the session cache (per JMS Session type).",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.jms.client-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Client id of the connection."
+    },
+    {
+      "name": "spring.jms.jndi-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Connection factory JNDI name. When set, takes precedence to others connection factory auto-configurations."
+    },
+    {
+      "name": "spring.jms.listener.acknowledge-mode",
+      "schema": {
+        "properties": {
+          "mode": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.jms.AcknowledgeMode",
+      "deprecation": {
+        "replacement": "spring.jms.listener.session.acknowledge-mode"
+      }
+    },
+    {
+      "name": "spring.jms.listener.auto-startup",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Start the container automatically on startup.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.jms.listener.concurrency",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.jms.listener.min-concurrency"
+      }
+    },
+    {
+      "name": "spring.jms.listener.max-concurrency",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of concurrent consumers."
+    },
+    {
+      "name": "spring.jms.listener.max-messages-per-task",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of messages to process in one task. By default, unlimited unless a SchedulingTaskExecutor is configured on the listener (10 messages), as it indicates a preference for short-lived tasks."
+    },
+    {
+      "name": "spring.jms.listener.min-concurrency",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Minimum number of concurrent consumers. When max-concurrency is not specified the minimum will also be used as the maximum."
+    },
+    {
+      "name": "spring.jms.listener.receive-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout to use for receive calls. Use -1 for a no-wait receive or 0 for no timeout at all. The latter is only feasible if not running within a transaction manager and is generally discouraged since it prevents clean shutdown.",
+      "defaultValue": "1s"
+    },
+    {
+      "name": "spring.jms.listener.session.acknowledge-mode",
+      "schema": {
+        "properties": {
+          "mode": {
+            "examples": [
+              "auto",
+              "client",
+              "dups_ok"
+            ],
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.jms.AcknowledgeMode",
+      "description": "Acknowledge mode of the listener container.",
+      "defaultValue": "auto"
+    },
+    {
+      "name": "spring.jms.listener.session.transacted",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the listener container should use transacted JMS sessions. Defaults to false in the presence of a JtaTransactionManager and true otherwise."
+    },
+    {
+      "name": "spring.jms.pub-sub-domain",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the default destination type is topic.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jms.subscription-durable",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the subscription is durable.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jms.template.default-destination",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Default destination to use on send and receive operations that do not have a destination parameter."
+    },
+    {
+      "name": "spring.jms.template.delivery-delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Delivery delay to use for send calls."
+    },
+    {
+      "name": "spring.jms.template.delivery-mode",
+      "schema": {
+        "enum": [
+          "NON_PERSISTENT",
+          "PERSISTENT"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.jms.JmsProperties$DeliveryMode",
+      "description": "Delivery mode. Enables QoS (Quality of Service) when set."
+    },
+    {
+      "name": "spring.jms.template.priority",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Priority of a message when sending. Enables QoS (Quality of Service) when set."
+    },
+    {
+      "name": "spring.jms.template.qos-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable explicit QoS (Quality of Service) when sending a message. When enabled, the delivery mode, priority and time-to-live properties will be used when sending a message. QoS is automatically enabled when at least one of those settings is customized."
+    },
+    {
+      "name": "spring.jms.template.receive-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout to use for receive calls."
+    },
+    {
+      "name": "spring.jms.template.session.acknowledge-mode",
+      "schema": {
+        "properties": {
+          "mode": {
+            "examples": [
+              "auto",
+              "client",
+              "dups_ok"
+            ],
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "mode"
+        ],
+        "type": "object"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.jms.AcknowledgeMode",
+      "description": "Acknowledge mode used when creating sessions.",
+      "defaultValue": "auto"
+    },
+    {
+      "name": "spring.jms.template.session.transacted",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use transacted sessions.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jms.template.time-to-live",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time-to-live of a message when sending. Enables QoS (Quality of Service) when set."
+    },
+    {
+      "name": "spring.jmx.default-domain",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JMX domain name."
+    },
+    {
+      "name": "spring.jmx.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Expose Spring's management beans to the JMX domain.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jmx.registration-policy",
+      "schema": {
+        "enum": [
+          "FAIL_ON_EXISTING",
+          "IGNORE_EXISTING",
+          "REPLACE_EXISTING"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.jmx.support.RegistrationPolicy",
+      "description": "JMX Registration policy.",
+      "defaultValue": "fail-on-existing"
+    },
+    {
+      "name": "spring.jmx.server",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "MBeanServer bean name.",
+      "defaultValue": "mbeanServer"
+    },
+    {
+      "name": "spring.jmx.unique-names",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether unique runtime object names should be ensured.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jooq.config",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the jOOQ config file."
+    },
+    {
+      "name": "spring.jooq.sql-dialect",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.jooq.SQLDialect",
+      "description": "SQL dialect to use. Auto-detected by default."
+    },
+    {
+      "name": "spring.jpa.database",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.orm.jpa.vendor.Database",
+      "description": "Target database to operate on, auto-detected by default. Can be alternatively set using the \"databasePlatform\" property."
+    },
+    {
+      "name": "spring.jpa.database-platform",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the target database to operate on, auto-detected by default. Can be alternatively set using the \"Database\" enum."
+    },
+    {
+      "name": "spring.jpa.generate-ddl",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to initialize the schema on startup.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jpa.hibernate.ddl-auto",
+      "schema": {
+        "examples": [
+          "create",
+          "create-drop",
+          "create-only",
+          "drop",
+          "none",
+          "truncate",
+          "update",
+          "validate"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "DDL mode. This is actually a shortcut for the \"hibernate.hbm2ddl.auto\" property. Defaults to \"create-drop\" when using an embedded database and no schema manager was detected. Otherwise, defaults to \"none\"."
+    },
+    {
+      "name": "spring.jpa.hibernate.naming.implicit-strategy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Fully qualified name of the implicit naming strategy."
+    },
+    {
+      "name": "spring.jpa.hibernate.naming.physical-strategy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Fully qualified name of the physical naming strategy."
+    },
+    {
+      "name": "spring.jpa.hibernate.use-new-id-generator-mappings",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use Hibernate's newer IdentifierGenerator for AUTO, TABLE and SEQUENCE. This is actually a shortcut for the \"hibernate.id.new_generator_mappings\" property. When not specified will default to \"true\".",
+      "deprecation": {
+        "reason": "Hibernate no longer supports disabling the use of new ID generator mappings."
+      }
+    },
+    {
+      "name": "spring.jpa.mapping-resources",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Mapping resources (equivalent to \"mapping-file\" entries in persistence.xml)."
+    },
+    {
+      "name": "spring.jpa.open-in-view",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Register OpenEntityManagerInViewInterceptor. Binds a JPA EntityManager to the thread for the entire processing of the request.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.jpa.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional native properties to set on the JPA provider."
+    },
+    {
+      "name": "spring.jpa.show-sql",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable logging of SQL statements.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.jta.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable JTA support.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.jta.narayana.default-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Transaction timeout. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "60s",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.expiry-scanners",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Comma-separated list of expiry scanners.",
+      "defaultValue": "com.arjuna.ats.internal.arjuna.recovery.ExpiredTransactionStatusManagerScanner",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.log-dir",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Transaction object store directory.",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.one-phase-commit",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable one phase commit optimization.",
+      "defaultValue": "true",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.periodic-recovery-period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Interval in which periodic recovery scans are performed. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "120s",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.recovery-backoff-period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Back off period between first and second phases of the recovery scan. If a duration suffix is not specified, seconds will be used.",
+      "defaultValue": "10s",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.recovery-db-pass",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Database password to be used by the recovery manager.",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.recovery-db-user",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Database username to be used by the recovery manager.",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.recovery-jms-pass",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JMS password to be used by the recovery manager.",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.recovery-jms-user",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JMS username to be used by the recovery manager.",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.recovery-modules",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Comma-separated list of recovery modules.",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.transaction-manager-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Unique transaction manager id.",
+      "defaultValue": "1",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.jta.narayana.xa-resource-orphan-filters",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Comma-separated list of orphan filters.",
+      "deprecation": {
+        "reason": "Narayana support has moved to third party starter."
+      }
+    },
+    {
+      "name": "spring.kafka.admin.auto-create",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to automatically create topics during context initialization. When set to false, disables automatic topic creation during context initialization.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.kafka.admin.client-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "ID to pass to the server when making requests. Used for server-side logging."
+    },
+    {
+      "name": "spring.kafka.admin.close-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Close timeout."
+    },
+    {
+      "name": "spring.kafka.admin.fail-fast",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to fail fast if the broker is not available on startup.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.admin.modify-topic-configs",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable modification of existing topic configuration.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.admin.operation-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Operation timeout."
+    },
+    {
+      "name": "spring.kafka.admin.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional admin-specific properties used to configure the client."
+    },
+    {
+      "name": "spring.kafka.admin.security.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Security protocol used to communicate with brokers."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the SSL bundle to use."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.key-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password of the private key in either key store key or key store file."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.key-store-certificate-chain",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Certificate chain in PEM format with a list of X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.key-store-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Private key in PEM format with PKCS#8 keys."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.key-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.key-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the key store."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.keystore-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.admin.ssl.key-store-location"
+      }
+    },
+    {
+      "name": "spring.kafka.admin.ssl.keystore-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.admin.ssl.key-store-password"
+      }
+    },
+    {
+      "name": "spring.kafka.admin.ssl.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL protocol to use."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.trust-store-certificates",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trusted certificates in PEM format with X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.trust-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.trust-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.trust-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the trust store."
+    },
+    {
+      "name": "spring.kafka.admin.ssl.truststore-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.admin.ssl.trust-store-location"
+      }
+    },
+    {
+      "name": "spring.kafka.admin.ssl.truststore-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.admin.ssl.trust-store-password"
+      }
+    },
+    {
+      "name": "spring.kafka.bootstrap-servers",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of host:port pairs to use for establishing the initial connections to the Kafka cluster. Applies to all components unless overridden."
+    },
+    {
+      "name": "spring.kafka.client-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "ID to pass to the server when making requests. Used for server-side logging."
+    },
+    {
+      "name": "spring.kafka.consumer.auto-commit-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Frequency with which the consumer offsets are auto-committed to Kafka if 'enable.auto.commit' is set to true."
+    },
+    {
+      "name": "spring.kafka.consumer.auto-offset-reset",
+      "schema": {
+        "examples": [
+          "earliest",
+          "exception",
+          "latest",
+          "none"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "What to do when there is no initial offset in Kafka or if the current offset no longer exists on the server."
+    },
+    {
+      "name": "spring.kafka.consumer.bootstrap-servers",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of host:port pairs to use for establishing the initial connections to the Kafka cluster. Overrides the global property, for consumers."
+    },
+    {
+      "name": "spring.kafka.consumer.client-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "ID to pass to the server when making requests. Used for server-side logging."
+    },
+    {
+      "name": "spring.kafka.consumer.enable-auto-commit",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the consumer's offset is periodically committed in the background."
+    },
+    {
+      "name": "spring.kafka.consumer.fetch-max-wait",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum amount of time the server blocks before answering the fetch request if there isn't sufficient data to immediately satisfy the requirement given by \"fetch-min-size\"."
+    },
+    {
+      "name": "spring.kafka.consumer.fetch-min-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Minimum amount of data the server should return for a fetch request."
+    },
+    {
+      "name": "spring.kafka.consumer.group-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Unique string that identifies the consumer group to which this consumer belongs."
+    },
+    {
+      "name": "spring.kafka.consumer.heartbeat-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Expected time between heartbeats to the consumer coordinator."
+    },
+    {
+      "name": "spring.kafka.consumer.isolation-level",
+      "schema": {
+        "enum": [
+          "READ_COMMITTED",
+          "READ_UNCOMMITTED"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.kafka.KafkaProperties$IsolationLevel",
+      "description": "Isolation level for reading messages that have been written transactionally.",
+      "defaultValue": "read-uncommitted"
+    },
+    {
+      "name": "spring.kafka.consumer.key-deserializer",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class<?>",
+      "description": "Deserializer class for keys."
+    },
+    {
+      "name": "spring.kafka.consumer.max-poll-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum delay between invocations of poll() when using consumer group management."
+    },
+    {
+      "name": "spring.kafka.consumer.max-poll-records",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of records returned in a single call to poll()."
+    },
+    {
+      "name": "spring.kafka.consumer.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional consumer-specific properties used to configure the client."
+    },
+    {
+      "name": "spring.kafka.consumer.security.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Security protocol used to communicate with brokers."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the SSL bundle to use."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.key-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password of the private key in either key store key or key store file."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.key-store-certificate-chain",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Certificate chain in PEM format with a list of X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.key-store-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Private key in PEM format with PKCS#8 keys."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.key-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.key-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the key store."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.keystore-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.consumer.ssl.key-store-location"
+      }
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.keystore-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.consumer.ssl.key-store-password"
+      }
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL protocol to use."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.trust-store-certificates",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trusted certificates in PEM format with X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.trust-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.trust-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.trust-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the trust store."
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.truststore-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.consumer.ssl.trust-store-location"
+      }
+    },
+    {
+      "name": "spring.kafka.consumer.ssl.truststore-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.consumer.ssl.trust-store-password"
+      }
+    },
+    {
+      "name": "spring.kafka.consumer.value-deserializer",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class<?>",
+      "description": "Deserializer class for values."
+    },
+    {
+      "name": "spring.kafka.jaas.control-flag",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.kafka.security.jaas.KafkaJaasLoginModuleInitializer$ControlFlag",
+      "description": "Control flag for login configuration.",
+      "defaultValue": "required"
+    },
+    {
+      "name": "spring.kafka.jaas.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable JAAS configuration.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.jaas.login-module",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login module.",
+      "defaultValue": "com.sun.security.auth.module.Krb5LoginModule"
+    },
+    {
+      "name": "spring.kafka.jaas.options",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional JAAS options."
+    },
+    {
+      "name": "spring.kafka.listener.ack-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of records between offset commits when ackMode is \"COUNT\" or \"COUNT_TIME\"."
+    },
+    {
+      "name": "spring.kafka.listener.ack-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.kafka.listener.ContainerProperties$AckMode",
+      "description": "Listener AckMode. See the spring-kafka documentation."
+    },
+    {
+      "name": "spring.kafka.listener.ack-time",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time between offset commits when ackMode is \"TIME\" or \"COUNT_TIME\"."
+    },
+    {
+      "name": "spring.kafka.listener.async-acks",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Support for asynchronous record acknowledgements. Only applies when spring.kafka.listener.ack-mode is manual or manual-immediate."
+    },
+    {
+      "name": "spring.kafka.listener.auth-exception-retry-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time between retries after authentication exceptions."
+    },
+    {
+      "name": "spring.kafka.listener.auto-startup",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to auto start the container.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.kafka.listener.change-consumer-thread-name",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to instruct the container to change the consumer thread name during initialization."
+    },
+    {
+      "name": "spring.kafka.listener.client-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix for the listener's consumer client.id property."
+    },
+    {
+      "name": "spring.kafka.listener.concurrency",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of threads to run in the listener containers."
+    },
+    {
+      "name": "spring.kafka.listener.idle-between-polls",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Sleep interval between Consumer.poll(Duration) calls.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.kafka.listener.idle-event-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time between publishing idle consumer events (no data received)."
+    },
+    {
+      "name": "spring.kafka.listener.idle-partition-event-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time between publishing idle partition consumer events (no data received for partition)."
+    },
+    {
+      "name": "spring.kafka.listener.immediate-stop",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the container stops after the current record is processed or after all the records from the previous poll are processed.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.listener.log-container-config",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to log the container configuration during initialization (INFO level)."
+    },
+    {
+      "name": "spring.kafka.listener.missing-topics-fatal",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the container should fail to start if at least one of the configured topics are not present on the broker.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.listener.monitor-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time between checks for non-responsive consumers. If a duration suffix is not specified, seconds will be used."
+    },
+    {
+      "name": "spring.kafka.listener.no-poll-threshold",
+      "schema": {
+        "format": "float",
+        "type": "number"
+      },
+      "typeName": "java.lang.Float",
+      "description": "Multiplier applied to \"pollTimeout\" to determine if a consumer is non-responsive."
+    },
+    {
+      "name": "spring.kafka.listener.observation-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable observation.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.listener.only-log-record-metadata",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to suppress the entire record from being written to the log when retries are being attempted.",
+      "defaultValue": "true",
+      "deprecation": {
+        "reason": "Use KafkaUtils#setConsumerRecordFormatter instead."
+      }
+    },
+    {
+      "name": "spring.kafka.listener.poll-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout to use when polling the consumer."
+    },
+    {
+      "name": "spring.kafka.listener.type",
+      "schema": {
+        "enum": [
+          "BATCH",
+          "SINGLE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.kafka.KafkaProperties$Listener$Type",
+      "description": "Listener type.",
+      "defaultValue": "single"
+    },
+    {
+      "name": "spring.kafka.producer.acks",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Number of acknowledgments the producer requires the leader to have received before considering a request complete."
+    },
+    {
+      "name": "spring.kafka.producer.batch-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Default batch size. A small batch size will make batching less common and may reduce throughput (a batch size of zero disables batching entirely)."
+    },
+    {
+      "name": "spring.kafka.producer.bootstrap-servers",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of host:port pairs to use for establishing the initial connections to the Kafka cluster. Overrides the global property, for producers."
+    },
+    {
+      "name": "spring.kafka.producer.buffer-memory",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Total memory size the producer can use to buffer records waiting to be sent to the server."
+    },
+    {
+      "name": "spring.kafka.producer.client-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "ID to pass to the server when making requests. Used for server-side logging."
+    },
+    {
+      "name": "spring.kafka.producer.compression-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Compression type for all data generated by the producer."
+    },
+    {
+      "name": "spring.kafka.producer.key-serializer",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class<?>",
+      "description": "Serializer class for keys."
+    },
+    {
+      "name": "spring.kafka.producer.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional producer-specific properties used to configure the client."
+    },
+    {
+      "name": "spring.kafka.producer.retries",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "When greater than zero, enables retrying of failed sends."
+    },
+    {
+      "name": "spring.kafka.producer.security.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Security protocol used to communicate with brokers."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the SSL bundle to use."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.key-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password of the private key in either key store key or key store file."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.key-store-certificate-chain",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Certificate chain in PEM format with a list of X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.key-store-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Private key in PEM format with PKCS#8 keys."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.key-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.key-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the key store."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.keystore-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.producer.ssl.key-store-location"
+      }
+    },
+    {
+      "name": "spring.kafka.producer.ssl.keystore-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.producer.ssl.key-store-password"
+      }
+    },
+    {
+      "name": "spring.kafka.producer.ssl.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL protocol to use."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.trust-store-certificates",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trusted certificates in PEM format with X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.trust-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.trust-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.trust-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the trust store."
+    },
+    {
+      "name": "spring.kafka.producer.ssl.truststore-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.producer.ssl.trust-store-location"
+      }
+    },
+    {
+      "name": "spring.kafka.producer.ssl.truststore-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.producer.ssl.trust-store-password"
+      }
+    },
+    {
+      "name": "spring.kafka.producer.transaction-id-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "When non empty, enables transaction support for producer."
+    },
+    {
+      "name": "spring.kafka.producer.value-serializer",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.Class<?>",
+      "description": "Serializer class for values."
+    },
+    {
+      "name": "spring.kafka.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional properties, common to producers and consumers, used to configure the client."
+    },
+    {
+      "name": "spring.kafka.retry.topic.attempts",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Total number of processing attempts made before sending the message to the DLT.",
+      "defaultValue": "3"
+    },
+    {
+      "name": "spring.kafka.retry.topic.backoff.delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Canonical backoff period. Used as an initial value in the exponential case, and as a minimum value in the uniform case.",
+      "defaultValue": "1s"
+    },
+    {
+      "name": "spring.kafka.retry.topic.backoff.max-delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum wait between retries. If less than the delay then the default of 30 seconds is applied.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.kafka.retry.topic.backoff.multiplier",
+      "schema": {
+        "format": "double",
+        "type": "number"
+      },
+      "typeName": "java.lang.Double",
+      "description": "Multiplier to use for generating the next backoff delay.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.kafka.retry.topic.backoff.random",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to have the backoff delays.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.retry.topic.delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.kafka.retry.topic.backoff.delay"
+      }
+    },
+    {
+      "name": "spring.kafka.retry.topic.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable topic-based non-blocking retries.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.retry.topic.max-delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.kafka.retry.topic.backoff.maxDelay"
+      }
+    },
+    {
+      "name": "spring.kafka.retry.topic.multiplier",
+      "schema": {
+        "format": "double",
+        "type": "number"
+      },
+      "typeName": "java.lang.Double",
+      "deprecation": {
+        "replacement": "spring.kafka.retry.topic.backoff.multiplier"
+      }
+    },
+    {
+      "name": "spring.kafka.retry.topic.random-back-off",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.kafka.retry.topic.backoff.random"
+      }
+    },
+    {
+      "name": "spring.kafka.security.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Security protocol used to communicate with brokers."
+    },
+    {
+      "name": "spring.kafka.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the SSL bundle to use."
+    },
+    {
+      "name": "spring.kafka.ssl.key-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password of the private key in either key store key or key store file."
+    },
+    {
+      "name": "spring.kafka.ssl.key-store-certificate-chain",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Certificate chain in PEM format with a list of X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.ssl.key-store-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Private key in PEM format with PKCS#8 keys."
+    },
+    {
+      "name": "spring.kafka.ssl.key-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file."
+    },
+    {
+      "name": "spring.kafka.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file."
+    },
+    {
+      "name": "spring.kafka.ssl.key-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the key store."
+    },
+    {
+      "name": "spring.kafka.ssl.keystore-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.ssl.key-store-location"
+      }
+    },
+    {
+      "name": "spring.kafka.ssl.keystore-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.ssl.key-store-password"
+      }
+    },
+    {
+      "name": "spring.kafka.ssl.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL protocol to use."
+    },
+    {
+      "name": "spring.kafka.ssl.trust-store-certificates",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trusted certificates in PEM format with X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.ssl.trust-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file."
+    },
+    {
+      "name": "spring.kafka.ssl.trust-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file."
+    },
+    {
+      "name": "spring.kafka.ssl.trust-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the trust store."
+    },
+    {
+      "name": "spring.kafka.ssl.truststore-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.ssl.trust-store-location"
+      }
+    },
+    {
+      "name": "spring.kafka.ssl.truststore-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file.",
+      "deprecation": {
+        "replacement": "spring.kafka.ssl.trust-store-password"
+      }
+    },
+    {
+      "name": "spring.kafka.streams.application-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Kafka streams application.id property; default spring.application.name."
+    },
+    {
+      "name": "spring.kafka.streams.auto-startup",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to auto-start the streams factory bean.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.kafka.streams.bootstrap-servers",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of host:port pairs to use for establishing the initial connections to the Kafka cluster. Overrides the global property, for streams."
+    },
+    {
+      "name": "spring.kafka.streams.cache-max-bytes-buffering",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.kafka.streams.state-store-cache-max-size"
+      }
+    },
+    {
+      "name": "spring.kafka.streams.cache-max-size-buffering",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.kafka.streams.state-store-cache-max-size"
+      }
+    },
+    {
+      "name": "spring.kafka.streams.cleanup.on-shutdown",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Cleanup the application’s local state directory on shutdown.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.streams.cleanup.on-startup",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Cleanup the application’s local state directory on startup.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.streams.client-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "ID to pass to the server when making requests. Used for server-side logging."
+    },
+    {
+      "name": "spring.kafka.streams.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional Kafka properties used to configure the streams."
+    },
+    {
+      "name": "spring.kafka.streams.replication-factor",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "The replication factor for change log topics and repartition topics created by the stream processing application."
+    },
+    {
+      "name": "spring.kafka.streams.security.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Security protocol used to communicate with brokers."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the SSL bundle to use."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.key-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password of the private key in either key store key or key store file."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.key-store-certificate-chain",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Certificate chain in PEM format with a list of X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.key-store-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Private key in PEM format with PKCS#8 keys."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.key-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the key store file."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the key store file."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.key-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the key store."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL protocol to use."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.trust-store-certificates",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trusted certificates in PEM format with X.509 certificates."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.trust-store-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the trust store file."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.trust-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Store password for the trust store file."
+    },
+    {
+      "name": "spring.kafka.streams.ssl.trust-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the trust store."
+    },
+    {
+      "name": "spring.kafka.streams.state-dir",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Directory location for the state store."
+    },
+    {
+      "name": "spring.kafka.streams.state-store-cache-max-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of the in-memory state store cache across all threads."
+    },
+    {
+      "name": "spring.kafka.template.default-topic",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Default topic to which messages are sent."
+    },
+    {
+      "name": "spring.kafka.template.observation-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable observation.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.kafka.template.transaction-id-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Transaction id prefix, override the transaction id prefix in the producer factory."
+    },
+    {
+      "name": "spring.ldap.anonymous-read-only",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether read-only operations should use an anonymous environment. Disabled by default unless a username is set."
+    },
+    {
+      "name": "spring.ldap.base",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Base suffix from which all operations should originate."
+    },
+    {
+      "name": "spring.ldap.base-environment",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "LDAP specification settings."
+    },
+    {
+      "name": "spring.ldap.embedded.base-dn",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of base DNs."
+    },
+    {
+      "name": "spring.ldap.embedded.credential.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Embedded LDAP password."
+    },
+    {
+      "name": "spring.ldap.embedded.credential.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Embedded LDAP username."
+    },
+    {
+      "name": "spring.ldap.embedded.ldif",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Schema (LDIF) script resource reference.",
+      "defaultValue": "classpath:schema.ldif"
+    },
+    {
+      "name": "spring.ldap.embedded.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Embedded LDAP port.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.ldap.embedded.validation.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable LDAP schema validation.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.ldap.embedded.validation.schema",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Path to the custom schema."
+    },
+    {
+      "name": "spring.ldap.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the server."
+    },
+    {
+      "name": "spring.ldap.referral",
+      "schema": {
+        "enum": [
+          "FOLLOW",
+          "IGNORE",
+          "THROW"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.ldap.LdapProperties$Referral",
+      "description": "Specify how referrals encountered by the service provider are to be processed. If not specified, the default is determined by the provider."
+    },
+    {
+      "name": "spring.ldap.template.ignore-name-not-found-exception",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether NameNotFoundException should be ignored in searches through the LdapTemplate.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.ldap.template.ignore-partial-result-exception",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether PartialResultException should be ignored in searches through the LdapTemplate.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.ldap.template.ignore-size-limit-exceeded-exception",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether SizeLimitExceededException should be ignored in searches through the LdapTemplate.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.ldap.urls",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "LDAP URLs of the server."
+    },
+    {
+      "name": "spring.ldap.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login username of the server."
+    },
+    {
+      "name": "spring.lifecycle.timeout-per-shutdown-phase",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for the shutdown of any phase (group of SmartLifecycle beans with the same 'phase' value).",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.liquibase.analytics-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to send product usage data and analytics to Liquibase."
+    },
+    {
+      "name": "spring.liquibase.change-log",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Change log configuration path.",
+      "defaultValue": "classpath:/db/changelog/db.changelog-master.yaml"
+    },
+    {
+      "name": "spring.liquibase.check-change-log-location",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Check the change log location exists.",
+      "defaultValue": "true",
+      "deprecation": {
+        "reason": "Liquibase has its own check that checks if the change log location exists making this property redundant."
+      }
+    },
+    {
+      "name": "spring.liquibase.clear-checksums",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to clear all checksums in the current changelog, so they will be recalculated upon the next update.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.liquibase.contexts",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of runtime contexts to use."
+    },
+    {
+      "name": "spring.liquibase.database-change-log-lock-table",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of table to use for tracking concurrent Liquibase usage.",
+      "defaultValue": "DATABASECHANGELOGLOCK"
+    },
+    {
+      "name": "spring.liquibase.database-change-log-table",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of table to use for tracking change history.",
+      "defaultValue": "DATABASECHANGELOG"
+    },
+    {
+      "name": "spring.liquibase.default-schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Default database schema."
+    },
+    {
+      "name": "spring.liquibase.driver-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Fully qualified name of the JDBC driver. Auto-detected based on the URL by default."
+    },
+    {
+      "name": "spring.liquibase.drop-first",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to first drop the database schema.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.liquibase.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Liquibase support.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.liquibase.label-filter",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of runtime labels to use."
+    },
+    {
+      "name": "spring.liquibase.labels",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.liquibase.label-filter"
+      }
+    },
+    {
+      "name": "spring.liquibase.license-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Liquibase Pro license key."
+    },
+    {
+      "name": "spring.liquibase.liquibase-schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Schema to use for Liquibase objects."
+    },
+    {
+      "name": "spring.liquibase.liquibase-tablespace",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Tablespace to use for Liquibase objects."
+    },
+    {
+      "name": "spring.liquibase.parameters",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Change log parameters."
+    },
+    {
+      "name": "spring.liquibase.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the database to migrate."
+    },
+    {
+      "name": "spring.liquibase.rollback-file",
+      "schema": {
+        "format": "uri",
+        "type": "string"
+      },
+      "typeName": "java.io.File",
+      "description": "File to which rollback SQL is written when an update is performed."
+    },
+    {
+      "name": "spring.liquibase.show-summary",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "summary"
+    },
+    {
+      "name": "spring.liquibase.show-summary-output",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "log"
+    },
+    {
+      "name": "spring.liquibase.tag",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Tag name to use when applying database changes. Can also be used with \"rollbackFile\" to generate a rollback script for all existing changes associated with that tag."
+    },
+    {
+      "name": "spring.liquibase.test-rollback-on-update",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether rollback should be tested before update is performed.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.liquibase.ui-service",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "logger"
+    },
+    {
+      "name": "spring.liquibase.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JDBC URL of the database to migrate. If not set, the primary configured data source is used."
+    },
+    {
+      "name": "spring.liquibase.user",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the database to migrate."
+    },
+    {
+      "name": "spring.mail.default-encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Default MimeMessage encoding.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.mail.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SMTP server host. For instance, 'smtp.example.com'."
+    },
+    {
+      "name": "spring.mail.jndi-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Session JNDI name. When set, takes precedence over other Session settings."
+    },
+    {
+      "name": "spring.mail.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the SMTP server."
+    },
+    {
+      "name": "spring.mail.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "SMTP server port."
+    },
+    {
+      "name": "spring.mail.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional JavaMail Session properties."
+    },
+    {
+      "name": "spring.mail.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Protocol used by the SMTP server.",
+      "defaultValue": "smtp"
+    },
+    {
+      "name": "spring.mail.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle name. If set, 'mail.(protocol).ssl.socketFactory' property is set to an SSLSocketFactory obtained from the corresponding SSL bundle. <p> Note that the STARTTLS command can use the corresponding SSLSocketFactory, even if the 'mail.(protocol).ssl.enable' property is not set."
+    },
+    {
+      "name": "spring.mail.ssl.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable SSL support. If enabled, 'mail.(protocol).ssl.enable' property is set to 'true'.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mail.test-connection",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to test that the mail server is available on startup.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mail.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the SMTP server."
+    },
+    {
+      "name": "spring.messages.always-use-message-format",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to always apply the MessageFormat rules, parsing even messages without arguments.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.messages.basename",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of basenames (essentially a fully-qualified classpath location), each following the ResourceBundle convention with relaxed support for slash based locations. If it doesn't contain a package qualifier (such as \"org.mypackage\"), it will be resolved from the classpath root.",
+      "defaultValue": "messages"
+    },
+    {
+      "name": "spring.messages.cache-duration",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Loaded resource bundle files cache duration. When not set, bundles are cached forever. If a duration suffix is not specified, seconds will be used."
+    },
+    {
+      "name": "spring.messages.common-messages",
+      "schema": {
+        "items": {
+          "format": "resource",
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<org.springframework.core.io.Resource>",
+      "description": "List of locale-independent property file resources containing common messages."
+    },
+    {
+      "name": "spring.messages.encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Message bundles encoding.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.messages.fallback-to-system-locale",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to fall back to the system Locale if no files for a specific Locale have been found. if this is turned off, the only fallback will be the default file (e.g. \"messages.properties\" for basename \"messages\").",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.messages.use-code-as-default-message",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use the message code as the default message instead of throwing a \"NoSuchMessageException\". Recommended during development only.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mustache.charset",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Template encoding.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.mustache.check-template-location",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to check that the templates location exists.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.mustache.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable MVC view resolution for Mustache.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.mustache.prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix to apply to template names.",
+      "defaultValue": "classpath:/templates/"
+    },
+    {
+      "name": "spring.mustache.reactive.media-types",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.List<org.springframework.http.MediaType>",
+      "description": "Media types supported by Mustache views.",
+      "defaultValue": "text/html;charset=UTF-8"
+    },
+    {
+      "name": "spring.mustache.request-context-attribute",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the RequestContext attribute for all views."
+    },
+    {
+      "name": "spring.mustache.servlet.allow-request-override",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether HttpServletRequest attributes are allowed to override (hide) controller generated model attributes of the same name.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mustache.servlet.allow-session-override",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether HttpSession attributes are allowed to override (hide) controller generated model attributes of the same name.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mustache.servlet.cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable template caching.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mustache.servlet.content-type",
+      "schema": {
+        "format": "mime-type",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.MimeType",
+      "description": "Content-Type value."
+    },
+    {
+      "name": "spring.mustache.servlet.expose-request-attributes",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether all request attributes should be added to the model prior to merging with the template.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mustache.servlet.expose-session-attributes",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether all HttpSession attributes should be added to the model prior to merging with the template.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mustache.servlet.expose-spring-macro-helpers",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to expose a RequestContext for use by Spring's macro library, under the name \"springMacroRequestContext\".",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.mustache.suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Suffix to apply to template names.",
+      "defaultValue": ".mustache"
+    },
+    {
+      "name": "spring.mustache.view-names",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "View names that can be resolved."
+    },
+    {
+      "name": "spring.mvc.async.request-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Amount of time before asynchronous request handling times out. If this value is not set, the default timeout of the underlying implementation is used."
+    },
+    {
+      "name": "spring.mvc.contentnegotiation.default-content-types",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.List<org.springframework.http.MediaType>",
+      "description": "List of default content types to be used when no specific content type is requested."
+    },
+    {
+      "name": "spring.mvc.contentnegotiation.favor-parameter",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether a request parameter (\"format\" by default) should be used to determine the requested media type.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mvc.contentnegotiation.media-types",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.Map<java.lang.String,org.springframework.http.MediaType>",
+      "description": "Map file extensions to media types for content negotiation. For instance, yml to text/yaml."
+    },
+    {
+      "name": "spring.mvc.contentnegotiation.parameter-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Query parameter name to use when \"favor-parameter\" is enabled."
+    },
+    {
+      "name": "spring.mvc.converters.preferred-json-mapper",
+      "schema": {
+        "examples": [
+          "gson",
+          "jackson",
+          "jsonb"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Preferred JSON mapper to use for HTTP message conversion. By default, auto-detected according to the environment. Supported values are 'jackson', 'gson', and 'jsonb'. When other json mapping libraries (such as kotlinx.serialization) are present, use a custom HttpMessageConverters bean to control the preferred mapper.",
+      "defaultValue": "jackson",
+      "deprecation": {
+        "replacement": "spring.http.converters.preferred-json-mapper"
+      }
+    },
+    {
+      "name": "spring.mvc.date-format",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Date format to use, for example 'dd/MM/yyyy'.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.mvc.dispatch-options-request",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to dispatch OPTIONS requests to the FrameworkServlet doService method.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.mvc.dispatch-trace-request",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to dispatch TRACE requests to the FrameworkServlet doService method.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mvc.favicon.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable resolution of favicon.ico.",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.mvc.format.date",
+      "schema": {
+        "examples": [
+          "dd/MM/yyyy",
+          "iso"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Date format to use, for example 'dd/MM/yyyy'. Used for formatting of java.util.Date and java.time.LocalDate."
+    },
+    {
+      "name": "spring.mvc.format.date-time",
+      "schema": {
+        "examples": [
+          "iso",
+          "iso-offset",
+          "yyyy-MM-dd HH:mm:ss"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Date-time format to use, for example 'yyyy-MM-dd HH:mm:ss'. Used for formatting of java.time's LocalDateTime, OffsetDateTime, and ZonedDateTime."
+    },
+    {
+      "name": "spring.mvc.format.time",
+      "schema": {
+        "examples": [
+          "HH:mm:ss",
+          "iso",
+          "iso-offset"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Time format to use, for example 'HH:mm:ss'. Used for formatting of java.time's LocalTime and OffsetTime."
+    },
+    {
+      "name": "spring.mvc.formcontent.filter.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Spring's FormContentFilter.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.mvc.formcontent.putfilter.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Spring's HttpPutFormContentFilter.",
+      "defaultValue": "true",
+      "deprecation": {
+        "replacement": "spring.mvc.formcontent.filter.enabled"
+      }
+    },
+    {
+      "name": "spring.mvc.hiddenmethod.filter.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Spring's HiddenHttpMethodFilter.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mvc.ignore-default-model-on-redirect",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "Deprecated for removal in Spring MVC."
+      }
+    },
+    {
+      "name": "spring.mvc.locale",
+      "schema": {
+        "format": "language",
+        "type": "string"
+      },
+      "typeName": "java.util.Locale",
+      "deprecation": {
+        "replacement": "spring.web.locale"
+      }
+    },
+    {
+      "name": "spring.mvc.locale-resolver",
+      "schema": {
+        "enum": [
+          "ACCEPT_HEADER",
+          "FIXED"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.WebProperties$LocaleResolver",
+      "deprecation": {
+        "replacement": "spring.web.locale-resolver"
+      }
+    },
+    {
+      "name": "spring.mvc.log-request-details",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether logging of (potentially sensitive) request details at DEBUG and TRACE level is allowed.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mvc.log-resolved-exception",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable warn logging of exceptions resolved by a \"HandlerExceptionResolver\", except for \"DefaultHandlerExceptionResolver\".",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mvc.message-codes-resolver-format",
+      "schema": {
+        "enum": [
+          "POSTFIX_ERROR_CODE",
+          "PREFIX_ERROR_CODE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.validation.DefaultMessageCodesResolver$Format",
+      "description": "Formatting strategy for message codes. For instance, 'PREFIX_ERROR_CODE'."
+    },
+    {
+      "name": "spring.mvc.pathmatch.matching-strategy",
+      "schema": {
+        "enum": [
+          "ANT_PATH_MATCHER",
+          "PATH_PATTERN_PARSER"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.servlet.WebMvcProperties$MatchingStrategy",
+      "description": "Choice of strategy for matching request paths against registered mappings.",
+      "defaultValue": "path-pattern-parser"
+    },
+    {
+      "name": "spring.mvc.problemdetails.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether RFC 9457 Problem Details support should be enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.mvc.publish-request-handled-events",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to publish a ServletRequestHandledEvent at the end of each request.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.mvc.servlet.load-on-startup",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Load on startup priority of the dispatcher servlet.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "spring.mvc.servlet.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path of the dispatcher servlet. Setting a custom value for this property is not compatible with the PathPatternParser matching strategy.",
+      "defaultValue": "/"
+    },
+    {
+      "name": "spring.mvc.static-path-pattern",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path pattern used for static resources.",
+      "defaultValue": "/**"
+    },
+    {
+      "name": "spring.mvc.throw-exception-if-no-handler-found",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "reason": "DispatcherServlet property is deprecated for removal and should no longer need to be configured."
+      }
+    },
+    {
+      "name": "spring.mvc.view.prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Spring MVC view prefix."
+    },
+    {
+      "name": "spring.mvc.view.suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Spring MVC view suffix."
+    },
+    {
+      "name": "spring.mvc.webjars-path-pattern",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path pattern used for WebJar assets.",
+      "defaultValue": "/webjars/**"
+    },
+    {
+      "name": "spring.neo4j.authentication.kerberos-ticket",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Kerberos ticket for connecting to the database. Mutual exclusive with a given username."
+    },
+    {
+      "name": "spring.neo4j.authentication.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the server."
+    },
+    {
+      "name": "spring.neo4j.authentication.realm",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Realm to connect to."
+    },
+    {
+      "name": "spring.neo4j.authentication.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user of the server."
+    },
+    {
+      "name": "spring.neo4j.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for borrowing connections from the pool.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.neo4j.max-transaction-retry-time",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time transactions are allowed to retry.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.neo4j.pool.connection-acquisition-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Acquisition of new connections will be attempted for at most configured timeout.",
+      "defaultValue": "60s"
+    },
+    {
+      "name": "spring.neo4j.pool.idle-time-before-connection-test",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Pooled connections that have been idle in the pool for longer than this threshold will be tested before they are used again."
+    },
+    {
+      "name": "spring.neo4j.pool.log-leaked-sessions",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to log leaked sessions.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.neo4j.pool.max-connection-lifetime",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Pooled connections older than this threshold will be closed and removed from the pool.",
+      "defaultValue": "1h"
+    },
+    {
+      "name": "spring.neo4j.pool.max-connection-pool-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum amount of connections in the connection pool towards a single database.",
+      "defaultValue": "100"
+    },
+    {
+      "name": "spring.neo4j.pool.metrics-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable metrics.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.neo4j.security.cert-file",
+      "schema": {
+        "format": "uri",
+        "type": "string"
+      },
+      "typeName": "java.io.File",
+      "description": "Path to the file that holds the trusted certificates."
+    },
+    {
+      "name": "spring.neo4j.security.encrypted",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the driver should use encrypted traffic.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.neo4j.security.hostname-verification-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether hostname verification is required.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.neo4j.security.trust-strategy",
+      "schema": {
+        "enum": [
+          "TRUST_ALL_CERTIFICATES",
+          "TRUST_CUSTOM_CA_SIGNED_CERTIFICATES",
+          "TRUST_SYSTEM_CA_SIGNED_CERTIFICATES"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.neo4j.Neo4jProperties$Security$TrustStrategy",
+      "description": "Trust strategy to use.",
+      "defaultValue": "trust-system-ca-signed-certificates"
+    },
+    {
+      "name": "spring.neo4j.uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "bolt://localhost:7687"
+    },
+    {
+      "name": "spring.netty.leak-detection",
+      "schema": {
+        "enum": [
+          "ADVANCED",
+          "DISABLED",
+          "PARANOID",
+          "SIMPLE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.netty.NettyProperties$LeakDetection",
+      "description": "Level of leak detection for reference-counted buffers. If not configured via 'ResourceLeakDetector.setLevel' or the 'io.netty.leakDetection.level' system property, default to 'simple'."
+    },
+    {
+      "name": "spring.pulsar.admin.authentication.param",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Authentication parameter(s) as a map of parameter names to parameter values."
+    },
+    {
+      "name": "spring.pulsar.admin.authentication.plugin-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Fully qualified class name of the authentication plugin."
+    },
+    {
+      "name": "spring.pulsar.admin.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Duration to wait for a connection to server to be established.",
+      "defaultValue": "1m"
+    },
+    {
+      "name": "spring.pulsar.admin.read-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Server response read time out for any request.",
+      "defaultValue": "1m"
+    },
+    {
+      "name": "spring.pulsar.admin.request-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Server request time out for any request.",
+      "defaultValue": "5m"
+    },
+    {
+      "name": "spring.pulsar.admin.service-url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Pulsar web URL for the admin endpoint in the format '(http|https)://host:port'.",
+      "defaultValue": "http://localhost:8080"
+    },
+    {
+      "name": "spring.pulsar.client.authentication.param",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Authentication parameter(s) as a map of parameter names to parameter values."
+    },
+    {
+      "name": "spring.pulsar.client.authentication.plugin-class-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Fully qualified class name of the authentication plugin."
+    },
+    {
+      "name": "spring.pulsar.client.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Duration to wait for a connection to a broker to be established.",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "spring.pulsar.client.failover.backup-clusters",
+      "schema": {
+        "items": {
+          "properties": {
+            "authentication": {
+              "properties": {
+                "pluginClassName": {
+                  "type": "string"
+                },
+                "param": {
+                  "additionalProperties": {
+                    "type": "object"
+                  },
+                  "propertyNames": {
+                    "type": "object"
+                  },
+                  "type": "object"
+                }
+              },
+              "type": "object"
+            },
+            "serviceUrl": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<org.springframework.boot.autoconfigure.pulsar.PulsarProperties$Failover$BackupCluster>",
+      "description": "List of backup clusters. The backup cluster is chosen in the sequence of the given list. If all backup clusters are available, the Pulsar client chooses the first backup cluster."
+    },
+    {
+      "name": "spring.pulsar.client.failover.check-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Frequency of performing a probe task."
+    },
+    {
+      "name": "spring.pulsar.client.failover.delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Delay before the Pulsar client switches from the primary cluster to the backup cluster."
+    },
+    {
+      "name": "spring.pulsar.client.failover.policy",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.AutoClusterFailoverBuilder$FailoverPolicy",
+      "description": "Cluster failover policy.",
+      "defaultValue": "order"
+    },
+    {
+      "name": "spring.pulsar.client.failover.switch-back-delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Delay before the Pulsar client switches from the backup cluster to the primary cluster."
+    },
+    {
+      "name": "spring.pulsar.client.lookup-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Client lookup timeout."
+    },
+    {
+      "name": "spring.pulsar.client.operation-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Client operation timeout.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.pulsar.client.service-url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Pulsar service URL in the format '(pulsar|pulsar+ssl)://host:port'.",
+      "defaultValue": "pulsar://localhost:6650"
+    },
+    {
+      "name": "spring.pulsar.client.threads.io",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of threads to be used for handling connections to brokers."
+    },
+    {
+      "name": "spring.pulsar.client.threads.listener",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of threads to be used for message listeners."
+    },
+    {
+      "name": "spring.pulsar.consumer.dead-letter-policy.dead-letter-topic",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the dead topic where the failing messages will be sent."
+    },
+    {
+      "name": "spring.pulsar.consumer.dead-letter-policy.initial-subscription-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the initial subscription of the dead letter topic. When not set, the initial subscription will not be created. However, when the property is set then the broker's 'allowAutoSubscriptionCreation' must be enabled or the DLQ producer will fail."
+    },
+    {
+      "name": "spring.pulsar.consumer.dead-letter-policy.max-redeliver-count",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of times that a message will be redelivered before being sent to the dead letter queue.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.pulsar.consumer.dead-letter-policy.retry-letter-topic",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the retry topic where the failing messages will be sent."
+    },
+    {
+      "name": "spring.pulsar.consumer.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Consumer name to identify a particular consumer from the topic stats."
+    },
+    {
+      "name": "spring.pulsar.consumer.priority-level",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Priority level for shared subscription consumers.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.pulsar.consumer.read-compacted",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to read messages from the compacted topic rather than the full message backlog.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.pulsar.consumer.retry-enable",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to auto retry messages.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.pulsar.consumer.subscription.initial-position",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.SubscriptionInitialPosition",
+      "description": "Position where to initialize a newly created subscription.",
+      "defaultValue": "latest"
+    },
+    {
+      "name": "spring.pulsar.consumer.subscription.mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.SubscriptionMode",
+      "description": "Subscription mode to be used when subscribing to the topic.",
+      "defaultValue": "durable"
+    },
+    {
+      "name": "spring.pulsar.consumer.subscription.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Subscription name for the consumer."
+    },
+    {
+      "name": "spring.pulsar.consumer.subscription.topics-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.RegexSubscriptionMode",
+      "description": "Determines which type of topics (persistent, non-persistent, or all) the consumer should be subscribed to when using pattern subscriptions.",
+      "defaultValue": "persistentonly"
+    },
+    {
+      "name": "spring.pulsar.consumer.subscription.type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.SubscriptionType",
+      "description": "Subscription type to be used when subscribing to a topic.",
+      "defaultValue": "exclusive"
+    },
+    {
+      "name": "spring.pulsar.consumer.topics",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Topics the consumer subscribes to."
+    },
+    {
+      "name": "spring.pulsar.consumer.topics-pattern",
+      "schema": {
+        "properties": {
+          "pattern": {
+            "type": "string"
+          },
+          "flags": {
+            "format": "int32",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "flags"
+        ],
+        "type": "object"
+      },
+      "typeName": "java.util.regex.Pattern",
+      "description": "Pattern for topics the consumer subscribes to."
+    },
+    {
+      "name": "spring.pulsar.defaults.topic.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable default tenant and namespace support for topics.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.pulsar.defaults.topic.namespace",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Default namespace to use when producing or consuming messages against a non-fully-qualified topic URL.",
+      "defaultValue": "default"
+    },
+    {
+      "name": "spring.pulsar.defaults.topic.tenant",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Default tenant to use when producing or consuming messages against a non-fully-qualified topic URL.",
+      "defaultValue": "public"
+    },
+    {
+      "name": "spring.pulsar.defaults.type-mappings",
+      "schema": {
+        "items": {
+          "properties": {
+            "topicName": {
+              "type": "string"
+            },
+            "messageType": {
+              "type": "string"
+            },
+            "schemaInfo": {
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<org.springframework.boot.autoconfigure.pulsar.PulsarProperties$Defaults$TypeMapping>",
+      "description": "List of mappings from message type to topic name and schema info to use as a defaults when a topic name and/or schema is not explicitly specified when producing or consuming messages of the mapped type."
+    },
+    {
+      "name": "spring.pulsar.function.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable function support.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.pulsar.function.fail-fast",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to stop processing further function creates/updates when a failure occurs.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.pulsar.function.propagate-failures",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to throw an exception if any failure is encountered during server startup while creating/updating functions.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.pulsar.function.propagate-stop-failures",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to throw an exception if any failure is encountered during server shutdown while enforcing stop policy on functions.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.pulsar.listener.concurrency",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of threads used by listener container."
+    },
+    {
+      "name": "spring.pulsar.listener.observation-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to record observations for when the Observations API is available and the client supports it.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.pulsar.listener.schema-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.common.schema.SchemaType",
+      "description": "SchemaType of the consumed messages."
+    },
+    {
+      "name": "spring.pulsar.producer.access-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.ProducerAccessMode",
+      "description": "Type of access to the topic the producer requires.",
+      "defaultValue": "shared"
+    },
+    {
+      "name": "spring.pulsar.producer.batching-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to automatically batch messages.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.pulsar.producer.cache.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable caching in the PulsarProducerFactory.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.pulsar.producer.cache.expire-after-access",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time period to expire unused entries in the cache.",
+      "defaultValue": "1m"
+    },
+    {
+      "name": "spring.pulsar.producer.cache.initial-capacity",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Initial size of cache.",
+      "defaultValue": "50"
+    },
+    {
+      "name": "spring.pulsar.producer.cache.maximum-size",
+      "schema": {
+        "format": "int64",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Long",
+      "description": "Maximum size of cache (entries).",
+      "defaultValue": "1000"
+    },
+    {
+      "name": "spring.pulsar.producer.chunking-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to split large-size messages into multiple chunks.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.pulsar.producer.compression-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.CompressionType",
+      "description": "Message compression type."
+    },
+    {
+      "name": "spring.pulsar.producer.hashing-scheme",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.HashingScheme",
+      "description": "Message hashing scheme to choose the partition to which the message is published.",
+      "defaultValue": "javastringhash"
+    },
+    {
+      "name": "spring.pulsar.producer.message-routing-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.apache.pulsar.client.api.MessageRoutingMode",
+      "description": "Message routing mode for a partitioned producer.",
+      "defaultValue": "roundrobinpartition"
+    },
+    {
+      "name": "spring.pulsar.producer.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name for the producer. If not assigned, a unique name is generated."
+    },
+    {
+      "name": "spring.pulsar.producer.send-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time before a message has to be acknowledged by the broker.",
+      "defaultValue": "30s"
+    },
+    {
+      "name": "spring.pulsar.producer.topic-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Topic the producer will publish to."
+    },
+    {
+      "name": "spring.pulsar.reader.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Reader name."
+    },
+    {
+      "name": "spring.pulsar.reader.read-compacted",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to read messages from a compacted topic rather than a full message backlog of a topic.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.pulsar.reader.subscription-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Subscription name."
+    },
+    {
+      "name": "spring.pulsar.reader.subscription-role-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix of subscription role."
+    },
+    {
+      "name": "spring.pulsar.reader.topics",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Topics the reader subscribes to."
+    },
+    {
+      "name": "spring.pulsar.template.observations-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to record observations for when the Observations API is available.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.pulsar.transaction.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether transaction support is enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.quartz.auto-startup",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to automatically start the scheduler after initialization.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.quartz.jdbc.comment-prefix",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Prefixes for single-line comments in SQL initialization scripts.",
+      "defaultValue": "#, --"
+    },
+    {
+      "name": "spring.quartz.jdbc.initialize-schema",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "EMBEDDED",
+          "NEVER"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.sql.init.DatabaseInitializationMode",
+      "description": "Database schema initialization mode.",
+      "defaultValue": "embedded"
+    },
+    {
+      "name": "spring.quartz.jdbc.platform",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Platform to use in initialization scripts if the @@platform@@ placeholder is used. Auto-detected by default."
+    },
+    {
+      "name": "spring.quartz.jdbc.schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the SQL file to use to initialize the database schema.",
+      "defaultValue": "classpath:org/quartz/impl/jdbcjobstore/tables_@@platform@@.sql"
+    },
+    {
+      "name": "spring.quartz.job-store-type",
+      "schema": {
+        "enum": [
+          "JDBC",
+          "MEMORY"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.quartz.JobStoreType",
+      "description": "Quartz job store type.",
+      "defaultValue": "memory"
+    },
+    {
+      "name": "spring.quartz.overwrite-existing-jobs",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether configured jobs should overwrite existing job definitions.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.quartz.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional Quartz Scheduler properties."
+    },
+    {
+      "name": "spring.quartz.scheduler-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the scheduler.",
+      "defaultValue": "quartzScheduler"
+    },
+    {
+      "name": "spring.quartz.startup-delay",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Delay after which the scheduler is started once initialization completes. Setting this property makes sense if no jobs should be run before the entire application has started up.",
+      "defaultValue": "0s"
+    },
+    {
+      "name": "spring.quartz.wait-for-jobs-to-complete-on-shutdown",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to wait for running jobs to complete on shutdown.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.r2dbc.generate-unique-name",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to generate a random database name. Ignore any configured name when enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.r2dbc.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Database name. Set if no name is specified in the url. Default to \"testdb\" when using an embedded database."
+    },
+    {
+      "name": "spring.r2dbc.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password of the database. Set if no password is specified in the url."
+    },
+    {
+      "name": "spring.r2dbc.pool.acquire-retry",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of acquire retries if the first acquire attempt fails.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.r2dbc.pool.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether pooling is enabled. Requires r2dbc-pool.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.r2dbc.pool.initial-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Initial connection pool size.",
+      "defaultValue": "10"
+    },
+    {
+      "name": "spring.r2dbc.pool.max-acquire-time",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time to acquire a connection from the pool. By default, wait indefinitely."
+    },
+    {
+      "name": "spring.r2dbc.pool.max-create-connection-time",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time to wait to create a new connection. By default, wait indefinitely."
+    },
+    {
+      "name": "spring.r2dbc.pool.max-idle-time",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum amount of time that a connection is allowed to sit idle in the pool.",
+      "defaultValue": "30m"
+    },
+    {
+      "name": "spring.r2dbc.pool.max-life-time",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum lifetime of a connection in the pool. By default, connections have an infinite lifetime."
+    },
+    {
+      "name": "spring.r2dbc.pool.max-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximal connection pool size.",
+      "defaultValue": "10"
+    },
+    {
+      "name": "spring.r2dbc.pool.max-validation-time",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time to validate a connection from the pool. By default, wait indefinitely."
+    },
+    {
+      "name": "spring.r2dbc.pool.min-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Minimal number of idle connections.",
+      "defaultValue": "0"
+    },
+    {
+      "name": "spring.r2dbc.pool.validation-depth",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "io.r2dbc.spi.ValidationDepth",
+      "description": "Validation depth.",
+      "defaultValue": "local"
+    },
+    {
+      "name": "spring.r2dbc.pool.validation-query",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Validation query."
+    },
+    {
+      "name": "spring.r2dbc.properties",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Additional R2DBC options."
+    },
+    {
+      "name": "spring.r2dbc.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "R2DBC URL of the database. database name, username, password and pooling options specified in the url take precedence over individual options."
+    },
+    {
+      "name": "spring.r2dbc.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login username of the database. Set if no username is specified in the url."
+    },
+    {
+      "name": "spring.rabbitmq.address-shuffle-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.amqp.rabbit.connection.AbstractConnectionFactory$AddressShuffleMode",
+      "description": "Mode used to shuffle configured addresses.",
+      "defaultValue": "none"
+    },
+    {
+      "name": "spring.rabbitmq.addresses",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "List of addresses to which the client should connect. When set, the host and port are ignored."
+    },
+    {
+      "name": "spring.rabbitmq.cache.channel.checkout-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Duration to wait to obtain a channel if the cache size has been reached. If 0, always create a new channel."
+    },
+    {
+      "name": "spring.rabbitmq.cache.channel.size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of channels to retain in the cache. When \"check-timeout\" > 0, max channels per connection."
+    },
+    {
+      "name": "spring.rabbitmq.cache.connection.mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.amqp.rabbit.connection.CachingConnectionFactory$CacheMode",
+      "description": "Connection factory cache mode.",
+      "defaultValue": "channel"
+    },
+    {
+      "name": "spring.rabbitmq.cache.connection.size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of connections to cache. Only applies when mode is CONNECTION."
+    },
+    {
+      "name": "spring.rabbitmq.channel-rpc-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Continuation timeout for RPC calls in channels. Set it to zero to wait forever.",
+      "defaultValue": "10m"
+    },
+    {
+      "name": "spring.rabbitmq.connection-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Connection timeout. Set it to zero to wait forever."
+    },
+    {
+      "name": "spring.rabbitmq.dynamic",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to create an AmqpAdmin bean.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "RabbitMQ host. Ignored if an address is set.",
+      "defaultValue": "localhost"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.acknowledge-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.amqp.core.AcknowledgeMode",
+      "description": "Acknowledge mode of container."
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.auto-startup",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to start the container automatically on startup.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.consumers-per-queue",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of consumers per queue."
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.de-batching-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the container should present batched messages as discrete messages or call the listener with the batch.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.default-requeue-rejected",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether rejected deliveries are re-queued by default."
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.force-stop",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the container (when stopped) should stop immediately after processing the current message or stop after processing all pre-fetched messages.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.idle-event-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "How often idle container events should be published."
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.missing-queues-fatal",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to fail if the queues declared by the container are not available on the broker.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.observation-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable observation.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.prefetch",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of unacknowledged messages that can be outstanding at each consumer."
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.retry.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether publishing retries are enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.retry.initial-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Duration between the first and second attempt to deliver a message.",
+      "defaultValue": "1000ms"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.retry.max-attempts",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of attempts to deliver a message.",
+      "defaultValue": "3"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.retry.max-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum duration between attempts.",
+      "defaultValue": "10000ms"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.retry.multiplier",
+      "schema": {
+        "format": "double",
+        "type": "number"
+      },
+      "typeName": "java.lang.Double",
+      "description": "Multiplier to apply to the previous retry interval.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.rabbitmq.listener.direct.retry.stateless",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether retries are stateless or stateful.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.acknowledge-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.amqp.core.AcknowledgeMode",
+      "description": "Acknowledge mode of container."
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.auto-startup",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to start the container automatically on startup.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.batch-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Batch size, expressed as the number of physical messages, to be used by the container."
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.concurrency",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Minimum number of listener invoker threads."
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.consumer-batch-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the container creates a batch of messages based on the 'receive-timeout' and 'batch-size'. Coerces 'de-batching-enabled' to true to include the contents of a producer created batch in the batch as discrete records.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.de-batching-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the container should present batched messages as discrete messages or call the listener with the batch.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.default-requeue-rejected",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether rejected deliveries are re-queued by default."
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.force-stop",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the container (when stopped) should stop immediately after processing the current message or stop after processing all pre-fetched messages.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.idle-event-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "How often idle container events should be published."
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.max-concurrency",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of listener invoker threads."
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.missing-queues-fatal",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to fail if the queues declared by the container are not available on the broker and/or whether to stop the container if one or more queues are deleted at runtime.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.observation-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable observation.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.prefetch",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of unacknowledged messages that can be outstanding at each consumer."
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.retry.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether publishing retries are enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.retry.initial-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Duration between the first and second attempt to deliver a message.",
+      "defaultValue": "1000ms"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.retry.max-attempts",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of attempts to deliver a message.",
+      "defaultValue": "3"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.retry.max-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum duration between attempts.",
+      "defaultValue": "10000ms"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.retry.multiplier",
+      "schema": {
+        "format": "double",
+        "type": "number"
+      },
+      "typeName": "java.lang.Double",
+      "description": "Multiplier to apply to the previous retry interval.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.retry.stateless",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether retries are stateless or stateful.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.listener.simple.transaction-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.rabbitmq.listener.stream.native-listener",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the container will support listeners that consume native stream messages instead of Spring AMQP messages.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.stream.observation-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable observation.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.listener.type",
+      "schema": {
+        "enum": [
+          "DIRECT",
+          "SIMPLE",
+          "STREAM"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.amqp.RabbitProperties$ContainerType",
+      "description": "Listener container type.",
+      "defaultValue": "simple"
+    },
+    {
+      "name": "spring.rabbitmq.max-inbound-message-body-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of the body of inbound (received) messages.",
+      "defaultValue": "64MB"
+    },
+    {
+      "name": "spring.rabbitmq.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login to authenticate against the broker.",
+      "defaultValue": "guest"
+    },
+    {
+      "name": "spring.rabbitmq.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "RabbitMQ port. Ignored if an address is set. Default to 5672, or 5671 if SSL is enabled."
+    },
+    {
+      "name": "spring.rabbitmq.publisher-confirm-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.amqp.rabbit.connection.CachingConnectionFactory$ConfirmType",
+      "description": "Type of publisher confirms to use."
+    },
+    {
+      "name": "spring.rabbitmq.publisher-confirms",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.rabbitmq.publisher-returns",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable publisher returns.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.requested-channel-max",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Number of channels per connection requested by the client. Use 0 for unlimited.",
+      "defaultValue": "2047"
+    },
+    {
+      "name": "spring.rabbitmq.requested-heartbeat",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Requested heartbeat timeout; zero for none. If a duration suffix is not specified, seconds will be used."
+    },
+    {
+      "name": "spring.rabbitmq.ssl.algorithm",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL algorithm to use. By default, configured by the Rabbit client library."
+    },
+    {
+      "name": "spring.rabbitmq.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL bundle name."
+    },
+    {
+      "name": "spring.rabbitmq.ssl.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable SSL support. Determined automatically if an address is provided with the protocol (amqp:// vs. amqps://)."
+    },
+    {
+      "name": "spring.rabbitmq.ssl.key-store",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the key store that holds the SSL certificate."
+    },
+    {
+      "name": "spring.rabbitmq.ssl.key-store-algorithm",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Key store algorithm.",
+      "defaultValue": "SunX509"
+    },
+    {
+      "name": "spring.rabbitmq.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the key store."
+    },
+    {
+      "name": "spring.rabbitmq.ssl.key-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Key store type.",
+      "defaultValue": "PKCS12"
+    },
+    {
+      "name": "spring.rabbitmq.ssl.trust-store",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trust store that holds SSL certificates."
+    },
+    {
+      "name": "spring.rabbitmq.ssl.trust-store-algorithm",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trust store algorithm.",
+      "defaultValue": "SunX509"
+    },
+    {
+      "name": "spring.rabbitmq.ssl.trust-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the trust store."
+    },
+    {
+      "name": "spring.rabbitmq.ssl.trust-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trust store type.",
+      "defaultValue": "JKS"
+    },
+    {
+      "name": "spring.rabbitmq.ssl.validate-server-certificate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable server side certificate validation.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.ssl.verify-hostname",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable hostname verification.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rabbitmq.stream.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Host of a RabbitMQ instance with the Stream plugin enabled.",
+      "defaultValue": "localhost"
+    },
+    {
+      "name": "spring.rabbitmq.stream.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the stream."
+    },
+    {
+      "name": "spring.rabbitmq.stream.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login password to authenticate to the broker. When not set spring.rabbitmq.password is used."
+    },
+    {
+      "name": "spring.rabbitmq.stream.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Stream port of a RabbitMQ instance with the Stream plugin enabled."
+    },
+    {
+      "name": "spring.rabbitmq.stream.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user to authenticate to the broker. When not set, spring.rabbitmq.username is used."
+    },
+    {
+      "name": "spring.rabbitmq.stream.virtual-host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Virtual host of a RabbitMQ instance with the Stream plugin enabled. When not set, spring.rabbitmq.virtual-host is used."
+    },
+    {
+      "name": "spring.rabbitmq.template.allowed-list-patterns",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Simple patterns for allowable packages/classes for deserialization."
+    },
+    {
+      "name": "spring.rabbitmq.template.default-receive-queue",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the default queue to receive messages from when none is specified explicitly."
+    },
+    {
+      "name": "spring.rabbitmq.template.exchange",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the default exchange to use for send operations."
+    },
+    {
+      "name": "spring.rabbitmq.template.mandatory",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable mandatory messages."
+    },
+    {
+      "name": "spring.rabbitmq.template.observation-enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable observation.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.template.queue",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.rabbitmq.template.default-receive-queue"
+      }
+    },
+    {
+      "name": "spring.rabbitmq.template.receive-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for receive() operations."
+    },
+    {
+      "name": "spring.rabbitmq.template.reply-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Timeout for sendAndReceive() operations."
+    },
+    {
+      "name": "spring.rabbitmq.template.retry.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether publishing retries are enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rabbitmq.template.retry.initial-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Duration between the first and second attempt to deliver a message.",
+      "defaultValue": "1000ms"
+    },
+    {
+      "name": "spring.rabbitmq.template.retry.max-attempts",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of attempts to deliver a message.",
+      "defaultValue": "3"
+    },
+    {
+      "name": "spring.rabbitmq.template.retry.max-interval",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum duration between attempts.",
+      "defaultValue": "10000ms"
+    },
+    {
+      "name": "spring.rabbitmq.template.retry.multiplier",
+      "schema": {
+        "format": "double",
+        "type": "number"
+      },
+      "typeName": "java.lang.Double",
+      "description": "Multiplier to apply to the previous retry interval.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.rabbitmq.template.routing-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Value of a default routing key to use for send operations."
+    },
+    {
+      "name": "spring.rabbitmq.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Login user to authenticate to the broker.",
+      "defaultValue": "guest"
+    },
+    {
+      "name": "spring.rabbitmq.virtual-host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Virtual host to use when connecting to the broker."
+    },
+    {
+      "name": "spring.reactor.context-propagation",
+      "schema": {
+        "enum": [
+          "AUTO",
+          "LIMITED"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.reactor.ReactorProperties$ContextPropagationMode",
+      "description": "Context Propagation support mode for Reactor operators.",
+      "defaultValue": "limited"
+    },
+    {
+      "name": "spring.reactor.netty.shutdown-quiet-period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Amount of time to wait before shutting down resources."
+    },
+    {
+      "name": "spring.reactor.stacktrace-mode.enabled",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether Reactor should collect stacktrace information at runtime.",
+      "defaultValue": "false",
+      "deprecation": {
+        "replacement": "spring.reactor.debug-agent.enabled"
+      }
+    },
+    {
+      "name": "spring.redis.client-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.redis.client-name"
+      }
+    },
+    {
+      "name": "spring.redis.client-type",
+      "schema": {
+        "enum": [
+          "JEDIS",
+          "LETTUCE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.data.redis.RedisProperties$ClientType",
+      "deprecation": {
+        "replacement": "spring.data.redis.client-type"
+      }
+    },
+    {
+      "name": "spring.redis.cluster.max-redirects",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.data.redis.cluster.max-redirects"
+      }
+    },
+    {
+      "name": "spring.redis.cluster.nodes",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "deprecation": {
+        "replacement": "spring.data.redis.cluster.nodes"
+      }
+    },
+    {
+      "name": "spring.redis.connect-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.data.redis.connect-timeout"
+      }
+    },
+    {
+      "name": "spring.redis.database",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.data.redis.database"
+      }
+    },
+    {
+      "name": "spring.redis.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.redis.host"
+      }
+    },
+    {
+      "name": "spring.redis.jedis.pool.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.jedis.pool.max-active",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.jedis.pool.max-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.jedis.pool.max-wait",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.jedis.pool.min-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.jedis.pool.time-between-eviction-runs",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.lettuce.cluster.refresh.adaptive",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.data.redis.lettuce.cluster.refresh.adaptive"
+      }
+    },
+    {
+      "name": "spring.redis.lettuce.cluster.refresh.dynamic-refresh-sources",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.data.redis.lettuce.cluster.refresh.dynamic-refresh-sources"
+      }
+    },
+    {
+      "name": "spring.redis.lettuce.cluster.refresh.period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.data.redis.lettuce.cluster.refresh.period"
+      }
+    },
+    {
+      "name": "spring.redis.lettuce.pool.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.lettuce.pool.max-active",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.lettuce.pool.max-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.lettuce.pool.max-wait",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.lettuce.pool.min-idle",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.lettuce.pool.time-between-eviction-runs",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.redis.lettuce.shutdown-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.data.redis.lettuce.shutdown-timeout"
+      }
+    },
+    {
+      "name": "spring.redis.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.redis.password"
+      }
+    },
+    {
+      "name": "spring.redis.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "deprecation": {
+        "replacement": "spring.data.redis.port"
+      }
+    },
+    {
+      "name": "spring.redis.sentinel.master",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.redis.sentinel.master"
+      }
+    },
+    {
+      "name": "spring.redis.sentinel.nodes",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "deprecation": {
+        "replacement": "spring.data.redis.sentinel.nodes"
+      }
+    },
+    {
+      "name": "spring.redis.sentinel.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.redis.sentinel.password"
+      }
+    },
+    {
+      "name": "spring.redis.sentinel.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.redis.sentinel.username"
+      }
+    },
+    {
+      "name": "spring.redis.ssl",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.data.redis.ssl"
+      }
+    },
+    {
+      "name": "spring.redis.timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.data.redis.timeout"
+      }
+    },
+    {
+      "name": "spring.redis.url",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.redis.url"
+      }
+    },
+    {
+      "name": "spring.redis.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.data.redis.username"
+      }
+    },
+    {
+      "name": "spring.resources.add-mappings",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.add-mappings"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.cache-private",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.cache-private"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.cache-public",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.cache-public"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.max-age",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.max-age"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.must-revalidate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.must-revalidate"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.no-cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.no-cache"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.no-store",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.no-store"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.no-transform",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.no-transform"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.proxy-revalidate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.proxy-revalidate"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.s-max-age",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.s-max-age"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.stale-if-error",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.stale-if-error"
+      }
+    },
+    {
+      "name": "spring.resources.cache.cachecontrol.stale-while-revalidate",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.cachecontrol.stale-while-revalidate"
+      }
+    },
+    {
+      "name": "spring.resources.cache.period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.period"
+      }
+    },
+    {
+      "name": "spring.resources.cache.use-last-modified",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.cache.use-last-modified"
+      }
+    },
+    {
+      "name": "spring.resources.chain.cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.cache"
+      }
+    },
+    {
+      "name": "spring.resources.chain.compressed",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.compressed"
+      }
+    },
+    {
+      "name": "spring.resources.chain.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.enabled"
+      }
+    },
+    {
+      "name": "spring.resources.chain.gzipped",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.compressed"
+      }
+    },
+    {
+      "name": "spring.resources.chain.html-application-cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {}
+    },
+    {
+      "name": "spring.resources.chain.strategy.content.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.strategy.content.enabled"
+      }
+    },
+    {
+      "name": "spring.resources.chain.strategy.content.paths",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.strategy.content.paths"
+      }
+    },
+    {
+      "name": "spring.resources.chain.strategy.fixed.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.strategy.fixed.enabled"
+      }
+    },
+    {
+      "name": "spring.resources.chain.strategy.fixed.paths",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.strategy.fixed.paths"
+      }
+    },
+    {
+      "name": "spring.resources.chain.strategy.fixed.version",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.web.resources.chain.strategy.fixed.version"
+      }
+    },
+    {
+      "name": "spring.resources.static-locations",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "deprecation": {
+        "replacement": "spring.web.resources.static-locations"
+      }
+    },
+    {
+      "name": "spring.rsocket.server.address",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.net.InetAddress",
+      "description": "Network address to which the server should bind."
+    },
+    {
+      "name": "spring.rsocket.server.fragment-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum transmission unit. Frames larger than the specified value are fragmented."
+    },
+    {
+      "name": "spring.rsocket.server.mapping-path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path under which RSocket handles requests (only works with websocket transport)."
+    },
+    {
+      "name": "spring.rsocket.server.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Server port."
+    },
+    {
+      "name": "spring.rsocket.server.spec.compress",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the websocket compression extension is enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rsocket.server.spec.handle-ping",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to proxy websocket ping frames or respond to them.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.rsocket.server.spec.max-frame-payload-length",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum allowable frame payload length.",
+      "defaultValue": "65536B"
+    },
+    {
+      "name": "spring.rsocket.server.spec.protocols",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Sub-protocols to use in websocket handshake signature."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.bundle",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of a configured SSL bundle."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.certificate",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to a PEM-encoded SSL certificate file."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.certificate-private-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to a PEM-encoded private key file for the SSL certificate."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.ciphers",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Supported SSL ciphers."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.client-auth",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Client authentication mode. Requires a trust store."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.enabled",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Whether to enable SSL support.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.rsocket.server.ssl.enabled-protocols",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Enabled SSL protocols."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.key-alias",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Alias that identifies the key in the key store."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.key-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the key in the key store."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.key-store",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the key store that holds the SSL certificate (typically a jks file)."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.key-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the key store."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.key-store-provider",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Provider for the key store."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.key-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the key store."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.protocol",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SSL protocol to use.",
+      "defaultValue": "TLS"
+    },
+    {
+      "name": "spring.rsocket.server.ssl.server-name-bundles",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Mapping of host names to SSL bundles for SNI configuration."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.trust-certificate",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to a PEM-encoded SSL certificate authority file."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.trust-certificate-private-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to a PEM-encoded private key file for the SSL certificate authority."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.trust-store",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Trust store that holds SSL certificates."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.trust-store-password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password used to access the trust store."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.trust-store-provider",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Provider for the trust store."
+    },
+    {
+      "name": "spring.rsocket.server.ssl.trust-store-type",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Type of the trust store."
+    },
+    {
+      "name": "spring.rsocket.server.transport",
+      "schema": {
+        "enum": [
+          "TCP",
+          "WEBSOCKET"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.rsocket.server.RSocketServer$Transport",
+      "description": "RSocket transport protocol.",
+      "defaultValue": "tcp"
+    },
+    {
+      "name": "spring.security.filter.dispatcher-types",
+      "schema": {
+        "items": {
+          "enum": [
+            "ASYNC",
+            "ERROR",
+            "FORWARD",
+            "INCLUDE",
+            "REQUEST"
+          ],
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.Set<org.springframework.boot.web.servlet.DispatcherType>",
+      "description": "Security filter chain dispatcher types for Servlet-based web applications.",
+      "defaultValue": "async, error, forward, include, request"
+    },
+    {
+      "name": "spring.security.filter.order",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Security filter chain order for Servlet-based web applications.",
+      "defaultValue": "-100"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.client",
+      "schema": {
+        "additionalProperties": {
+          "properties": {
+            "tokenEndpointAuthenticationSigningAlgorithm": {
+              "type": "string"
+            },
+            "jwkSetUri": {
+              "type": "string"
+            },
+            "requireProofKey": {
+              "type": "boolean"
+            },
+            "token": {
+              "properties": {
+                "accessTokenTimeToLive": {
+                  "format": "duration",
+                  "type": "string"
+                },
+                "accessTokenFormat": {
+                  "type": "string"
+                },
+                "deviceCodeTimeToLive": {
+                  "format": "duration",
+                  "type": "string"
+                },
+                "authorizationCodeTimeToLive": {
+                  "format": "duration",
+                  "type": "string"
+                },
+                "reuseRefreshTokens": {
+                  "type": "boolean"
+                },
+                "refreshTokenTimeToLive": {
+                  "format": "duration",
+                  "type": "string"
+                },
+                "idTokenSignatureAlgorithm": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "reuseRefreshTokens"
+              ],
+              "type": "object"
+            },
+            "requireAuthorizationConsent": {
+              "type": "boolean"
+            },
+            "registration": {
+              "properties": {
+                "clientAuthenticationMethods": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "redirectUris": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "clientName": {
+                  "type": "string"
+                },
+                "clientId": {
+                  "type": "string"
+                },
+                "authorizationGrantTypes": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "clientSecret": {
+                  "type": "string"
+                },
+                "postLogoutRedirectUris": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "scopes": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "requireAuthorizationConsent",
+            "requireProofKey"
+          ],
+          "type": "object"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,org.springframework.boot.autoconfigure.security.oauth2.server.servlet.OAuth2AuthorizationServerProperties$Client>",
+      "description": "Registered clients of the Authorization Server."
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.authorization-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OAuth 2.0 Authorization Endpoint.",
+      "defaultValue": "/oauth2/authorize"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.device-authorization-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OAuth 2.0 Device Authorization Endpoint.",
+      "defaultValue": "/oauth2/device_authorization"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.device-verification-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OAuth 2.0 Device Verification Endpoint.",
+      "defaultValue": "/oauth2/device_verification"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.jwk-set-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's JWK Set Endpoint.",
+      "defaultValue": "/oauth2/jwks"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.oidc.client-registration-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OpenID Connect 1.0 Client Registration Endpoint.",
+      "defaultValue": "/connect/register"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.oidc.logout-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OpenID Connect 1.0 Logout Endpoint.",
+      "defaultValue": "/connect/logout"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.oidc.user-info-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OpenID Connect 1.0 UserInfo Endpoint.",
+      "defaultValue": "/userinfo"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.pushed-authorization-request-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OAuth 2.0 Pushed Authorization Request Endpoint.",
+      "defaultValue": "/oauth2/par"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.token-introspection-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OAuth 2.0 Token Introspection Endpoint.",
+      "defaultValue": "/oauth2/introspect"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.token-revocation-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OAuth 2.0 Token Revocation Endpoint.",
+      "defaultValue": "/oauth2/revoke"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.endpoint.token-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Authorization Server's OAuth 2.0 Token Endpoint.",
+      "defaultValue": "/oauth2/token"
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.issuer",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "URL of the Authorization Server's Issuer Identifier."
+    },
+    {
+      "name": "spring.security.oauth2.authorizationserver.multiple-issuers-allowed",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether multiple issuers are allowed per host. Using path components in the URL of the issuer identifier enables supporting multiple issuers per host in a multi-tenant hosting configuration.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.security.oauth2.client.provider",
+      "schema": {
+        "additionalProperties": {
+          "properties": {
+            "issuerUri": {
+              "type": "string"
+            },
+            "userNameAttribute": {
+              "type": "string"
+            },
+            "userInfoAuthenticationMethod": {
+              "type": "string"
+            },
+            "jwkSetUri": {
+              "type": "string"
+            },
+            "userInfoUri": {
+              "type": "string"
+            },
+            "authorizationUri": {
+              "type": "string"
+            },
+            "tokenUri": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties$Provider>",
+      "description": "OAuth provider details."
+    },
+    {
+      "name": "spring.security.oauth2.client.registration",
+      "schema": {
+        "additionalProperties": {
+          "properties": {
+            "redirectUri": {
+              "type": "string"
+            },
+            "provider": {
+              "type": "string"
+            },
+            "scope": {
+              "items": {
+                "type": "object"
+              },
+              "type": "array"
+            },
+            "clientAuthenticationMethod": {
+              "type": "string"
+            },
+            "clientName": {
+              "type": "string"
+            },
+            "clientId": {
+              "type": "string"
+            },
+            "clientSecret": {
+              "type": "string"
+            },
+            "authorizationGrantType": {
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientProperties$Registration>",
+      "description": "OAuth client registrations."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.audiences",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Identifies the recipients that the JWT is intended for."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.authorities-claim-delimiter",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Regex to use for splitting the value of the authorities claim into authorities."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.authorities-claim-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of token claim to use for mapping authorities from JWT."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.authority-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix to use for authorities mapped from JWT."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.issuer-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "URI that can either be an OpenID Connect discovery endpoint or an OAuth 2.0 Authorization Server Metadata endpoint defined by RFC 8414."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.jwk-set-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JSON Web Key URI to use to verify the JWT token."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.jws-algorithm",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "deprecation": {
+        "replacement": "spring.security.oauth2.resourceserver.jwt.jws-algorithms"
+      }
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.jws-algorithms",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "JSON Web Algorithms used for verifying the digital signatures.",
+      "defaultValue": "RS256"
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.principal-claim-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "JWT principal claim name."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.jwt.public-key-location",
+      "schema": {
+        "format": "resource",
+        "type": "string"
+      },
+      "typeName": "org.springframework.core.io.Resource",
+      "description": "Location of the file containing the public key used to verify a JWT."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.opaquetoken.client-id",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Client id used to authenticate with the token introspection endpoint."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.opaquetoken.client-secret",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Client secret used to authenticate with the token introspection endpoint."
+    },
+    {
+      "name": "spring.security.oauth2.resourceserver.opaquetoken.introspection-uri",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "OAuth 2.0 endpoint through which token introspection is accomplished."
+    },
+    {
+      "name": "spring.security.saml2.relyingparty.registration",
+      "schema": {
+        "additionalProperties": {
+          "properties": {
+            "entityId": {
+              "type": "string"
+            },
+            "assertingparty": {
+              "properties": {
+                "metadataUri": {
+                  "type": "string"
+                },
+                "singlesignon": {
+                  "type": "object"
+                },
+                "verification": {
+                  "properties": {
+                    "credentials": {
+                      "items": {
+                        "type": "object"
+                      },
+                      "type": "array"
+                    }
+                  },
+                  "type": "object"
+                },
+                "singlelogout": {
+                  "type": "object"
+                },
+                "entityId": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "signing": {
+              "properties": {
+                "credentials": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "decryption": {
+              "properties": {
+                "credentials": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "nameIdFormat": {
+              "type": "string"
+            },
+            "singlelogout": {
+              "type": "object"
+            },
+            "acs": {
+              "type": "object"
+            }
+          },
+          "type": "object"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,org.springframework.boot.autoconfigure.security.saml2.Saml2RelyingPartyProperties$Registration>",
+      "description": "SAML2 relying party registrations."
+    },
+    {
+      "name": "spring.security.user.name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Default user name.",
+      "defaultValue": "user"
+    },
+    {
+      "name": "spring.security.user.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password for the default user name."
+    },
+    {
+      "name": "spring.security.user.roles",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Granted roles for the default user name."
+    },
+    {
+      "name": "spring.sendgrid.api-key",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SendGrid API key."
+    },
+    {
+      "name": "spring.sendgrid.proxy.host",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "SendGrid proxy host."
+    },
+    {
+      "name": "spring.sendgrid.proxy.port",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "SendGrid proxy port."
+    },
+    {
+      "name": "spring.servlet.multipart.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable support of multipart uploads.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.servlet.multipart.file-size-threshold",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Threshold after which files are written to disk.",
+      "defaultValue": "0B"
+    },
+    {
+      "name": "spring.servlet.multipart.location",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Intermediate location of uploaded files."
+    },
+    {
+      "name": "spring.servlet.multipart.max-file-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Max file size.",
+      "defaultValue": "1MB"
+    },
+    {
+      "name": "spring.servlet.multipart.max-request-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Max request size.",
+      "defaultValue": "10MB"
+    },
+    {
+      "name": "spring.servlet.multipart.resolve-lazily",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to resolve the multipart request lazily at the time of file or parameter access.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.servlet.multipart.strict-servlet-compliance",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to resolve the multipart request strictly complying with the Servlet specification, only to be used for \"multipart/form-data\" requests.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.session.hazelcast.flush-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.session.FlushMode",
+      "description": "Sessions flush mode. Determines when session changes are written to the session store.",
+      "defaultValue": "on-save"
+    },
+    {
+      "name": "spring.session.hazelcast.map-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the map used to store sessions.",
+      "defaultValue": "spring:session:sessions"
+    },
+    {
+      "name": "spring.session.hazelcast.save-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.session.SaveMode",
+      "description": "Sessions save mode. Determines how session changes are tracked and saved to the session store.",
+      "defaultValue": "on-set-attribute"
+    },
+    {
+      "name": "spring.session.jdbc.cleanup-cron",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Cron expression for expired session cleanup job.",
+      "defaultValue": "0 * * * * *"
+    },
+    {
+      "name": "spring.session.jdbc.flush-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.session.FlushMode",
+      "description": "Sessions flush mode. Determines when session changes are written to the session store.",
+      "defaultValue": "on-save"
+    },
+    {
+      "name": "spring.session.jdbc.initialize-schema",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "EMBEDDED",
+          "NEVER"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.sql.init.DatabaseInitializationMode",
+      "description": "Database schema initialization mode.",
+      "defaultValue": "embedded"
+    },
+    {
+      "name": "spring.session.jdbc.platform",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Platform to use in initialization scripts if the @@platform@@ placeholder is used. Auto-detected by default."
+    },
+    {
+      "name": "spring.session.jdbc.save-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.session.SaveMode",
+      "description": "Sessions save mode. Determines how session changes are tracked and saved to the session store.",
+      "defaultValue": "on-set-attribute"
+    },
+    {
+      "name": "spring.session.jdbc.schema",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path to the SQL file to use to initialize the database schema.",
+      "defaultValue": "classpath:org/springframework/session/jdbc/schema-@@platform@@.sql"
+    },
+    {
+      "name": "spring.session.jdbc.table-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Name of the database table used to store sessions.",
+      "defaultValue": "SPRING_SESSION"
+    },
+    {
+      "name": "spring.session.mongodb.collection-name",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Collection name used to store sessions.",
+      "defaultValue": "sessions"
+    },
+    {
+      "name": "spring.session.redis.cleanup-cron",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "0 * * * * *"
+    },
+    {
+      "name": "spring.session.redis.configure-action",
+      "schema": {
+        "enum": [
+          "NONE",
+          "NOTIFY_KEYSPACE_EVENTS"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.session.RedisSessionProperties$ConfigureAction",
+      "description": "The configure action to apply when no user-defined ConfigureRedisAction or ConfigureReactiveRedisAction bean is present.",
+      "defaultValue": "notify-keyspace-events"
+    },
+    {
+      "name": "spring.session.redis.flush-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.session.FlushMode",
+      "description": "Sessions flush mode. Determines when session changes are written to the session store. Not supported with a reactive session repository.",
+      "defaultValue": "on-save"
+    },
+    {
+      "name": "spring.session.redis.namespace",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Namespace for keys used to store sessions.",
+      "defaultValue": "spring:session"
+    },
+    {
+      "name": "spring.session.redis.repository-type",
+      "schema": {
+        "enum": [
+          "DEFAULT",
+          "INDEXED"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.session.RedisSessionProperties$RepositoryType",
+      "description": "Type of Redis session repository to configure.",
+      "defaultValue": "default"
+    },
+    {
+      "name": "spring.session.redis.save-mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "org.springframework.session.SaveMode",
+      "description": "Sessions save mode. Determines how session changes are tracked and saved to the session store.",
+      "defaultValue": "on-set-attribute"
+    },
+    {
+      "name": "spring.session.servlet.filter-dispatcher-types",
+      "schema": {
+        "items": {
+          "enum": [
+            "ASYNC",
+            "ERROR",
+            "FORWARD",
+            "INCLUDE",
+            "REQUEST"
+          ],
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.Set<org.springframework.boot.web.servlet.DispatcherType>",
+      "description": "Session repository filter dispatcher types.",
+      "defaultValue": "async, error, request"
+    },
+    {
+      "name": "spring.session.servlet.filter-order",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Session repository filter order."
+    },
+    {
+      "name": "spring.session.timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Session timeout. If a duration suffix is not specified, seconds will be used."
+    },
+    {
+      "name": "spring.sql.init.continue-on-error",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether initialization should continue when an error occurs.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.sql.init.data-locations",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Locations of the data (DML) scripts to apply to the database."
+    },
+    {
+      "name": "spring.sql.init.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether basic script-based initialization of an SQL database is enabled.",
+      "defaultValue": "true",
+      "deprecation": {
+        "replacement": "spring.sql.init.mode"
+      }
+    },
+    {
+      "name": "spring.sql.init.encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Encoding of the schema and data scripts."
+    },
+    {
+      "name": "spring.sql.init.mode",
+      "schema": {
+        "enum": [
+          "ALWAYS",
+          "EMBEDDED",
+          "NEVER"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.sql.init.DatabaseInitializationMode",
+      "description": "Mode to apply when determining whether initialization should be performed.",
+      "defaultValue": "embedded"
+    },
+    {
+      "name": "spring.sql.init.password",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Password of the database to use when applying initialization scripts (if different)."
+    },
+    {
+      "name": "spring.sql.init.platform",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Platform to use in the default schema or data script locations, schema-${platform}.sql and data-${platform}.sql.",
+      "defaultValue": "all"
+    },
+    {
+      "name": "spring.sql.init.schema-locations",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Locations of the schema (DDL) scripts to apply to the database."
+    },
+    {
+      "name": "spring.sql.init.separator",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Statement separator in the schema and data scripts.",
+      "defaultValue": ";"
+    },
+    {
+      "name": "spring.sql.init.username",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Username of the database to use when applying initialization scripts (if different)."
+    },
+    {
+      "name": "spring.ssl.bundle.jks",
+      "schema": {
+        "additionalProperties": {
+          "properties": {
+            "keystore": {
+              "properties": {
+                "provider": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "reloadOnUpdate": {
+              "type": "boolean"
+            },
+            "options": {
+              "properties": {
+                "ciphers": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "enabledProtocols": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "protocol": {
+              "type": "string"
+            },
+            "truststore": {
+              "properties": {
+                "provider": {
+                  "type": "string"
+                },
+                "type": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                },
+                "location": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "key": {
+              "properties": {
+                "alias": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "reloadOnUpdate"
+          ],
+          "type": "object"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,org.springframework.boot.autoconfigure.ssl.JksSslBundleProperties>",
+      "description": "Java keystore SSL trust material."
+    },
+    {
+      "name": "spring.ssl.bundle.pem",
+      "schema": {
+        "additionalProperties": {
+          "properties": {
+            "keystore": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "verifyKeys": {
+                  "type": "boolean"
+                },
+                "privateKey": {
+                  "type": "string"
+                },
+                "privateKeyPassword": {
+                  "type": "string"
+                },
+                "certificate": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "verifyKeys"
+              ],
+              "type": "object"
+            },
+            "reloadOnUpdate": {
+              "type": "boolean"
+            },
+            "options": {
+              "properties": {
+                "ciphers": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                },
+                "enabledProtocols": {
+                  "items": {
+                    "type": "object"
+                  },
+                  "type": "array"
+                }
+              },
+              "type": "object"
+            },
+            "protocol": {
+              "type": "string"
+            },
+            "truststore": {
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "verifyKeys": {
+                  "type": "boolean"
+                },
+                "privateKey": {
+                  "type": "string"
+                },
+                "privateKeyPassword": {
+                  "type": "string"
+                },
+                "certificate": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "verifyKeys"
+              ],
+              "type": "object"
+            },
+            "key": {
+              "properties": {
+                "alias": {
+                  "type": "string"
+                },
+                "password": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            }
+          },
+          "required": [
+            "reloadOnUpdate"
+          ],
+          "type": "object"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,org.springframework.boot.autoconfigure.ssl.PemSslBundleProperties>",
+      "description": "PEM-encoded SSL trust material."
+    },
+    {
+      "name": "spring.ssl.bundle.watch.file.quiet-period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Quiet period, after which changes are detected.",
+      "defaultValue": "10s"
+    },
+    {
+      "name": "spring.task.execution.mode",
+      "schema": {
+        "enum": [
+          "AUTO",
+          "FORCE"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.task.TaskExecutionProperties$Mode",
+      "description": "Determine when the task executor is to be created.",
+      "defaultValue": "auto"
+    },
+    {
+      "name": "spring.task.execution.pool.allow-core-thread-timeout",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether core threads are allowed to time out. This enables dynamic growing and shrinking of the pool. Doesn't have an effect if virtual threads are enabled.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.task.execution.pool.core-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Core number of threads. Doesn't have an effect if virtual threads are enabled.",
+      "defaultValue": "8"
+    },
+    {
+      "name": "spring.task.execution.pool.keep-alive",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Time limit for which threads may remain idle before being terminated. Doesn't have an effect if virtual threads are enabled.",
+      "defaultValue": "60s"
+    },
+    {
+      "name": "spring.task.execution.pool.max-size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum allowed number of threads. If tasks are filling up the queue, the pool can expand up to that size to accommodate the load. Ignored if the queue is unbounded. Doesn't have an effect if virtual threads are enabled."
+    },
+    {
+      "name": "spring.task.execution.pool.queue-capacity",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Queue capacity. An unbounded capacity does not increase the pool and therefore ignores the \"max-size\" property. Doesn't have an effect if virtual threads are enabled."
+    },
+    {
+      "name": "spring.task.execution.pool.shutdown.accept-tasks-after-context-close",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to accept further tasks after the application context close phase has begun.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.task.execution.shutdown.await-termination",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the executor should wait for scheduled tasks to complete on shutdown.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.task.execution.shutdown.await-termination-period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time the executor should wait for remaining tasks to complete."
+    },
+    {
+      "name": "spring.task.execution.simple.concurrency-limit",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Set the maximum number of parallel accesses allowed. -1 indicates no concurrency limit at all."
+    },
+    {
+      "name": "spring.task.execution.simple.reject-tasks-when-limit-reached",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to reject tasks when the concurrency limit has been reached.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.task.execution.thread-name-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix to use for the names of newly created threads.",
+      "defaultValue": "task-"
+    },
+    {
+      "name": "spring.task.scheduling.pool.size",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum allowed number of threads. Doesn't have an effect if virtual threads are enabled.",
+      "defaultValue": "1"
+    },
+    {
+      "name": "spring.task.scheduling.shutdown.await-termination",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether the executor should wait for scheduled tasks to complete on shutdown.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.task.scheduling.shutdown.await-termination-period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time the executor should wait for remaining tasks to complete."
+    },
+    {
+      "name": "spring.task.scheduling.simple.concurrency-limit",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Set the maximum number of parallel accesses allowed. -1 indicates no concurrency limit at all."
+    },
+    {
+      "name": "spring.task.scheduling.thread-name-prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Prefix to use for the names of newly created threads.",
+      "defaultValue": "scheduling-"
+    },
+    {
+      "name": "spring.threads.virtual.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to use virtual threads.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.thymeleaf.cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable template caching.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.thymeleaf.check-template",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to check that the template exists before rendering it.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.thymeleaf.check-template-location",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to check that the templates location exists.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.thymeleaf.enable-spring-el-compiler",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Enable the SpringEL compiler in SpringEL expressions.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.thymeleaf.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Thymeleaf view resolution for Web frameworks.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.thymeleaf.encoding",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Template files encoding.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.thymeleaf.excluded-view-names",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "List of view names (patterns allowed) that should be excluded from resolution."
+    },
+    {
+      "name": "spring.thymeleaf.mode",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Template mode to be applied to templates. See also Thymeleaf's TemplateMode enum.",
+      "defaultValue": "HTML"
+    },
+    {
+      "name": "spring.thymeleaf.prefix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": "classpath:/templates/"
+    },
+    {
+      "name": "spring.thymeleaf.reactive.chunked-mode-view-names",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Comma-separated list of view names (patterns allowed) that should be the only ones executed in CHUNKED mode when a max chunk size is set."
+    },
+    {
+      "name": "spring.thymeleaf.reactive.full-mode-view-names",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Comma-separated list of view names (patterns allowed) that should be executed in FULL mode even if a max chunk size is set."
+    },
+    {
+      "name": "spring.thymeleaf.reactive.max-chunk-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum size of data buffers used for writing to the response. Templates will execute in CHUNKED mode by default if this is set.",
+      "defaultValue": "0B"
+    },
+    {
+      "name": "spring.thymeleaf.reactive.media-types",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.util.List<org.springframework.http.MediaType>",
+      "description": "Media types supported by the view technology.",
+      "defaultValue": "text/html, application/xhtml+xml, application/xml, text/xml, application/rss+xml, application/atom+xml, application/javascript, application/ecmascript, text/javascript, text/ecmascript, application/json, text/css, text/plain, text/event-stream"
+    },
+    {
+      "name": "spring.thymeleaf.render-hidden-markers-before-checkboxes",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether hidden form inputs acting as markers for checkboxes should be rendered before the checkbox element itself.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.thymeleaf.servlet.content-type",
+      "schema": {
+        "format": "mime-type",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.MimeType",
+      "description": "Content-Type value written to HTTP responses.",
+      "defaultValue": "text/html"
+    },
+    {
+      "name": "spring.thymeleaf.servlet.produce-partial-output-while-processing",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether Thymeleaf should start writing partial output as soon as possible or buffer until template processing is finished.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.thymeleaf.suffix",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "defaultValue": ".html"
+    },
+    {
+      "name": "spring.thymeleaf.template-resolver-order",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Order of the template resolver in the chain. By default, the template resolver is first in the chain. Order start at 1 and should only be set if you have defined additional \"TemplateResolver\" beans."
+    },
+    {
+      "name": "spring.thymeleaf.view-names",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "List of view names (patterns allowed) that can be resolved."
+    },
+    {
+      "name": "spring.transaction.default-timeout",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Default transaction timeout. If a duration suffix is not specified, seconds will be used."
+    },
+    {
+      "name": "spring.transaction.rollback-on-commit-failure",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to roll back on commit failures."
+    },
+    {
+      "name": "spring.validation.method.adapt-constraint-violations",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to adapt ConstraintViolations to MethodValidationResult.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.web.locale",
+      "schema": {
+        "format": "language",
+        "type": "string"
+      },
+      "typeName": "java.util.Locale",
+      "description": "Locale to use. By default, this locale is overridden by the \"Accept-Language\" header."
+    },
+    {
+      "name": "spring.web.locale-resolver",
+      "schema": {
+        "enum": [
+          "ACCEPT_HEADER",
+          "FIXED"
+        ],
+        "type": "string"
+      },
+      "typeName": "org.springframework.boot.autoconfigure.web.WebProperties$LocaleResolver",
+      "description": "Define how the locale should be resolved.",
+      "defaultValue": "accept-header"
+    },
+    {
+      "name": "spring.web.resources.add-mappings",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable default resource handling.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.cache-private",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Indicate that the response message is intended for a single user and must not be stored by a shared cache."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.cache-public",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Indicate that any cache may store the response."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.max-age",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time the response should be cached, in seconds if no duration suffix is not specified."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.must-revalidate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Indicate that once it has become stale, a cache must not use the response without re-validating it with the server."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.no-cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Indicate that the cached response can be reused only if re-validated with the server."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.no-store",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Indicate to not cache the response in any case."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.no-transform",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Indicate intermediaries (caches and others) that they should not transform the response content."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.proxy-revalidate",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Same meaning as the \"must-revalidate\" directive, except that it does not apply to private caches."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.s-max-age",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time the response should be cached by shared caches, in seconds if no duration suffix is not specified."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.stale-if-error",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time the response may be used when errors are encountered, in seconds if no duration suffix is not specified."
+    },
+    {
+      "name": "spring.web.resources.cache.cachecontrol.stale-while-revalidate",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Maximum time the response can be served after it becomes stale, in seconds if no duration suffix is not specified."
+    },
+    {
+      "name": "spring.web.resources.cache.period",
+      "schema": {
+        "format": "duration",
+        "type": "string"
+      },
+      "typeName": "java.time.Duration",
+      "description": "Cache period for the resources served by the resource handler. If a duration suffix is not specified, seconds will be used. Can be overridden by the 'spring.web.resources.cache.cachecontrol' properties."
+    },
+    {
+      "name": "spring.web.resources.cache.use-last-modified",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether we should use the \"lastModified\" metadata of the files in HTTP caching headers.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.web.resources.chain.cache",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable caching in the Resource chain.",
+      "defaultValue": "true"
+    },
+    {
+      "name": "spring.web.resources.chain.compressed",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable resolution of already compressed resources (gzip, brotli). Checks for a resource name with the '.gz' or '.br' file extensions.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.web.resources.chain.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the Spring Resource Handling chain. By default, disabled unless at least one strategy has been enabled."
+    },
+    {
+      "name": "spring.web.resources.chain.strategy.content.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the content Version Strategy.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.web.resources.chain.strategy.content.paths",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "List of patterns to apply to the content Version Strategy.",
+      "defaultValue": "/**"
+    },
+    {
+      "name": "spring.web.resources.chain.strategy.fixed.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable the fixed Version Strategy.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.web.resources.chain.strategy.fixed.paths",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "List of patterns to apply to the fixed Version Strategy.",
+      "defaultValue": "/**"
+    },
+    {
+      "name": "spring.web.resources.chain.strategy.fixed.version",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Version string to use for the fixed Version Strategy."
+    },
+    {
+      "name": "spring.web.resources.static-locations",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.lang.String[]",
+      "description": "Locations of static resources. Defaults to classpath:[/META-INF/resources/, /resources/, /static/, /public/].",
+      "defaultValue": "classpath:/META-INF/resources/, classpath:/resources/, classpath:/static/, classpath:/public/"
+    },
+    {
+      "name": "spring.webflux.base-path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Base path for all web handlers."
+    },
+    {
+      "name": "spring.webflux.format.date",
+      "schema": {
+        "examples": [
+          "dd/MM/yyyy",
+          "iso"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Date format to use, for example 'dd/MM/yyyy'. Used for formatting of java.util.Date and java.time.LocalDate."
+    },
+    {
+      "name": "spring.webflux.format.date-time",
+      "schema": {
+        "examples": [
+          "iso",
+          "iso-offset",
+          "yyyy-MM-dd HH:mm:ss"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Date-time format to use, for example 'yyyy-MM-dd HH:mm:ss'. Used for formatting of java.time's LocalDateTime, OffsetDateTime, and ZonedDateTime."
+    },
+    {
+      "name": "spring.webflux.format.time",
+      "schema": {
+        "examples": [
+          "HH:mm:ss",
+          "iso",
+          "iso-offset"
+        ],
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Time format to use, for example 'HH:mm:ss'. Used for formatting of java.time's LocalTime and OffsetTime."
+    },
+    {
+      "name": "spring.webflux.hiddenmethod.filter.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether to enable Spring's HiddenHttpMethodFilter.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.webflux.multipart.file-storage-directory",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Directory used to store file parts larger than 'maxInMemorySize'. Default is a directory named 'spring-multipart' created under the system temporary directory. Ignored when using the PartEvent streaming support."
+    },
+    {
+      "name": "spring.webflux.multipart.headers-charset",
+      "schema": {
+        "format": "charset",
+        "type": "string"
+      },
+      "typeName": "java.nio.charset.Charset",
+      "description": "Character set used to decode headers.",
+      "defaultValue": "UTF-8"
+    },
+    {
+      "name": "spring.webflux.multipart.max-disk-usage-per-part",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum amount of disk space allowed per part. Default is -1 which enforces no limits.",
+      "defaultValue": "-1B"
+    },
+    {
+      "name": "spring.webflux.multipart.max-headers-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum amount of memory allowed per headers section of each part. Set to -1 to enforce no limits.",
+      "defaultValue": "10KB"
+    },
+    {
+      "name": "spring.webflux.multipart.max-in-memory-size",
+      "schema": {
+        "format": "data-size",
+        "type": "string"
+      },
+      "typeName": "org.springframework.util.unit.DataSize",
+      "description": "Maximum amount of memory allowed per part before it's written to disk. Set to -1 to store all contents in memory.",
+      "defaultValue": "256KB"
+    },
+    {
+      "name": "spring.webflux.multipart.max-parts",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Maximum number of parts allowed in a given multipart request. Default is -1 which enforces no limits.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "spring.webflux.multipart.streaming",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "deprecation": {
+        "reason": "Replaced by the PartEventHttpMessageReader and the PartEvent API."
+      }
+    },
+    {
+      "name": "spring.webflux.problemdetails.enabled",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Whether RFC 9457 Problem Details support should be enabled.",
+      "defaultValue": "false"
+    },
+    {
+      "name": "spring.webflux.static-path-pattern",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path pattern used for static resources.",
+      "defaultValue": "/**"
+    },
+    {
+      "name": "spring.webflux.webjars-path-pattern",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path pattern used for WebJar assets.",
+      "defaultValue": "/webjars/**"
+    },
+    {
+      "name": "spring.webservices.path",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Path that serves as the base URI for the services.",
+      "defaultValue": "/services"
+    },
+    {
+      "name": "spring.webservices.servlet.init",
+      "schema": {
+        "additionalProperties": {
+          "type": "string"
+        },
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "typeName": "java.util.Map<java.lang.String,java.lang.String>",
+      "description": "Servlet init parameters to pass to Spring Web Services."
+    },
+    {
+      "name": "spring.webservices.servlet.load-on-startup",
+      "schema": {
+        "format": "int32",
+        "type": "integer"
+      },
+      "typeName": "java.lang.Integer",
+      "description": "Load on startup priority of the Spring Web Services servlet.",
+      "defaultValue": "-1"
+    },
+    {
+      "name": "spring.webservices.wsdl-locations",
+      "schema": {
+        "items": {
+          "type": "string"
+        },
+        "type": "array"
+      },
+      "typeName": "java.util.List<java.lang.String>",
+      "description": "Comma-separated list of locations of WSDLs and accompanying XSDs to be exposed as beans."
+    }
+  ]
+}


### PR DESCRIPTION
Adds `POST /namespaces/{ns}/services/{svc}/releases/{id}/artifacts`, accepting the plugin's own `ArtifactMetadata` directly as the request body, Jackson already knows how to deserialize it via the registered Artifactory module, so there's no wrapper DTO or multipart handling.

Uploaded properties are exploded into `service_configuration_catalog`, replacing any rows already there for that coordinate on re-upload, and the matching `service_artifacts` row's checksum is updated to `metadata.checksum()`, the signal that the coordinate is now settled.

Uploads for coordinates never declared via the resolve endpoint are rejected with 404 (`UndeclaredArtifactException`), and uploads against a release that is no longer pending are rejected with 409 (`ReleaseNotPendingException`).
