### PR TITLE
Complete service releases and promote local artifacts once indexed by the Artifactory

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -321,6 +321,16 @@ class AuditEventListener {
 		});
 	}
 
+	@TransactionalEventListener(id = "audit.service-release-failed", classes = ServiceEvent.ReleaseFailed.class)
+	void on(ServiceEvent.ReleaseFailed event) {
+		insert(event, builder -> builder
+				.entityType("service")
+				.entityId(event.id())
+				.eventType("service.release-failed")
+				.details("errors", event.errors())
+		);
+	}
+
 	@TransactionalEventListener(id = "audit.service-deleted", classes = ServiceEvent.Deleted.class)
 	void on(ServiceEvent.Deleted event) {
 		insert(event, builder -> builder

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -1,7 +1,6 @@
 package com.konfigyr.audit;
 
 import com.konfigyr.account.AccountEvent;
-import com.konfigyr.artifactory.Artifact;
 import com.konfigyr.artifactory.ArtifactCoordinates;
 import com.konfigyr.artifactory.ArtifactoryEvent;
 import com.konfigyr.entity.EntityEvent;
@@ -23,11 +22,14 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.context.event.EventListener;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.util.CollectionUtils;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
 import static com.konfigyr.data.tables.Services.SERVICES;
 
@@ -308,16 +310,13 @@ class AuditEventListener {
 	@TransactionalEventListener(id = "audit.service-released", classes = ServiceEvent.Released.class)
 	void on(ServiceEvent.Released event) {
 		insert(event, builder -> {
-			final List<String> artifacts = new ArrayList<>();
-
-			for (Artifact artifact : event.manifest().artifacts()) {
-				artifacts.add(ArtifactCoordinates.of(artifact).format());
-			}
+			final List<String> artifacts = toSecureList(event.manifest().artifacts(),
+					artifact -> ArtifactCoordinates.of(artifact).format());
 
 			builder.entityType("service")
 					.entityId(event.id())
 					.eventType("service.released")
-					.details("artifacts", Collections.unmodifiableList(artifacts));
+					.details("artifacts", artifacts);
 		});
 	}
 
@@ -327,7 +326,7 @@ class AuditEventListener {
 				.entityType("service")
 				.entityId(event.id())
 				.eventType("service.release-failed")
-				.details("errors", event.errors())
+				.details("errors", toSecureList(event.errors()))
 		);
 	}
 
@@ -514,6 +513,51 @@ class AuditEventListener {
 				log.error("Failed to persist audit event: {}", event, ex);
 			}
 		});
+	}
+
+	/**
+	 * Copies the given {@code collection} into a plain {@link ArrayList} before it is stored as an
+	 * {@link AuditEvent} detail.
+	 * <p>
+	 * Audit event details are serialized using a Jackson mapper hardened with Spring Security's
+	 * {@code SecurityJacksonModules}, which installs a {@code PolymorphicTypeValidator} that only
+	 * allows a curated subset of types to be (de)serialized polymorphically. Collections such as the
+	 * ones returned by {@link List#of} or {@link java.util.stream.Stream#toList()} are backed by
+	 * JDK-internal {@code ImmutableCollections} types that are not part of that allow-list, so passing
+	 * them straight through would fail serialization. Re-collecting into a plain {@link ArrayList}
+	 * guarantees the stored value is always a type the validator recognizes.
+	 *
+	 * @param collection the collection to convert, can be {@literal null} or empty
+	 * @return an unmodifiable {@link ArrayList} copy of the given collection, never {@literal null}
+	 */
+	private static <T> List<T> toSecureList(@Nullable Collection<T> collection) {
+		return toSecureList(collection, Function.identity());
+	}
+
+	/**
+	 * Maps each element of the given {@code collection} with the supplied {@code mapper} and copies the
+	 * result into a plain {@link ArrayList} before it is stored as an {@link AuditEvent} detail.
+	 * <p>
+	 * See {@link #toSecureList(Collection)} for why this copy is necessary: the mapped result must land
+	 * in a type accepted by the {@code PolymorphicTypeValidator} that guards the audit Jackson mapper,
+	 * rather than whatever collection type {@code mapper} or the caller happened to produce.
+	 *
+	 * @param collection the collection to convert, can be {@literal null} or empty
+	 * @param mapper the function applied to each element, can't be {@literal null}
+	 * @return an unmodifiable {@link ArrayList} of the mapped elements, never {@literal null}
+	 */
+	private static <T, R> List<R> toSecureList(@Nullable Collection<T> collection, Function<T, R> mapper) {
+		if (CollectionUtils.isEmpty(collection)) {
+			return Collections.emptyList();
+		}
+
+		final List<R> list = new ArrayList<>(collection.size());
+
+		for (T entry : collection) {
+			list.add(mapper.apply(entry));
+		}
+
+		return Collections.unmodifiableList(list);
 	}
 
 	/**

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -528,6 +528,7 @@ class AuditEventListener {
 	 * guarantees the stored value is always a type the validator recognizes.
 	 *
 	 * @param collection the collection to convert, can be {@literal null} or empty
+	 * @param <T> the type of elements in the collection
 	 * @return an unmodifiable {@link ArrayList} copy of the given collection, never {@literal null}
 	 */
 	private static <T> List<T> toSecureList(@Nullable Collection<T> collection) {
@@ -544,6 +545,8 @@ class AuditEventListener {
 	 *
 	 * @param collection the collection to convert, can be {@literal null} or empty
 	 * @param mapper the function applied to each element, can't be {@literal null}
+	 * @param <T> the type of elements in the source collection
+	 * @param <R> the type of elements in the secured collection
 	 * @return an unmodifiable {@link ArrayList} of the mapped elements, never {@literal null}
 	 */
 	private static <T, R> List<R> toSecureList(@Nullable Collection<T> collection, Function<T, R> mapper) {

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
@@ -4,7 +4,6 @@ import com.konfigyr.artifactory.*;
 import com.konfigyr.data.PageableExecutor;
 import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
-import com.konfigyr.io.ByteArray;
 import com.konfigyr.namespace.catalog.ServiceCatalogSource;
 import com.konfigyr.support.SearchQuery;
 import com.konfigyr.support.Slug;
@@ -22,23 +21,16 @@ import org.jspecify.annotations.NonNull;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
-import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
 import static com.konfigyr.data.tables.Services.SERVICES;
-import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
-import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
 
 @Slf4j
 @RequiredArgsConstructor
 class DefaultServices implements Services {
-
-	private static final Name SERVICE_ARTIFACTS_ALIAS = DSL.name("artifacts");
 
 	private final Marker CREATED = MarkerFactory.getMarker("SERVICE_CREATED");
 
@@ -187,19 +179,6 @@ class DefaultServices implements Services {
 
 	@NonNull
 	@Override
-	@Transactional(readOnly = true, label = "retrieve-service-manifest")
-	public Manifest manifest(@NonNull Service service) {
-		return createManifestQuery(SERVICE_RELEASES.SERVICE_ID.eq(service.id().get()))
-			.fetchOptional(DefaultServices::toManifest)
-			.orElseGet(() -> Manifest.builder()
-					.id(service.id().serialize())
-					.name(service.name())
-					.build()
-			);
-	}
-
-	@NonNull
-	@Override
 	@Transactional(readOnly = true, label = "retrieve-service-catalog")
 	public ServiceCatalog catalog(@NonNull EntityId id) {
 		final Service service = get(id).orElseThrow(() -> new ServiceNotFoundException(id));
@@ -260,47 +239,8 @@ class DefaultServices implements Services {
 	}
 
 	@NonNull
-	private SelectConditionStep<? extends Record> createManifestQuery(@NonNull Condition condition) {
-		return context.select(SERVICE_RELEASES.ID, SERVICES.NAME, SERVICE_RELEASES.CREATED_AT, createServiceArtifactMultiselectField())
-				.from(SERVICE_RELEASES)
-				.innerJoin(SERVICES)
-				.on(SERVICES.ID.eq(SERVICE_RELEASES.SERVICE_ID))
-				.where(condition);
-	}
-
-	@NonNull
 	private Optional<Service> fetch(@NonNull Condition condition) {
 		return createServicesQuery(condition).fetchOptional(DefaultServices::toService);
-	}
-
-	private Field<List<Artifact>> createServiceArtifactMultiselectField() {
-		return DSL.multiset(
-				DSL.select(
-						SERVICE_ARTIFACTS.GROUP_ID,
-						SERVICE_ARTIFACTS.ARTIFACT_ID,
-						SERVICE_ARTIFACTS.VERSION,
-						SERVICE_ARTIFACTS.SOURCE,
-						SERVICE_ARTIFACTS.CHECKSUM,
-						ARTIFACTS.NAME,
-						ARTIFACTS.DESCRIPTION,
-						ARTIFACTS.WEBSITE,
-						ARTIFACTS.REPOSITORY,
-						ARTIFACTS.CREATED_AT,
-						ARTIFACT_VERSIONS.CHECKSUM
-				)
-				.from(SERVICE_ARTIFACTS)
-				.leftJoin(ARTIFACTS)
-				.on(DSL.and(
-						ARTIFACTS.GROUP_ID.eq(SERVICE_ARTIFACTS.GROUP_ID),
-						ARTIFACTS.ARTIFACT_ID.eq(SERVICE_ARTIFACTS.ARTIFACT_ID)
-				))
-				.leftJoin(ARTIFACT_VERSIONS)
-				.on(DSL.and(
-						ARTIFACT_VERSIONS.ARTIFACT_ID.eq(ARTIFACTS.ID),
-						ARTIFACT_VERSIONS.VERSION.eq(SERVICE_ARTIFACTS.VERSION)
-				))
-				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(SERVICE_RELEASES.ID))
-		).as(SERVICE_ARTIFACTS_ALIAS).convertFrom(results -> results.map(DefaultServices::toManifestEntry));
 	}
 
 	@NonNull
@@ -313,41 +253,6 @@ class DefaultServices implements Services {
 				.description(record.get(SERVICES.DESCRIPTION))
 				.createdAt(record.get(SERVICES.CREATED_AT))
 				.updatedAt(record.get(SERVICES.UPDATED_AT))
-				.build();
-	}
-
-	@NonNull
-	@SuppressWarnings("unchecked")
-	private static Manifest toManifest(@NonNull Record record) {
-		return Manifest.builder()
-				.id(record.get(SERVICE_RELEASES.ID, EntityId.class).serialize())
-				.name(record.get(SERVICES.NAME))
-				.artifacts((Iterable<? extends ManifestEntry>) record.get(SERVICE_ARTIFACTS_ALIAS))
-				.createdAt(record.get(SERVICE_RELEASES.CREATED_AT, Instant.class))
-				.build();
-	}
-
-	@NonNull
-	private static ManifestEntry toManifestEntry(@NonNull Record record) {
-		final ArtifactSource source = record.get(SERVICE_ARTIFACTS.SOURCE, ArtifactSource.class);
-
-		// LOCAL artifacts carry their own uploaded metadata checksum; ARTIFACTORY artifacts reuse the
-		// checksum of the indexed artifact version, since service_artifacts.checksum is always null for them
-		final String checksum = source == ArtifactSource.LOCAL
-				? record.get(SERVICE_ARTIFACTS.CHECKSUM)
-				: record.get(ARTIFACT_VERSIONS.CHECKSUM, Converter.from(ByteArray.class, String.class, ByteArray::encodeHex));
-
-		return ManifestEntry.builder()
-				.groupId(record.get(SERVICE_ARTIFACTS.GROUP_ID))
-				.artifactId(record.get(SERVICE_ARTIFACTS.ARTIFACT_ID))
-				.version(record.get(SERVICE_ARTIFACTS.VERSION))
-				.name(record.get(ARTIFACTS.NAME))
-				.description(record.get(ARTIFACTS.DESCRIPTION))
-				.website(record.get(ARTIFACTS.WEBSITE))
-				.repository(record.get(ARTIFACTS.REPOSITORY))
-				.checksum(checksum)
-				.resolvedAt(record.get(ARTIFACTS.CREATED_AT, Instant.class))
-				.source(source)
 				.build();
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/ServiceEvent.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/ServiceEvent.java
@@ -7,6 +7,7 @@ import com.konfigyr.support.Slug;
 import org.jmolecules.event.annotation.DomainEvent;
 import org.jspecify.annotations.NonNull;
 
+import java.util.List;
 import java.util.function.Supplier;
 
 /**
@@ -16,7 +17,8 @@ import java.util.function.Supplier;
  * @since 1.0.0
  **/
 public sealed abstract class ServiceEvent extends EntityEvent implements Supplier<Service>
-		permits ServiceEvent.Created, ServiceEvent.Renamed, ServiceEvent.Released, ServiceEvent.Deleted {
+		permits ServiceEvent.Created, ServiceEvent.Renamed, ServiceEvent.Released, ServiceEvent.ReleaseFailed,
+		ServiceEvent.Deleted {
 
 	protected final Service service;
 
@@ -125,6 +127,38 @@ public sealed abstract class ServiceEvent extends EntityEvent implements Supplie
 		@NonNull
 		public Manifest manifest() {
 			return manifest;
+		}
+	}
+
+	/**
+	 * Event that would be published when a release attempt for a {@link Service} fails, so that
+	 * anything left behind by the attempt can be cleaned up.
+	 */
+	@DomainEvent(name = "service-release-failed", namespace = "namespaces")
+	public static final class ReleaseFailed extends ServiceEvent {
+
+		private final List<String> errors;
+
+		/**
+		 * Create a new {@link ReleaseFailed} event with the {@link EntityId entity identifier} of the
+		 * {@link Service} whose release attempt failed, and the reasons it failed.
+		 *
+		 * @param service the service whose release attempt failed.
+		 * @param errors the errors that caused the release attempt to fail.
+		 */
+		public ReleaseFailed(Service service, List<String> errors) {
+			super(service);
+			this.errors = List.copyOf(errors);
+		}
+
+		/**
+		 * Returns the errors that caused the release attempt to fail.
+		 *
+		 * @return release errors, never {@literal null}.
+		 */
+		@NonNull
+		public List<String> errors() {
+			return errors;
 		}
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/Services.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/Services.java
@@ -1,6 +1,5 @@
 package com.konfigyr.namespace;
 
-import com.konfigyr.artifactory.ArtifactCoordinates;
 import com.konfigyr.artifactory.Manifest;
 import com.konfigyr.artifactory.PropertyDescriptor;
 import com.konfigyr.entity.EntityId;
@@ -86,23 +85,6 @@ public interface Services {
 	 */
 	@DomainEventPublisher(publishes = "namespaces.service-renamed")
 	Service update(EntityId id, ServiceDefinition definition);
-
-	/**
-	 * Returns the current manifest associated with the given service.
-	 * <p>
-	 * A manifest represents the set of {@link ArtifactCoordinates artifacts} that are currently
-	 * used by a specific service within a {@link Namespace}. Each artifact referenced by the
-	 * manifest contributes configuration metadata resolved through the {@code Artifactory} domain.
-	 * <p>
-	 * The manifest acts as the bridge between a service and the configuration metadata
-	 * provided by its dependencies. When a manifest is resolved, the Artifactory aggregates
-	 * the configuration property definitions contributed by all referenced artifacts and
-	 * produces the effective configuration metadata used by the service.
-	 *
-	 * @param service service for which manifest should be retrieved, can't be {@literal null}
-	 * @return the current {@link Manifest} for the service, never {@literal null}
-	 */
-	Manifest manifest(Service service);
 
 	/**
 	 * Returns the complete configuration catalog of the specified {@link Service}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/catalog/ServiceCatalogWorker.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/catalog/ServiceCatalogWorker.java
@@ -1,5 +1,6 @@
 package com.konfigyr.namespace.catalog;
 
+import com.konfigyr.artifactory.ArtifactSource;
 import com.konfigyr.entity.EntityId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +41,20 @@ import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
  * the associated release are removed using a targeted {@code DELETE} statement. Then the new rows are
  * inserted using a set-based SQL projection (JOIN between release artifacts and artifact property
  * definitions).
+ * <p>
+ * The {@code DELETE} removes every catalog row for the release except the ones matching a currently
+ * declared {@code LOCAL} coordinate, and the projection only ever inserts rows resolved through the
+ * Artifactory's own tables. {@code LOCAL} coordinates are uploaded directly into
+ * {@code service_configuration_catalog} by the service manifest upload endpoint and are the only rows
+ * this rebuild leaves untouched, everything else, including stale rows for a coordinate that has
+ * since been removed from the release entirely, is cleaned up on every re-build.
+ * <p>
+ * Before that {@code DELETE}/{@code INSERT} pair runs, {@link #promoteLocalArtifactsIndexedByArtifactory}
+ * upgrades any {@code LOCAL} coordinate for this release that has since been indexed by the Artifactory
+ * to {@code ARTIFACTORY}: once a coordinate is indexed there, that is the more trustworthy source and
+ * supersedes whatever the plugin uploaded directly. See that method's Javadoc for why this promotion is
+ * scoped per-release here rather than done as one fan-out {@code UPDATE} when the Artifactory
+ * publication event first arrives.
  * <p>
  * Because rebuilds operate on a subset of rows within a service partition, partition-level truncation is
  * not possible. Instead, the system relies on efficient partition pruning (via {@code service_id}) and
@@ -84,14 +99,69 @@ class ServiceCatalogWorker {
 	void build(EntityId release) {
 		assertReleaseExists(release);
 
+		final long promoted = promoteLocalArtifactsIndexedByArtifactory(release);
+
 		final long dropped = context.deleteFrom(SERVICE_CONFIGURATION_CATALOG)
 				.where(SERVICE_CONFIGURATION_CATALOG.RELEASE_ID.eq(release.get()))
+				.and(SERVICE_CONFIGURATION_CATALOG.COORDINATES.notIn(DSL.select(SERVICE_ARTIFACTS.COORDINATES)
+						.from(SERVICE_ARTIFACTS)
+						.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(release.get()))
+						.and(SERVICE_ARTIFACTS.SOURCE.eq(ArtifactSource.LOCAL.name()))))
 				.execute();
 
 		final long inserted = createCatalogForRelease(release);
 
-		log.info("Service configuration catalog successfully built: [release={}, propertes_dropped={}, propertes_inserted={}]",
-				release, dropped, inserted);
+		log.info("Service configuration catalog successfully built: [release={}, artifacts_promoted={}, propertes_dropped={}, propertes_inserted={}]",
+				release, promoted, dropped, inserted);
+	}
+
+	/**
+	 * Promotes every {@code LOCAL} {@code service_artifacts} coordinate declared for this release to
+	 * {@code ARTIFACTORY}, for every coordinate that now has a matching artifact version indexed by the
+	 * Artifactory.
+	 * <p>
+	 * Once a coordinate is indexed in the Artifactory, that is the more trustworthy source and should
+	 * supersede whatever the plugin uploaded directly, so the columns {@link #build} otherwise never
+	 * touches for an {@code ARTIFACTORY} row, {@code checksum}, {@code name}, {@code description},
+	 * {@code website}, {@code repository}, are cleared here. Clearing {@code checksum} also drops the
+	 * coordinate out of {@code ServiceManifests#findMissingArtifactCoordinates}'s scan, since that scan
+	 * is itself scoped to {@code LOCAL} rows only; a promoted coordinate is no longer something the
+	 * plugin is expected to upload.
+	 * <p>
+	 * This runs scoped to a single release, immediately before this class's own {@code DELETE}/
+	 * {@code INSERT} pair, rather than as a single fan-out {@code UPDATE} across every affected release
+	 * when the Artifactory publication event first arrives: a single publication can affect many
+	 * releases at once, and this worker already processes them one at a time off the debounced queue, so
+	 * promoting per-release keeps each individual unit of work small instead of paying for one large,
+	 * upfront {@code UPDATE}.
+	 *
+	 * @param release the release to check for promotable coordinates, can't be {@literal null}
+	 * @return the number of coordinates promoted, never negative
+	 */
+	private long promoteLocalArtifactsIndexedByArtifactory(EntityId release) {
+		return context.update(SERVICE_ARTIFACTS)
+				.set(SERVICE_ARTIFACTS.SOURCE, ArtifactSource.ARTIFACTORY.name())
+				.set(SERVICE_ARTIFACTS.CHECKSUM, (String) null)
+				.set(SERVICE_ARTIFACTS.NAME, (String) null)
+				.set(SERVICE_ARTIFACTS.DESCRIPTION, (String) null)
+				.set(SERVICE_ARTIFACTS.WEBSITE, (String) null)
+				.set(SERVICE_ARTIFACTS.REPOSITORY, (String) null)
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(release.get()))
+				.and(SERVICE_ARTIFACTS.SOURCE.eq(ArtifactSource.LOCAL.name()))
+				.and(DSL.exists(
+						DSL.selectOne()
+								.from(ARTIFACTS)
+								.innerJoin(ARTIFACT_VERSIONS)
+								.on(DSL.and(
+										ARTIFACT_VERSIONS.ARTIFACT_ID.eq(ARTIFACTS.ID),
+										ARTIFACT_VERSIONS.VERSION.eq(SERVICE_ARTIFACTS.VERSION)
+								))
+								.where(DSL.and(
+										ARTIFACTS.GROUP_ID.eq(SERVICE_ARTIFACTS.GROUP_ID),
+										ARTIFACTS.ARTIFACT_ID.eq(SERVICE_ARTIFACTS.ARTIFACT_ID)
+								))
+				))
+				.execute();
 	}
 
 	private long createCatalogForRelease(EntityId release) {
@@ -140,7 +210,10 @@ class ServiceCatalogWorker {
 								.on(ARTIFACT_VERSION_PROPERTIES.ARTIFACT_VERSION_ID.eq(ARTIFACT_VERSIONS.ID))
 								.innerJoin(PROPERTY_DEFINITIONS)
 								.on(PROPERTY_DEFINITIONS.ID.eq(ARTIFACT_VERSION_PROPERTIES.PROPERTY_DEFINITION_ID))
-								.where(SERVICE_RELEASES.ID.eq(release.get()))
+								.where(DSL.and(
+										SERVICE_RELEASES.ID.eq(release.get()),
+										SERVICE_ARTIFACTS.SOURCE.eq(ArtifactSource.ARTIFACTORY.name())
+								))
 				).execute();
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/Assemblers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/Assemblers.java
@@ -2,6 +2,7 @@ package com.konfigyr.namespace.controller;
 
 import com.konfigyr.artifactory.Manifest;
 import com.konfigyr.artifactory.PropertyDescriptor;
+import com.konfigyr.artifactory.ServiceRelease;
 import com.konfigyr.hateoas.*;
 import com.konfigyr.namespace.*;
 import org.springframework.http.HttpMethod;
@@ -39,6 +40,12 @@ interface Assemblers {
 	static RepresentationModelAssembler<Manifest, EntityModel<Manifest>> manifest(Namespace namespace, Service service) {
 		return manifest -> EntityModel.of(manifest, linkBuilder(namespace, service).path("manifest").selfRel())
 				.add(linkBuilder(namespace, service).path("manifest").method(HttpMethod.POST).rel("release"));
+	}
+
+	static RepresentationModelAssembler<ServiceRelease, EntityModel<ServiceRelease>> release(Namespace namespace, Service service) {
+		return release -> EntityModel.of(release, linkBuilder(namespace, service, release).selfRel())
+				.add(linkBuilder(namespace, service, release).path("artifacts").method(HttpMethod.POST).rel("upload artifact metadata"))
+				.add(linkBuilder(namespace, service, release).path("complete").method(HttpMethod.POST).rel("complete service release"));
 	}
 
 	static RepresentationModelAssembler<ServiceCatalog, EntityModel<ServiceCatalog>> catalog(Namespace namespace) {
@@ -85,5 +92,11 @@ interface Assemblers {
 		return linkBuilder(namespace, service)
 				.path("catalog")
 				.path(descriptor.name());
+	}
+
+	static LinkBuilder linkBuilder(Namespace namespace, Service service, ServiceRelease release) {
+		return linkBuilder(namespace, service)
+				.path("releases")
+				.path(release.id());
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
@@ -1,9 +1,8 @@
 package com.konfigyr.namespace.controller;
 
-import com.konfigyr.artifactory.ArtifactMetadata;
-import com.konfigyr.artifactory.ServiceRelease;
-import com.konfigyr.artifactory.ServiceReleaseCandidate;
+import com.konfigyr.artifactory.*;
 import com.konfigyr.entity.EntityId;
+import com.konfigyr.hateoas.EntityModel;
 import com.konfigyr.namespace.Namespace;
 import com.konfigyr.namespace.NamespaceManager;
 import com.konfigyr.namespace.NamespaceNotFoundException;
@@ -16,29 +15,37 @@ import com.konfigyr.security.oauth.RequiresScope;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
-@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)
-@RequestMapping("/namespaces/{namespace}/services/{slug}/releases")
+@RequestMapping("/namespaces/{namespace}/services/{slug}")
 class ServiceManifestController {
 
 	private final NamespaceManager namespaces;
 	private final Services services;
 	private final ServiceManifests manifests;
 
-	@PostMapping
+	@GetMapping("manifest")
 	@PreAuthorize("isMember(#namespace)")
-	ServiceRelease resolve(
+	@RequiresScope(OAuthScope.READ_NAMESPACES)
+	EntityModel<Manifest> manifest(@PathVariable @NonNull String namespace, @PathVariable @NonNull String slug) {
+		final Namespace ns = lookupNamespace(namespace);
+		final Service service = services.get(ns, slug).orElseThrow(
+				() -> new ServiceNotFoundException(namespace, slug)
+		);
+
+		return Assemblers.manifest(ns, service).assemble(manifests.get(service));
+	}
+
+	@PostMapping("releases")
+	@PreAuthorize("isMember(#namespace)")
+	@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)
+	EntityModel<ServiceRelease> resolve(
 			@PathVariable String namespace,
 			@PathVariable String slug,
 			@RequestBody List<ServiceReleaseCandidate> candidates
@@ -48,12 +55,13 @@ class ServiceManifestController {
 				() -> new ServiceNotFoundException(namespace, slug)
 		);
 
-		return manifests.open(service, candidates);
+		return Assemblers.release(ns, service).assemble(manifests.open(service, candidates));
 	}
 
-	@PostMapping("/{id}/artifacts")
+	@PostMapping("/releases/{id}/artifacts")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	@PreAuthorize("isMember(#namespace)")
+	@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)
 	void upload(
 			@PathVariable String namespace,
 			@PathVariable String slug,
@@ -66,6 +74,26 @@ class ServiceManifestController {
 		);
 
 		manifests.upload(service, id, metadata);
+	}
+
+	@PostMapping("/releases/{id}/complete")
+	@PreAuthorize("isMember(#namespace)")
+	@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)
+	ResponseEntity<EntityModel<ServiceRelease>> complete(
+			@PathVariable String namespace,
+			@PathVariable String slug,
+			@PathVariable EntityId id
+	) {
+		final Namespace ns = lookupNamespace(namespace);
+		final Service service = services.get(ns, slug).orElseThrow(
+				() -> new ServiceNotFoundException(namespace, slug)
+		);
+
+		final ServiceRelease release = manifests.complete(service, id);
+		final HttpStatus status = release.state() == ReleaseState.FAILED ? HttpStatus.CONFLICT : HttpStatus.OK;
+
+		return ResponseEntity.status(status)
+				.body(Assemblers.release(ns, service).assemble(release));
 	}
 
 	@NonNull

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServicesController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServicesController.java
@@ -1,6 +1,5 @@
 package com.konfigyr.namespace.controller;
 
-import com.konfigyr.artifactory.Manifest;
 import com.konfigyr.artifactory.PropertyDescriptor;
 import com.konfigyr.hateoas.EntityModel;
 import com.konfigyr.hateoas.PagedModel;
@@ -123,17 +122,6 @@ class ServicesController {
 		}
 
 		return Assemblers.property(ns, service).assemble(services.search(service, builder.build()));
-	}
-
-	@GetMapping("{slug}/manifest")
-	@PreAuthorize("isMember(#namespace)")
-	EntityModel<Manifest> manifest(@PathVariable @NonNull String namespace, @PathVariable @NonNull String slug) {
-		final Namespace ns = lookupNamespace(namespace);
-		final Service service = services.get(ns, slug).orElseThrow(
-				() -> new ServiceNotFoundException(namespace, slug)
-		);
-
-		return Assemblers.manifest(ns, service).assemble(services.manifest(service));
 	}
 
 	@NonNull

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
@@ -4,20 +4,31 @@ import com.konfigyr.artifactory.*;
 import com.konfigyr.data.Keys;
 import com.konfigyr.data.SettableRecord;
 import com.konfigyr.entity.EntityId;
+import com.konfigyr.io.ByteArray;
 import com.konfigyr.namespace.Service;
+import com.konfigyr.namespace.ServiceEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jooq.Converter;
 import org.jooq.DSLContext;
+import org.jooq.Field;
+import org.jooq.Name;
+import org.jooq.Record;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.Assert;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.*;
 
+import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
+import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
 import static com.konfigyr.data.tables.ServiceConfigurationCatalog.SERVICE_CONFIGURATION_CATALOG;
 import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
@@ -68,20 +79,37 @@ import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
 class DefaultServiceManifests implements ServiceManifests {
 
 	private static final String VERSION = "latest";
+	private static final Name SERVICE_ARTIFACTS_ALIAS = DSL.name("artifacts");
 
 	private final Marker RELEASE_OPENED = MarkerFactory.getMarker("SERVICE_RELEASE_OPENED");
 	private final Marker ARTIFACT_UPLOADED = MarkerFactory.getMarker("SERVICE_ARTIFACT_UPLOADED");
+	private final Marker RELEASE_COMPLETED = MarkerFactory.getMarker("SERVICE_RELEASE_COMPLETED");
 
 	private final DSLContext context;
 	private final Artifactory artifactory;
 	private final ArtifactoryConverters converters;
+	private final ApplicationEventPublisher publisher;
+
+	@Override
+	@Transactional(readOnly = true, label = "service-manifest.get")
+	public Manifest get(Service service) {
+		return context.select(SERVICE_RELEASES.ID, SERVICE_RELEASES.CREATED_AT, createServiceArtifactMultiselectField())
+				.from(SERVICE_RELEASES)
+				.where(SERVICE_RELEASES.SERVICE_ID.eq(service.id().get()))
+				.fetchOptional(record -> toManifest(service, record))
+				.orElseGet(() -> Manifest.builder()
+						.id(service.id().serialize())
+						.name(service.name())
+						.build()
+				);
+	}
 
 	@Override
 	@Transactional(label = "service-manifest.open")
 	public ServiceRelease open(Service service, Collection<ServiceReleaseCandidate> artifacts) {
 		log.debug("Attempting to open a service manifest for {} with: {}", service, artifacts);
 
-		final Long releaseId = upsertRelease(service);
+		final EntityId releaseId = upsertRelease(service);
 
 		// Convert the incoming candidates to their ArtifactCoordinates pairs...
 		final List<CandidateArtifact> candidates = artifacts.stream().map(CandidateArtifact::new).toList();
@@ -93,6 +121,7 @@ class DefaultServiceManifests implements ServiceManifests {
 		existing.putAll(loadExistingPublications(artifacts));
 		existing.putAll(loadExistingServiceArtifacts(releaseId));
 
+		final OffsetDateTime timestamp = OffsetDateTime.now();
 		final List<ServiceReleaseEntry> entries = new ArrayList<>(artifacts.size());
 
 		// prepare the bulk insert query for the release///
@@ -102,7 +131,8 @@ class DefaultServiceManifests implements ServiceManifests {
 				SERVICE_ARTIFACTS.ARTIFACT_ID,
 				SERVICE_ARTIFACTS.VERSION,
 				SERVICE_ARTIFACTS.SOURCE,
-				SERVICE_ARTIFACTS.CHECKSUM
+				SERVICE_ARTIFACTS.CHECKSUM,
+				SERVICE_ARTIFACTS.CREATED_AT
 		);
 
 		for (CandidateArtifact candidate : candidates) {
@@ -126,12 +156,13 @@ class DefaultServiceManifests implements ServiceManifests {
 
 			// append the insert row statement for the artifact...
 			insert = insert.values(
-					releaseId,
+					releaseId.get(),
 					candidate.coordinates().groupId(),
 					candidate.coordinates().artifactId(),
 					candidate.coordinates().version().get(),
 					source.name(),
-					checksum
+					checksum,
+					timestamp
 			);
 		}
 
@@ -149,9 +180,207 @@ class DefaultServiceManifests implements ServiceManifests {
 				releaseId, service.id(), entries.size());
 
 		return ServiceRelease.builder()
-				.id(EntityId.from(releaseId).serialize())
+				.id(releaseId.serialize())
 				.state(ReleaseState.PENDING)
 				.artifacts(entries)
+				.build();
+	}
+
+	/**
+	 * Uploads the configuration property metadata for a single artifact that was previously declared
+	 * for this release via {@link #open}.
+	 * <p>
+	 * The given {@code metadata}'s coordinates must match a {@code LOCAL} {@code service_artifacts} row
+	 * already recorded for this release; anything else — a coordinate never declared, or one declared
+	 * as {@code ARTIFACTORY} rather than {@code LOCAL} — is rejected with an
+	 * {@link UndeclaredArtifactException}. The release must also still be {@link ReleaseState#PENDING},
+	 * otherwise a {@link ReleaseNotPendingException} is thrown: once a release is {@code RELEASED}, the
+	 * plugin must call {@link #open} again to start a new build before uploading anything.
+	 * <p>
+	 * {@code metadata.properties()} is exploded into {@code service_configuration_catalog} rows for
+	 * this coordinate, replacing whatever rows already exist there for it, so a re-upload of the same
+	 * coordinate overwrites rather than duplicates. The matching {@code service_artifacts} row's
+	 * {@code checksum} is then updated to {@code metadata.checksum()} — this is what turns it from
+	 * "declared" into "uploaded", see this class's own Javadoc for why that column doubles as that
+	 * signal. The row's {@code name}/{@code description}/{@code website}/{@code repository} columns are
+	 * updated from {@code metadata} at the same time: this is the only place that descriptive metadata
+	 * for a {@code LOCAL} coordinate is ever recorded, since it is never indexed in the Artifactory's
+	 * own tables the way an {@code ARTIFACTORY} coordinate is.
+	 *
+	 * @param service the service the release belongs to, can't be {@literal null}.
+	 * @param releaseId the entity identifier of the release the upload belongs to, can't be {@literal null}.
+	 * @param metadata the uploaded artifact metadata, can't be {@literal null}.
+	 * @throws UndeclaredArtifactException if the metadata's coordinates were not declared for this
+	 *         release as a {@code LOCAL} artifact.
+	 * @throws ReleaseNotPendingException if the release is not currently {@link ReleaseState#PENDING}.
+	 */
+	@Override
+	@Transactional(label = "service-manifest.upload")
+	public void upload(Service service, EntityId releaseId, ArtifactMetadata metadata) {
+		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(metadata);
+		final String formatted = coordinates.format();
+
+		log.debug("Attempting to upload artifact metadata for {} to release {} for service {}",
+				coordinates, releaseId, service);
+
+		final ReleaseState state = context.select(SERVICE_RELEASES.STATE)
+				.from(SERVICE_ARTIFACTS)
+				.join(SERVICE_RELEASES).on(SERVICE_RELEASES.ID.eq(SERVICE_ARTIFACTS.RELEASE_ID))
+				.where(DSL.and(
+						SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()),
+						SERVICE_RELEASES.SERVICE_ID.eq(service.id().get()),
+						SERVICE_ARTIFACTS.COORDINATES.eq(formatted),
+						SERVICE_ARTIFACTS.SOURCE.eq(ArtifactSource.LOCAL.name())
+				))
+				.fetchOptional(SERVICE_RELEASES.STATE)
+				.map(ReleaseState::valueOf)
+				.orElseThrow(() -> new UndeclaredArtifactException(coordinates));
+
+		if (state != ReleaseState.PENDING) {
+			throw new ReleaseNotPendingException(releaseId, state);
+		}
+
+		context.deleteFrom(SERVICE_CONFIGURATION_CATALOG)
+				.where(DSL.and(
+						SERVICE_CONFIGURATION_CATALOG.RELEASE_ID.eq(releaseId.get()),
+						SERVICE_CONFIGURATION_CATALOG.COORDINATES.eq(formatted)
+				))
+				.execute();
+
+		var insert = context.insertInto(SERVICE_CONFIGURATION_CATALOG).columns(
+				SERVICE_CONFIGURATION_CATALOG.SERVICE_ID,
+				SERVICE_CONFIGURATION_CATALOG.RELEASE_ID,
+				SERVICE_CONFIGURATION_CATALOG.GROUP_ID,
+				SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID,
+				SERVICE_CONFIGURATION_CATALOG.VERSION,
+				SERVICE_CONFIGURATION_CATALOG.NAME,
+				SERVICE_CONFIGURATION_CATALOG.TYPE_NAME,
+				SERVICE_CONFIGURATION_CATALOG.SCHEMA,
+				SERVICE_CONFIGURATION_CATALOG.DEFAULT_VALUE,
+				SERVICE_CONFIGURATION_CATALOG.DESCRIPTION,
+				SERVICE_CONFIGURATION_CATALOG.DEPRECATION
+		);
+
+		for (PropertyDescriptor property : metadata.properties()) {
+			insert = insert.values(
+					service.id().get(),
+					releaseId.get(),
+					coordinates.groupId(),
+					coordinates.artifactId(),
+					coordinates.version().get(),
+					property.name(),
+					property.typeName(),
+					converters.schema().to(property.schema()),
+					property.defaultValue(),
+					property.description(),
+					converters.deprecation().to(property.deprecation())
+			);
+		}
+
+		if (!metadata.properties().isEmpty()) {
+			insert.execute();
+		}
+
+		context.update(SERVICE_ARTIFACTS)
+				.set(SERVICE_ARTIFACTS.CHECKSUM, metadata.checksum())
+				.set(SERVICE_ARTIFACTS.NAME, metadata.name())
+				.set(SERVICE_ARTIFACTS.DESCRIPTION, metadata.description())
+				.set(SERVICE_ARTIFACTS.WEBSITE, Objects.toString(metadata.website(), null))
+				.set(SERVICE_ARTIFACTS.REPOSITORY, Objects.toString(metadata.repository(), null))
+				.where(DSL.and(
+						SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()),
+						SERVICE_ARTIFACTS.COORDINATES.eq(formatted)
+				))
+				.execute();
+
+		log.info(ARTIFACT_UPLOADED, "Successfully uploaded artifact metadata for {} to release {}", coordinates, releaseId);
+	}
+
+	/**
+	 * Finalizes a {@link ReleaseState#PENDING} release: checks that every declared {@code LOCAL}
+	 * artifact was uploaded, then transitions the release to {@link ReleaseState#RELEASED}.
+	 * <p>
+	 * If any {@code LOCAL} {@code service_artifacts} row for this release still has a {@literal null}
+	 * checksum — declared via {@link #open} but never uploaded via {@link #upload} — the release
+	 * cannot complete: it transitions to {@link ReleaseState#FAILED} instead, the returned
+	 * {@link ServiceRelease#errors()} lists those coordinates, and a {@code ServiceEvent.ReleaseFailed}
+	 * event is published so anything left behind by the attempt can be cleaned up. This is reported as
+	 * a normal, non-error result rather than an exception, since it is the release itself that failed,
+	 * not the call.
+	 * <p>
+	 * Otherwise, the release transitions to {@link ReleaseState#RELEASED} and a
+	 * {@code ServiceEvent.Released} event is published. This class does not populate
+	 * {@code service_configuration_catalog} for the release's {@code ARTIFACTORY} coordinates itself:
+	 * {@code ServiceCatalogQueueListener} reacts to that event and schedules
+	 * {@code ServiceCatalogWorker} to do so, the same mechanism already used when Artifactory metadata
+	 * changes. {@code LOCAL} coordinates were already exploded into the catalog by {@link #upload}.
+	 *
+	 * @param service the service the release belongs to, can't be {@literal null}.
+	 * @param releaseId the entity identifier of the release to complete, can't be {@literal null}.
+	 * @return the completed service release, never {@literal null}.
+	 * @throws ReleaseNotFoundException if no release with this identifier exists for this service.
+	 * @throws ReleaseNotPendingException if the release is not currently {@link ReleaseState#PENDING}.
+	 */
+	@Override
+	@Transactional(label = "service-manifest.complete")
+	public ServiceRelease complete(Service service, EntityId releaseId) {
+		log.debug("Attempting to complete release {} for service {}", releaseId, service);
+
+		final ReleaseState state = context.select(SERVICE_RELEASES.STATE)
+				.from(SERVICE_RELEASES)
+				.where(DSL.and(
+						SERVICE_RELEASES.ID.eq(releaseId.get()),
+						SERVICE_RELEASES.SERVICE_ID.eq(service.id().get())
+				))
+				.fetchOptional(SERVICE_RELEASES.STATE)
+				.map(ReleaseState::valueOf)
+				.orElseThrow(() -> new ReleaseNotFoundException(releaseId));
+
+		if (state != ReleaseState.PENDING) {
+			throw new ReleaseNotPendingException(releaseId, state);
+		}
+
+		final List<ArtifactCoordinates> missing = findMissingArtifactCoordinates(releaseId);
+
+		if (!missing.isEmpty()) {
+			final List<String> errors = missing.stream()
+					.map(ArtifactCoordinates::format)
+					.map("Artifact with coordinates '%s' was not uploaded"::formatted)
+					.toList();
+
+			context.update(SERVICE_RELEASES)
+					.set(SERVICE_RELEASES.STATE, ReleaseState.FAILED.name())
+					.where(SERVICE_RELEASES.ID.eq(releaseId.get()))
+					.execute();
+
+			publisher.publishEvent(new ServiceEvent.ReleaseFailed(service, errors));
+
+			log.info(RELEASE_COMPLETED, "Failed to complete release {} for service {}: {} artifact(s) never uploaded",
+					releaseId, service.id(), missing.size());
+
+			return ServiceRelease.builder()
+					.id(releaseId.serialize())
+					.state(ReleaseState.FAILED)
+					.errors(errors)
+					.build();
+		}
+
+		final OffsetDateTime publishedAt = OffsetDateTime.now();
+
+		context.update(SERVICE_RELEASES)
+				.set(SERVICE_RELEASES.STATE, ReleaseState.RELEASED.name())
+				.set(SERVICE_RELEASES.PUBLISHED_AT, publishedAt)
+				.where(SERVICE_RELEASES.ID.eq(releaseId.get()))
+				.execute();
+
+		publisher.publishEvent(new ServiceEvent.Released(service, get(service)));
+
+		log.info(RELEASE_COMPLETED, "Successfully completed release {} for service {}", releaseId, service.id());
+
+		return ServiceRelease.builder()
+				.id(releaseId.serialize())
+				.state(ReleaseState.RELEASED)
+				.publishedAt(publishedAt.toInstant())
 				.build();
 	}
 
@@ -171,7 +400,7 @@ class DefaultServiceManifests implements ServiceManifests {
 	 * @param service the service opening or taking over a build, can't be {@literal null}.
 	 * @return the entity identifier of the upserted release row, never {@literal null}.
 	 */
-	private Long upsertRelease(Service service) {
+	private EntityId upsertRelease(Service service) {
 		final Long releaseId = context.insertInto(SERVICE_RELEASES)
 				.set(
 						SettableRecord.of(context, SERVICE_RELEASES)
@@ -191,7 +420,7 @@ class DefaultServiceManifests implements ServiceManifests {
 
 		Assert.state(releaseId != null, "Failed to resolve the release identifier for: " + service);
 
-		return releaseId;
+		return EntityId.from(releaseId);
 	}
 
 	/**
@@ -207,7 +436,7 @@ class DefaultServiceManifests implements ServiceManifests {
 	 * @param releaseId the release to load existing artifacts for, can't be {@literal null}.
 	 * @return existing artifacts for the release keyed by their coordinates, never {@literal null}.
 	 */
-	private Map<ArtifactCoordinates, ExistingArtifact> loadExistingServiceArtifacts(Long releaseId) {
+	private Map<ArtifactCoordinates, ExistingArtifact> loadExistingServiceArtifacts(EntityId releaseId) {
 		return context.select(
 						SERVICE_ARTIFACTS.GROUP_ID,
 						SERVICE_ARTIFACTS.ARTIFACT_ID,
@@ -216,7 +445,7 @@ class DefaultServiceManifests implements ServiceManifests {
 						SERVICE_ARTIFACTS.CHECKSUM
 				)
 				.from(SERVICE_ARTIFACTS)
-				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()))
 				.fetchMap(
 						record -> ArtifactCoordinates.of(
 								record.get(SERVICE_ARTIFACTS.GROUP_ID),
@@ -274,162 +503,122 @@ class DefaultServiceManifests implements ServiceManifests {
 	 * @param candidates the complete, current set of declared candidates, can't be {@literal null}; an
 	 *                    empty collection removes every row for this release.
 	 */
-	private void pruneStaleArtifacts(Long releaseId, Collection<CandidateArtifact> candidates) {
+	private void pruneStaleArtifacts(EntityId releaseId, Collection<CandidateArtifact> candidates) {
 		if (candidates.isEmpty()) {
 			context.deleteFrom(SERVICE_ARTIFACTS)
-					.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
+					.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()))
 					.execute();
 			return;
 		}
 
-		final String[] groupIds = candidates.stream().map(CandidateArtifact::artifact).map(Artifact::groupId).toArray(String[]::new);
-		final String[] artifactIds = candidates.stream().map(CandidateArtifact::artifact).map(Artifact::artifactId).toArray(String[]::new);
-		final String[] versions = candidates.stream().map(CandidateArtifact::artifact).map(Artifact::version).toArray(String[]::new);
+		final String[] coordinates = candidates.stream()
+				.map(CandidateArtifact::coordinates)
+				.map(ArtifactCoordinates::format)
+				.toArray(String[]::new);
 
 		context.deleteFrom(SERVICE_ARTIFACTS)
-				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId))
-				.and(DSL.row(SERVICE_ARTIFACTS.GROUP_ID, SERVICE_ARTIFACTS.ARTIFACT_ID, SERVICE_ARTIFACTS.VERSION)
-						.notIn(DSL.select(DSL.field("g", String.class), DSL.field("a", String.class), DSL.field("v", String.class))
-								.from("unnest({0}::text[], {1}::text[], {2}::text[]) AS t(g, a, v)", groupIds, artifactIds, versions)))
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()))
+				.and(SERVICE_ARTIFACTS.COORDINATES.notIn(DSL.select(DSL.field("c", String.class))
+						.from("unnest({0}::text[]) AS t(c)", (Object) coordinates)))
 				.execute();
 	}
 
 	/**
-	 * Uploads the configuration property metadata for a single artifact that was previously declared
-	 * for this release via {@link #open}.
+	 * Finds the coordinates of every {@code LOCAL} artifact declared for this release that was never
+	 * uploaded, i.e. whose {@code service_artifacts} row still has a {@literal null} checksum.
 	 * <p>
-	 * The given {@code metadata}'s coordinates must match a {@code LOCAL} {@code service_artifacts} row
-	 * already recorded for this release; anything else — a coordinate never declared, or one declared
-	 * as {@code ARTIFACTORY} rather than {@code LOCAL} — is rejected with an
-	 * {@link UndeclaredArtifactException}. The release must also still be {@link ReleaseState#PENDING},
-	 * otherwise a {@link ReleaseNotPendingException} is thrown: once a release is {@code RELEASED}, the
-	 * plugin must call {@link #open} again to start a new build before uploading anything.
-	 * <p>
-	 * {@code metadata.properties()} is exploded into {@code service_configuration_catalog} rows for
-	 * this coordinate, replacing whatever rows already exist there for it, so a re-upload of the same
-	 * coordinate overwrites rather than duplicates. The matching {@code service_artifacts} row's
-	 * {@code checksum} is then updated to {@code metadata.checksum()} — this is what turns it from
-	 * "declared" into "uploaded", see this class's own Javadoc for why that column doubles as that
-	 * signal.
+	 * {@link #complete} calls this to decide whether a release can be finalized: a non-empty result
+	 * means the release must transition to {@link ReleaseState#FAILED} instead of
+	 * {@link ReleaseState#RELEASED}, with these coordinates reported back as the reason.
+	 * {@code ARTIFACTORY} coordinates are never included, since their checksum is always
+	 * {@literal null} by design and does not indicate a missing upload.
 	 *
-	 * @param service the service the release belongs to, can't be {@literal null}.
-	 * @param releaseId the entity identifier of the release the upload belongs to, can't be {@literal null}.
-	 * @param metadata the uploaded artifact metadata, can't be {@literal null}.
-	 * @throws UndeclaredArtifactException if the metadata's coordinates were not declared for this
-	 *         release as a {@code LOCAL} artifact.
-	 * @throws ReleaseNotPendingException if the release is not currently {@link ReleaseState#PENDING}.
+	 * @param releaseId the release to check for missing uploads, can't be {@literal null}.
+	 * @return the coordinates of every declared but not yet uploaded artifact, never {@literal null};
+	 *         empty when every declared {@code LOCAL} artifact has been uploaded.
 	 */
-	@Override
-	@Transactional(label = "service-manifest.upload")
-	public void upload(Service service, EntityId releaseId, ArtifactMetadata metadata) {
-		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(metadata);
-
-		log.debug("Attempting to upload artifact metadata for {} to release {} for service {}",
-				coordinates, releaseId, service);
-
-		final ReleaseState state = context.select(SERVICE_RELEASES.STATE)
+	private List<ArtifactCoordinates> findMissingArtifactCoordinates(EntityId releaseId) {
+		return context.select(SERVICE_ARTIFACTS.COORDINATES)
 				.from(SERVICE_ARTIFACTS)
-				.join(SERVICE_RELEASES).on(SERVICE_RELEASES.ID.eq(SERVICE_ARTIFACTS.RELEASE_ID))
-				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()))
-				.and(SERVICE_RELEASES.SERVICE_ID.eq(service.id().get()))
-				.and(SERVICE_ARTIFACTS.GROUP_ID.eq(coordinates.groupId()))
-				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()))
-				.and(SERVICE_ARTIFACTS.VERSION.eq(coordinates.version().get()))
-				.and(SERVICE_ARTIFACTS.SOURCE.eq(ArtifactSource.LOCAL.name()))
-				.fetchOptional(SERVICE_RELEASES.STATE)
-				.map(ReleaseState::valueOf)
-				.orElseThrow(() -> new UndeclaredArtifactException(coordinates));
-
-		if (state != ReleaseState.PENDING) {
-			throw new ReleaseNotPendingException(releaseId, state);
-		}
-
-		context.deleteFrom(SERVICE_CONFIGURATION_CATALOG)
-				.where(SERVICE_CONFIGURATION_CATALOG.RELEASE_ID.eq(releaseId.get()))
-				.and(SERVICE_CONFIGURATION_CATALOG.GROUP_ID.eq(coordinates.groupId()))
-				.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(coordinates.artifactId()))
-				.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(coordinates.version().get()))
-				.execute();
-
-		var insert = context.insertInto(SERVICE_CONFIGURATION_CATALOG).columns(
-				SERVICE_CONFIGURATION_CATALOG.SERVICE_ID,
-				SERVICE_CONFIGURATION_CATALOG.RELEASE_ID,
-				SERVICE_CONFIGURATION_CATALOG.GROUP_ID,
-				SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID,
-				SERVICE_CONFIGURATION_CATALOG.VERSION,
-				SERVICE_CONFIGURATION_CATALOG.NAME,
-				SERVICE_CONFIGURATION_CATALOG.TYPE_NAME,
-				SERVICE_CONFIGURATION_CATALOG.SCHEMA,
-				SERVICE_CONFIGURATION_CATALOG.DEFAULT_VALUE,
-				SERVICE_CONFIGURATION_CATALOG.DESCRIPTION,
-				SERVICE_CONFIGURATION_CATALOG.DEPRECATION
-		);
-
-		for (PropertyDescriptor property : metadata.properties()) {
-			insert = insert.values(
-					service.id().get(),
-					releaseId.get(),
-					coordinates.groupId(),
-					coordinates.artifactId(),
-					coordinates.version().get(),
-					property.name(),
-					property.typeName(),
-					converters.schema().to(property.schema()),
-					property.defaultValue(),
-					property.description(),
-					converters.deprecation().to(property.deprecation())
-			);
-		}
-
-		if (!metadata.properties().isEmpty()) {
-			insert.execute();
-		}
-
-		context.update(SERVICE_ARTIFACTS)
-				.set(SERVICE_ARTIFACTS.CHECKSUM, metadata.checksum())
-				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()))
-				.and(SERVICE_ARTIFACTS.GROUP_ID.eq(coordinates.groupId()))
-				.and(SERVICE_ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()))
-				.and(SERVICE_ARTIFACTS.VERSION.eq(coordinates.version().get()))
-				.execute();
-
-		log.info(ARTIFACT_UPLOADED, "Successfully uploaded artifact metadata for {} to release {}", coordinates, releaseId);
+				.where(DSL.and(
+						SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()),
+						SERVICE_ARTIFACTS.SOURCE.eq(ArtifactSource.LOCAL.name()),
+						SERVICE_ARTIFACTS.CHECKSUM.isNull()
+				))
+				.fetch(record -> ArtifactCoordinates.parse(
+						record.get(SERVICE_ARTIFACTS.COORDINATES)
+				));
 	}
 
-	/**
-	 * Not yet implemented. Notes for whoever picks this up:
-	 * <ul>
-	 *     <li>First check whether any {@code service_artifacts} row for this release still has
-	 *     {@code source = LOCAL AND checksum IS NULL} — meaning something declared via {@link #open}
-	 *     was never actually uploaded via {@link #upload}. If so, this release cannot complete: set
-	 *     {@code service_releases.state} to {@link ReleaseState#FAILED} and return a
-	 *     {@link ServiceRelease} whose {@link ServiceRelease#errors()} lists those coordinates.</li>
-	 *     <li>Otherwise, build the property catalog for this release in
-	 *     {@code service_configuration_catalog}. The {@code LOCAL} coordinates were already exploded
-	 *     into the catalog by {@link #upload}; what is still missing here is the {@code ARTIFACTORY}
-	 *     coordinates, whose property descriptors live in the Artifactory's own tables instead of
-	 *     having been uploaded directly. {@code ServiceCatalogWorker} (in the sibling
-	 *     {@code com.konfigyr.namespace.catalog} package) already contains the exact join needed —
-	 *     from {@code service_artifacts} through {@code artifacts}, {@code artifact_versions},
-	 *     {@code artifact_version_properties}, to {@code property_definitions} — but it is
-	 *     package-private today, so either expose it for reuse here or re-create the same join.</li>
-	 *     <li>Set {@code service_releases.state} to {@link ReleaseState#RELEASED} and
-	 *     {@code published_at} to the current time.</li>
-	 *     <li>Publish a {@code ServiceEvent.Released} event so that
-	 *     {@code ServiceCatalogQueueListener} picks up this release for indexing. Building that event
-	 *     needs the {@link Service} (already a parameter here) and a {@code Manifest}
-	 *     ({@code Services.manifest(Service)}), which means this class needs a new dependency on
-	 *     {@code Services} that it does not have today.</li>
-	 *     <li>Log the outcome, matching the {@code log.info(...)} call at the top of {@link #open}.</li>
-	 * </ul>
-	 *
-	 * @param service the service the release belongs to, can't be {@literal null}.
-	 * @param releaseId the entity identifier of the release to complete, can't be {@literal null}.
-	 * @return the completed service release, never {@literal null}.
-	 */
-	@Override
-	public ServiceRelease complete(Service service, EntityId releaseId) {
-		throw new UnsupportedOperationException("Not yet implemented");
+	private Field<List<Artifact>> createServiceArtifactMultiselectField() {
+		return DSL.multiset(
+				DSL.select(
+						SERVICE_ARTIFACTS.GROUP_ID,
+						SERVICE_ARTIFACTS.ARTIFACT_ID,
+						SERVICE_ARTIFACTS.VERSION,
+						SERVICE_ARTIFACTS.SOURCE,
+						SERVICE_ARTIFACTS.CHECKSUM,
+						SERVICE_ARTIFACTS.CREATED_AT,
+						SERVICE_ARTIFACTS.NAME,
+						SERVICE_ARTIFACTS.DESCRIPTION,
+						SERVICE_ARTIFACTS.WEBSITE,
+						SERVICE_ARTIFACTS.REPOSITORY,
+						ARTIFACTS.NAME,
+						ARTIFACTS.DESCRIPTION,
+						ARTIFACTS.WEBSITE,
+						ARTIFACTS.REPOSITORY,
+						ARTIFACT_VERSIONS.CHECKSUM
+				)
+				.from(SERVICE_ARTIFACTS)
+				.leftJoin(ARTIFACTS)
+				.on(DSL.and(
+						ARTIFACTS.GROUP_ID.eq(SERVICE_ARTIFACTS.GROUP_ID),
+						ARTIFACTS.ARTIFACT_ID.eq(SERVICE_ARTIFACTS.ARTIFACT_ID)
+				))
+				.leftJoin(ARTIFACT_VERSIONS)
+				.on(DSL.and(
+						ARTIFACT_VERSIONS.ARTIFACT_ID.eq(ARTIFACTS.ID),
+						ARTIFACT_VERSIONS.VERSION.eq(SERVICE_ARTIFACTS.VERSION)
+				))
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(SERVICE_RELEASES.ID))
+		).as(SERVICE_ARTIFACTS_ALIAS).convertFrom(results -> results.map(DefaultServiceManifests::toManifestEntry));
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Manifest toManifest(Service service, Record record) {
+		return Manifest.builder()
+				.id(record.get(SERVICE_RELEASES.ID, EntityId.class).serialize())
+				.name(service.name())
+				.artifacts((Iterable<? extends ManifestEntry>) record.get(SERVICE_ARTIFACTS_ALIAS))
+				.createdAt(record.get(SERVICE_RELEASES.CREATED_AT, Instant.class))
+				.build();
+	}
+
+	private static ManifestEntry toManifestEntry(Record record) {
+		final ArtifactSource source = record.get(SERVICE_ARTIFACTS.SOURCE, ArtifactSource.class);
+		final boolean local = source == ArtifactSource.LOCAL;
+
+		// LOCAL artifacts carry their own uploaded metadata checksum; ARTIFACTORY artifacts reuse the
+		// checksum of the indexed artifact version, since service_artifacts.checksum is always null for them
+		final String checksum = local
+				? record.get(SERVICE_ARTIFACTS.CHECKSUM)
+				: record.get(ARTIFACT_VERSIONS.CHECKSUM, Converter.from(ByteArray.class, String.class, ByteArray::encodeHex));
+
+		// LOCAL artifacts are never indexed in the Artifactory's own tables, so their descriptive
+		// metadata comes from what the plugin itself uploaded via upload(); ARTIFACTORY artifacts have
+		// this already resolved through the artifacts join
+		return ManifestEntry.builder()
+				.groupId(record.get(SERVICE_ARTIFACTS.GROUP_ID))
+				.artifactId(record.get(SERVICE_ARTIFACTS.ARTIFACT_ID))
+				.version(record.get(SERVICE_ARTIFACTS.VERSION))
+				.name(local ? record.get(SERVICE_ARTIFACTS.NAME) : record.get(ARTIFACTS.NAME))
+				.description(local ? record.get(SERVICE_ARTIFACTS.DESCRIPTION) : record.get(ARTIFACTS.DESCRIPTION))
+				.website(local ? record.get(SERVICE_ARTIFACTS.WEBSITE) : record.get(ARTIFACTS.WEBSITE))
+				.repository(local ? record.get(SERVICE_ARTIFACTS.REPOSITORY) : record.get(ARTIFACTS.REPOSITORY))
+				.resolvedAt(record.get(SERVICE_ARTIFACTS.CREATED_AT, Instant.class))
+				.checksum(checksum)
+				.source(source)
+				.build();
 	}
 
 	private record CandidateArtifact(ArtifactCoordinates coordinates, ServiceReleaseCandidate artifact) {
@@ -475,6 +664,7 @@ class DefaultServiceManifests implements ServiceManifests {
 		 * @param existing what is already known about this candidate's coordinates, can't be {@literal null}.
 		 * @return the checksum to persist, or {@literal null} when nothing settled should be recorded.
 		 */
+		@Nullable
 		private String resolveChecksum(ArtifactUploadStatus status, ExistingArtifact existing) {
 			return status == ArtifactUploadStatus.SKIP && existing.source() == ArtifactSource.LOCAL
 					? existing.checksum()

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ReleaseNotFoundException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ReleaseNotFoundException.java
@@ -1,0 +1,45 @@
+package com.konfigyr.namespace.manifest;
+
+import com.konfigyr.entity.EntityId;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown when a {@link ServiceManifests} operation is attempted for a release that does
+ * not exist for the given service, either because the identifier is unknown or because it identifies
+ * a release belonging to a different service.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ **/
+public class ReleaseNotFoundException extends ServiceManifestException {
+
+	@Serial
+	private static final long serialVersionUID = -3187004821552018403L;
+
+	private final EntityId releaseId;
+
+	/**
+	 * Create new instance of the {@link ReleaseNotFoundException} for the given release identifier.
+	 *
+	 * @param releaseId the entity identifier of the release that could not be found, can't be {@literal null}
+	 */
+	public ReleaseNotFoundException(@NonNull EntityId releaseId) {
+		super(HttpStatus.NOT_FOUND, "Could not find a release with the following identifier: " + releaseId.serialize());
+		this.releaseId = releaseId;
+	}
+
+	@Override
+	public Object @Nullable [] getDetailMessageArguments() {
+		return new Object[] { releaseId.serialize() };
+	}
+
+	@NonNull
+	public EntityId getReleaseId() {
+		return releaseId;
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestConfiguration.java
@@ -4,6 +4,7 @@ import com.konfigyr.artifactory.Artifactory;
 import com.konfigyr.artifactory.ArtifactoryConverters;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,8 +15,8 @@ public class ServiceManifestConfiguration {
 	private final DSLContext context;
 
 	@Bean
-	ServiceManifests serviceManifests(Artifactory artifactory, ArtifactoryConverters converters) {
-		return new DefaultServiceManifests(context, artifactory, converters);
+	ServiceManifests serviceManifests(Artifactory artifactory, ArtifactoryConverters converters, ApplicationEventPublisher publisher) {
+		return new DefaultServiceManifests(context, artifactory, converters, publisher);
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifests.java
@@ -1,6 +1,7 @@
 package com.konfigyr.namespace.manifest;
 
 import com.konfigyr.artifactory.ArtifactMetadata;
+import com.konfigyr.artifactory.Manifest;
 import com.konfigyr.artifactory.ServiceRelease;
 import com.konfigyr.artifactory.ServiceReleaseCandidate;
 import com.konfigyr.entity.EntityId;
@@ -23,6 +24,25 @@ import java.util.Collection;
  * @see ServiceRelease
  **/
 public interface ServiceManifests {
+
+	/**
+	 * Returns the current {@link Manifest} associated with the given service.
+	 * <p>
+	 * A manifest represents the set of {@link com.konfigyr.artifactory.ArtifactCoordinates artifacts}
+	 * that are currently used by a specific service within a {@link com.konfigyr.namespace.Namespace}.
+	 * Each artifact referenced by the manifest contributes configuration metadata resolved through the
+	 * {@code Artifactory} domain.
+	 * <p>
+	 * The manifest acts as the bridge between a service and the configuration metadata provided by its
+	 * dependencies. When a manifest is resolved, the Artifactory aggregates the configuration property
+	 * definitions contributed by all referenced artifacts and produces the effective configuration
+	 * metadata used by the service.
+	 *
+	 * @param service service for which the manifest should be retrieved, can't be {@literal null}.
+	 * @return the current {@link Manifest} for the service, never {@literal null}.
+	 */
+	@NonNull
+	Manifest get(@NonNull Service service);
 
 	/**
 	 * Opens a new build for the given service, or takes over its current {@link ServiceRelease} if one

--- a/konfigyr-api/src/main/resources/messages/audit.properties
+++ b/konfigyr-api/src/main/resources/messages/audit.properties
@@ -31,6 +31,7 @@ audit.event.invitation.canceled=Invitation was canceled
 audit.event.service.created=Service was created
 audit.event.service.renamed=Service was renamed from ''{0}'' to ''{1}''
 audit.event.service.released=Service was released
+audit.event.service.release-failed=Service release failed
 audit.event.service.deleted=Service was deleted
 
 ## Profile events ##

--- a/konfigyr-api/src/main/resources/messages/problem-detail.properties
+++ b/konfigyr-api/src/main/resources/messages/problem-detail.properties
@@ -312,3 +312,7 @@ problemDetail.com.konfigyr.namespace.manifest.UndeclaredArtifactException=The ar
 problemDetail.title.com.konfigyr.namespace.manifest.ReleaseNotPendingException=Release is not pending
 problemDetail.com.konfigyr.namespace.manifest.ReleaseNotPendingException=Release is no longer pending. \
   Resolve the release again to declare it before uploading its metadata.
+
+problemDetail.title.com.konfigyr.namespace.manifest.ReleaseNotFoundException=Release not found
+problemDetail.com.konfigyr.namespace.manifest.ReleaseNotFoundException=Could not find a release with the following \
+  identifier: ''{0}''.

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
@@ -2,10 +2,7 @@ package com.konfigyr.audit;
 
 import com.konfigyr.account.Account;
 import com.konfigyr.account.AccountEvent;
-import com.konfigyr.artifactory.Artifact;
-import com.konfigyr.artifactory.ArtifactCoordinates;
-import com.konfigyr.artifactory.ArtifactoryEvent;
-import com.konfigyr.artifactory.Manifest;
+import com.konfigyr.artifactory.*;
 import com.konfigyr.data.CursorPage;
 import com.konfigyr.data.CursorPageable;
 import com.konfigyr.entity.EntityId;
@@ -31,6 +28,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -555,8 +553,18 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 
 		final var manifest = mock(Manifest.class);
 		doReturn(Arrays.asList(
-				Artifact.of("com.konfigyr", "konfigyr-api", "1.0.0"),
-				Artifact.of("com.konfigyr", "konfigyr-identity", "1.0.0")
+				ManifestEntry.builder()
+						.artifact(Artifact.of("com.konfigyr", "konfigyr-api", "1.0.0"))
+						.checksum("konfigyr-api-checksum")
+						.source(ArtifactSource.ARTIFACTORY)
+						.resolvedAt(Instant.EPOCH)
+						.build(),
+				ManifestEntry.builder()
+						.artifact(Artifact.of("com.konfigyr", "konfigyr-identity", "1.0.0"))
+						.checksum("konfigyr-identity-checksum")
+						.source(ArtifactSource.ARTIFACTORY)
+						.resolvedAt(Instant.EPOCH)
+						.build()
 		)).when(manifest).artifacts();
 
 		listener.on(new ServiceEvent.Released(service, manifest));
@@ -570,6 +578,29 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 								"com.konfigyr:konfigyr-api:1.0.0",
 								"com.konfigyr:konfigyr-identity:1.0.0"
 						))
+				);
+	}
+
+	@Test
+	@DisplayName("should persist audit record for service release failed event with errors")
+	void shouldAuditReleaseFailed() {
+		setSecurityContext(TestPrincipals.john());
+
+		final Service service = Service.builder()
+				.id(903L)
+				.namespace(18L)
+				.slug("api-service")
+				.name("API Service")
+				.build();
+
+		listener.on(new ServiceEvent.ReleaseFailed(service, List.of("Release error")));
+
+		assertAuditRecord("service", EntityId.from(903))
+				.returns(EntityId.from(18), AuditRecord::namespaceId)
+				.satisfies(assertAuditRecordMessage("Service release failed"))
+				.returns("service.release-failed", AuditRecord::eventType)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("errors", List.of("Release error"))
 				);
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/ServicesTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/ServicesTest.java
@@ -295,9 +295,14 @@ class ServicesTest extends AbstractIntegrationTest {
 		final var catalog = services.catalog(EntityId.from(2));
 
 		assertThat(catalog)
-				.hasSize(3)
+				.hasSize(4)
 				.extracting(ServiceCatalog.Property::name)
-				.containsExactly("spring.application.deprecated", "spring.application.index", "spring.application.name");
+				.containsExactly(
+						"com.acme.service.property",
+						"spring.application.deprecated",
+						"spring.application.index",
+						"spring.application.name"
+				);
 
 		assertThatObject(catalog)
 				.returns(EntityId.from(2), ServiceCatalog::id)

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ConfigurationCatalogServiceTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ConfigurationCatalogServiceTest.java
@@ -55,12 +55,19 @@ class ConfigurationCatalogServiceTest extends AbstractIntegrationTest {
 				.returns(0, Page::getNumber)
 				.returns(2, Page::getSize)
 				.returns(2, Page::getNumberOfElements)
-				.returns(3L, Page::getTotalElements)
+				.returns(4L, Page::getTotalElements)
 				.returns(2, Page::getTotalPages);
 
 		assertThat(properties.getContent())
 				.hasSize(2)
 				.containsExactly(
+						ServiceCatalog.Property.builder()
+								.coordinates(ArtifactCoordinates.of("com.acme", "spring-boot-service", "1.0.0"))
+								.name("com.acme.service.property")
+								.typeName("java.lang.String")
+								.schema(StringSchema.instance())
+								.description("Local service property.")
+								.build(),
 						ServiceCatalog.Property.builder()
 								.coordinates(ArtifactCoordinates.of("org.springframework.boot", "spring-boot", "4.0.3"))
 								.name("spring.application.deprecated")
@@ -69,13 +76,6 @@ class ConfigurationCatalogServiceTest extends AbstractIntegrationTest {
 								.description("Deprecated property that is no longer needed.")
 								.defaultValue("true")
 								.deprecation("No longer needed", null)
-								.build(),
-						ServiceCatalog.Property.builder()
-								.coordinates(ArtifactCoordinates.of("org.springframework.boot", "spring-boot", "4.0.3"))
-								.name("spring.application.index")
-								.typeName("java.lang.Integer")
-								.schema(IntegerSchema.builder().format("int32").build())
-								.description("Application index.")
 								.build()
 				);
 	}

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ServiceCatalogWorkerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ServiceCatalogWorkerTest.java
@@ -2,14 +2,29 @@ package com.konfigyr.namespace.catalog;
 
 import com.konfigyr.artifactory.*;
 import com.konfigyr.entity.EntityId;
+import com.konfigyr.io.ByteArray;
+import com.konfigyr.namespace.Service;
 import com.konfigyr.namespace.ServiceCatalog;
 import com.konfigyr.namespace.Services;
+import com.konfigyr.namespace.manifest.ServiceManifests;
 import com.konfigyr.test.AbstractIntegrationTest;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.json.JsonMapper;
 
+import java.util.List;
+import java.util.Objects;
+
+import static com.konfigyr.data.tables.ArtifactVersionProperties.ARTIFACT_VERSION_PROPERTIES;
+import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
+import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
+import static com.konfigyr.data.tables.PropertyDefinitions.PROPERTY_DEFINITIONS;
+import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
 import static org.assertj.core.api.Assertions.*;
 
 class ServiceCatalogWorkerTest extends AbstractIntegrationTest {
@@ -18,7 +33,16 @@ class ServiceCatalogWorkerTest extends AbstractIntegrationTest {
 	Services services;
 
 	@Autowired
+	ServiceManifests manifests;
+
+	@Autowired
 	ServiceCatalogWorker worker;
+
+	@Autowired
+	DSLContext context;
+
+	@Autowired
+	JsonMapper jsonMapper;
 
 	@Test
 	@DisplayName("should fail to build service catalog for unknown service release")
@@ -33,11 +57,60 @@ class ServiceCatalogWorkerTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should build the service catalog for a service release with matching property descriptors")
 	void buildServiceCatalog() {
+		final var service = serviceFor(3);
+
 		assertThatNoException().isThrownBy(() -> worker.build(EntityId.from(2)));
 
-		assertThat(services.catalog(EntityId.from(3)))
-				.hasSize(5)
+		assertThatObject(manifests.get(service))
+				.returns(EntityId.from(2).serialize(), Manifest::id)
+				.returns(service.name(), Manifest::name)
+				.extracting(Manifest::artifacts, InstanceOfAssertFactories.iterable(ManifestEntry.class))
+				.hasSize(4)
+				.extracting(ArtifactCoordinates::of, ManifestEntry::source, ManifestEntry::checksum)
+				.containsExactlyInAnyOrder(
+						tuple(
+								ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.1"),
+								ArtifactSource.ARTIFACTORY,
+								"b4114c17ac46992508628d6c905e39b73a0208df56374dba3ddc545016f83fb7"
+						),
+						tuple(
+								ArtifactCoordinates.parse("org.springframework.modulith:spring-modulith-core:2.0.4"),
+								ArtifactSource.ARTIFACTORY,
+								"ec54eb43a2f17d3fecf5062c987c794ea025da258de0b6ea6483542ef79e3f8a"
+						),
+						tuple(
+								ArtifactCoordinates.parse("org.springframework.boot:spring-boot:4.0.4"),
+								ArtifactSource.ARTIFACTORY,
+								"ec54eb43a2f17d3fecf5062c987c794ea025da258de0b6ea6483542ef79e3f8a"
+						),
+						tuple(
+								ArtifactCoordinates.parse("com.acme:spring-boot-library:1.1.4"),
+								ArtifactSource.LOCAL,
+								"HX26naW4bSuS+0yUHCyXw83XsVgNAyafKDHD576DyhA="
+						)
+				);
+
+		assertThat(services.catalog(service.id()))
+				.hasSize(7)
 				.satisfiesExactly(
+						it -> assertThat(it)
+								.returns(ArtifactCoordinates.parse("com.acme:spring-boot-library:1.1.4"),
+										ServiceCatalog.Property::artifact)
+								.returns("com.acme.library.deprecated", ServiceCatalog.Property::name)
+								.returns("java.lang.Integer", ServiceCatalog.Property::typeName)
+								.returns(IntegerSchema.instance(), ServiceCatalog.Property::schema)
+								.returns("Deprecated local library property.", ServiceCatalog.Property::description)
+								.returns("567889", ServiceCatalog.Property::defaultValue)
+								.returns(new Deprecation("Removed without replacement", null), ServiceCatalog.Property::deprecation),
+						it -> assertThat(it)
+								.returns(ArtifactCoordinates.parse("com.acme:spring-boot-library:1.1.4"),
+										ServiceCatalog.Property::artifact)
+								.returns("com.acme.library.property", ServiceCatalog.Property::name)
+								.returns("java.lang.Boolean", ServiceCatalog.Property::typeName)
+								.returns(BooleanSchema.instance(), ServiceCatalog.Property::schema)
+								.returns("Local library property.", ServiceCatalog.Property::description)
+								.returns("true", ServiceCatalog.Property::defaultValue)
+								.returns(null, ServiceCatalog.Property::deprecation),
 						it -> assertThat(it)
 								.returns(ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.1"),
 										ServiceCatalog.Property::artifact)
@@ -96,11 +169,28 @@ class ServiceCatalogWorkerTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should re-build the service catalog for a service release with matching property descriptors")
 	void rebuildServiceCatalog() {
+		final var service = serviceFor(2);
+
 		assertThatNoException().isThrownBy(() -> worker.build(EntityId.from(1)));
 
-		assertThat(services.catalog(EntityId.from(2)))
-				.hasSize(10)
+		assertThatObject(manifests.get(service))
+				.returns(EntityId.from(1).serialize(), Manifest::id)
+				.returns(service.name(), Manifest::name)
+				.extracting(Manifest::artifacts, InstanceOfAssertFactories.iterable(ManifestEntry.class))
+				.hasSize(8);
+
+		assertThat(services.catalog(service.id()))
+				.hasSize(11)
 				.satisfiesExactly(
+						it -> assertThat(it)
+								.returns(ArtifactCoordinates.parse("com.acme:spring-boot-service:1.0.0"),
+										ServiceCatalog.Property::artifact)
+								.returns("com.acme.service.property", ServiceCatalog.Property::name)
+								.returns("java.lang.String", ServiceCatalog.Property::typeName)
+								.returns(StringSchema.instance(), ServiceCatalog.Property::schema)
+								.returns("Local service property.", ServiceCatalog.Property::description)
+								.returns(null, ServiceCatalog.Property::defaultValue)
+								.returns(null, ServiceCatalog.Property::deprecation),
 						it -> assertThat(it)
 								.returns(ArtifactCoordinates.parse("org.springframework.boot:spring-boot-actuator:4.0.4"),
 										ServiceCatalog.Property::artifact)
@@ -202,6 +292,133 @@ class ServiceCatalogWorkerTest extends AbstractIntegrationTest {
 								.returns("true", ServiceCatalog.Property::defaultValue)
 								.returns(null, ServiceCatalog.Property::deprecation)
 				);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should promote a LOCAL artifact to ARTIFACTORY once it is indexed and rebuild its properties")
+	void promoteLocalArtifactOnceIndexedByArtifactory() throws Exception {
+		final var service = serviceFor(3);
+		final var metadata = jsonMapper.readValue(
+				new ClassPathResource("fixtures/com.acme:spring-boot-library:1.1.4.json").getInputStream(),
+				ArtifactMetadata.class
+		);
+
+		assertThatNoException().isThrownBy(() -> insertArtifactMetadataPublication(metadata));
+		assertThatNoException().isThrownBy(() -> worker.build(EntityId.from(2)));
+
+		final var coordinates = ArtifactCoordinates.of(metadata);
+
+		assertThat(context.selectFrom(SERVICE_ARTIFACTS)
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(2L))
+				.and(SERVICE_ARTIFACTS.COORDINATES.eq(coordinates.format()))
+				.fetchOne())
+				.isNotNull()
+				.returns(ArtifactSource.ARTIFACTORY.name(), SERVICE_ARTIFACTS.SOURCE::get)
+				.returns(null, SERVICE_ARTIFACTS.CHECKSUM::get)
+				.returns(null, SERVICE_ARTIFACTS.NAME::get)
+				.returns(null, SERVICE_ARTIFACTS.DESCRIPTION::get)
+				.returns(null, SERVICE_ARTIFACTS.WEBSITE::get)
+				.returns(null, SERVICE_ARTIFACTS.REPOSITORY::get);
+
+		assertThatObject(manifests.get(service))
+				.returns(EntityId.from(2).serialize(), Manifest::id)
+				.returns(service.name(), Manifest::name)
+				.extracting(Manifest::artifacts, InstanceOfAssertFactories.iterable(ManifestEntry.class))
+				.hasSize(4)
+				.extracting(ArtifactCoordinates::of, ManifestEntry::source, ManifestEntry::checksum)
+				.containsExactlyInAnyOrder(
+						tuple(
+								ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.1"),
+								ArtifactSource.ARTIFACTORY,
+								"b4114c17ac46992508628d6c905e39b73a0208df56374dba3ddc545016f83fb7"
+						),
+						tuple(
+								ArtifactCoordinates.parse("org.springframework.modulith:spring-modulith-core:2.0.4"),
+								ArtifactSource.ARTIFACTORY,
+								"ec54eb43a2f17d3fecf5062c987c794ea025da258de0b6ea6483542ef79e3f8a"
+						),
+						tuple(
+								ArtifactCoordinates.parse("org.springframework.boot:spring-boot:4.0.4"),
+								ArtifactSource.ARTIFACTORY,
+								"ec54eb43a2f17d3fecf5062c987c794ea025da258de0b6ea6483542ef79e3f8a"
+						),
+						tuple(
+								ArtifactCoordinates.parse("com.acme:spring-boot-library:1.1.4"),
+								ArtifactSource.ARTIFACTORY,
+								"0688b5581b22b2ab5740e6b7f6d5f72ca159e571d7c40994329c95a7e9427edd"
+						)
+				);
+
+		assertThat(services.catalog(service.id()))
+				.hasSize(7)
+				.extracting(ServiceCatalog.Property::artifact, ServiceCatalog.Property::name)
+				.contains(tuple(coordinates, "com.acme.library.imported"))
+				.contains(tuple(coordinates, "com.acme.library.property"))
+				.doesNotContain(tuple(coordinates, "com.acme.library.deprecated"));
+	}
+
+	Service serviceFor(long id) {
+		return assertThat(services.get(EntityId.from(id)))
+				.as("Service with id %s must be present", id)
+				.isPresent()
+				.get()
+				.actual();
+	}
+
+	private void insertArtifactMetadataPublication(ArtifactMetadata metadata) {
+		final Long artifactId = context.insertInto(ARTIFACTS)
+				.set(ARTIFACTS.GROUP_ID, metadata.groupId())
+				.set(ARTIFACTS.ARTIFACT_ID, metadata.artifactId())
+				.set(ARTIFACTS.NAME, metadata.name())
+				.set(ARTIFACTS.DESCRIPTION, metadata.description())
+				.set(ARTIFACTS.WEBSITE, Objects.toString(metadata.website(), null))
+				.set(ARTIFACTS.REPOSITORY, Objects.toString(metadata.repository(), null))
+				.returning(ARTIFACTS.ID)
+				.fetchOne(ARTIFACTS.ID);
+
+		final Long artifactVersionId = context.insertInto(ARTIFACT_VERSIONS)
+				.set(ARTIFACT_VERSIONS.ARTIFACT_ID, artifactId)
+				.set(ARTIFACT_VERSIONS.VERSION, metadata.version())
+				.set(ARTIFACT_VERSIONS.STATE, PublicationState.PUBLISHED.name())
+				.set(ARTIFACT_VERSIONS.CHECKSUM, ByteArray.fromBase64String(metadata.checksum()))
+				.returning(ARTIFACT_VERSIONS.ID)
+				.fetchOne(ARTIFACT_VERSIONS.ID);
+
+		var propertyInsertQuery = context.insertInto(PROPERTY_DEFINITIONS).columns(
+				PROPERTY_DEFINITIONS.ARTIFACT_ID,
+				PROPERTY_DEFINITIONS.CHECKSUM,
+				PROPERTY_DEFINITIONS.NAME,
+				PROPERTY_DEFINITIONS.TYPE_NAME,
+				PROPERTY_DEFINITIONS.SCHEMA,
+				PROPERTY_DEFINITIONS.DESCRIPTION
+		);
+
+		for (final var property : metadata.properties()) {
+			propertyInsertQuery = propertyInsertQuery.values(
+					artifactId,
+					ByteArray.fromString(property.name()),
+					property.name(),
+					property.typeName(),
+					ByteArray.fromString(jsonMapper.writeValueAsString(property.schema())),
+					property.description()
+			);
+		}
+
+		final List<Long> propertyDefinitions = propertyInsertQuery
+				.returning(PROPERTY_DEFINITIONS.ID)
+				.fetch(PROPERTY_DEFINITIONS.ID);
+
+		var propertyVersionInsertQuery = context.insertInto(ARTIFACT_VERSION_PROPERTIES).columns(
+				ARTIFACT_VERSION_PROPERTIES.ARTIFACT_VERSION_ID,
+				ARTIFACT_VERSION_PROPERTIES.PROPERTY_DEFINITION_ID
+		);
+
+		for (final var id : propertyDefinitions) {
+			propertyVersionInsertQuery = propertyVersionInsertQuery.values(artifactVersionId, id);
+		}
+
+		propertyVersionInsertQuery.execute();
 	}
 
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceControllerTest.java
@@ -2,6 +2,7 @@ package com.konfigyr.namespace.controller;
 
 import com.konfigyr.artifactory.*;
 import com.konfigyr.entity.EntityId;
+import com.konfigyr.hateoas.CollectionModel;
 import com.konfigyr.hateoas.Link;
 import com.konfigyr.hateoas.LinkRelation;
 import com.konfigyr.hateoas.PagedModel;
@@ -10,7 +11,6 @@ import com.konfigyr.namespace.ServiceCatalog;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.test.AbstractControllerTest;
 import com.konfigyr.test.TestPrincipals;
-import com.konfigyr.version.Version;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,11 +18,9 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,9 +28,6 @@ import static org.assertj.core.api.Assertions.within;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 
 class ServiceControllerTest extends AbstractControllerTest {
-
-	// matches the checksum seeded for artifact_versions rows referenced by konfigyr-id's manifest, see artifactory.sql
-	private static final String EXISTING_ARTIFACT_VERSION_CHECKSUM = "ec54eb43a2f17d3fecf5062c987c794ea025da258de0b6ea6483542ef79e3f8a";
 
 	@Test
 	@DisplayName("should retrieve all available services for Konfigyr namespace")
@@ -490,178 +485,6 @@ class ServiceControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
-	@DisplayName("should retrieve the latest namespace service manifest")
-	void retrieveServiceManifest() {
-		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(Manifest.class)
-				.returns(EntityId.from(1).serialize(), Manifest::id)
-				.returns("Konfigyr ID", Manifest::name)
-				.satisfies(it -> assertThat(it.artifacts())
-						.hasSize(7)
-						.usingRecursiveFieldByFieldElementComparatorIgnoringFields("resolvedAt")
-						.containsExactly(
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot")
-										.version("4.0.4")
-										.name("Spring Boot")
-										.description("Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot-actuator")
-										.version("4.0.4")
-										.name("Spring Boot Actuator")
-										.description("Spring Boot Actuator")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot-autoconfigure")
-										.version("4.0.4")
-										.name("Spring Boot AutoConfigure")
-										.description("Spring Boot auto-configuration attempts to automatically configure your Spring applications")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot-jooq")
-										.version("4.0.4")
-										.name("Spring Boot jOOQ")
-										.description("Spring Boot jOOQ support")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot-liquibase")
-										.version("4.0.4")
-										.name("Spring Boot Liquibase")
-										.description("Spring Boot Liquibase support")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.modulith")
-										.artifactId("spring-modulith-core")
-										.version("2.0.3")
-										.name("Spring Modulith Core")
-										.description("Modular monoliths with Spring Boot")
-										.website("https://spring.io/projects/spring-modulith/spring-modulith-core")
-										.repository("https://github.com/spring-projects-experimental/spring-modulith")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.modulith")
-										.artifactId("spring-modulith-moments")
-										.version("2.0.3")
-										.name("Spring Modulith Moments")
-										.description("Modular monoliths with Spring Boot")
-										.website("https://spring.io/projects/spring-modulith/spring-modulith-moments")
-										.repository("https://github.com/spring-projects-experimental/spring-modulith")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build()
-						)
-				)
-				.satisfies(it -> assertThat(it.createdAt())
-						.isCloseTo(Instant.now().minus(3, ChronoUnit.DAYS), within(1, ChronoUnit.HOURS))
-				);
-	}
-
-	@Test
-	@DisplayName("should retrieve an empty manifest for service that was not yet released")
-	void retrieveManifestForUnreleasedService() {
-		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(Manifest.class)
-				.returns(EntityId.from(1).serialize(), Manifest::id)
-				.returns("John Doe Blog", Manifest::name)
-				.returns(List.of(), Manifest::artifacts)
-				.satisfies(it -> assertThat(it.createdAt())
-						.isCloseTo(Instant.now(), within(5, ChronoUnit.MINUTES))
-				);
-	}
-
-	@Test
-	@DisplayName("should fail to retrieve manifest for unknown service")
-	void retrieveManifestForUnknownService() {
-		mvc.get().uri("/namespaces/konfigyr/services/unknown-service/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(serviceNotFound("unknown-service"));
-	}
-
-	@Test
-	@DisplayName("should not retrieve a service manifest for an unknown namespace")
-	void retrieveManifestForUnknownNamespace() {
-		mvc.get().uri("/namespaces/unknown-namespace/services/unknown-service/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatus(HttpStatus.NOT_FOUND)
-				.satisfies(namespaceNotFound("unknown-namespace"));
-	}
-
-	@Test
-	@DisplayName("should not retrieve service manifest when namespaces:read scope is not present")
-	void retrieveManifestWithoutScope() {
-		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
-				.with(authentication(TestPrincipals.jane()))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(forbidden(OAuthScope.READ_NAMESPACES));
-	}
-
-	@Test
-	@DisplayName("should not retrieve service manifest when user is not a member of a namespace")
-	void retrieveManifestWithoutMembership() {
-		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
-				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(forbidden());
-	}
-
-	@Test
 	@DisplayName("should retrieve the latest namespace service catalog")
 	void retrieveServiceCatalog() {
 		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/catalog")
@@ -677,14 +500,10 @@ class ServiceControllerTest extends AbstractControllerTest {
 						.returns("konfigyr-id", Service::slug)
 				)
 				.satisfies(it -> assertThat(it.properties())
-						.hasSize(3)
-						.allSatisfy(property -> assertThat(property.artifact())
-								.returns("org.springframework.boot", ArtifactCoordinates::groupId)
-								.returns("spring-boot", ArtifactCoordinates::artifactId)
-								.returns(Version.of("4.0.3"), ArtifactCoordinates::version)
-						)
+						.hasSize(4)
 						.satisfiesExactlyInAnyOrder(
 								property -> assertThat(property)
+										.returns(ArtifactCoordinates.parse("org.springframework.boot:spring-boot:4.0.3"), ServiceCatalog.Property::artifact)
 										.returns("spring.application.name", ServiceCatalog.Property::name)
 										.returns("java.lang.String", ServiceCatalog.Property::typeName)
 										.returns(StringSchema.instance(), ServiceCatalog.Property::schema)
@@ -692,6 +511,7 @@ class ServiceControllerTest extends AbstractControllerTest {
 										.returns(null, ServiceCatalog.Property::defaultValue)
 										.returns(null, ServiceCatalog.Property::deprecation),
 								property -> assertThat(property)
+										.returns(ArtifactCoordinates.parse("org.springframework.boot:spring-boot:4.0.3"), ServiceCatalog.Property::artifact)
 										.returns("spring.application.index", ServiceCatalog.Property::name)
 										.returns("java.lang.Integer", ServiceCatalog.Property::typeName)
 										.returns(IntegerSchema.builder().format("int32").build(), ServiceCatalog.Property::schema)
@@ -699,12 +519,21 @@ class ServiceControllerTest extends AbstractControllerTest {
 										.returns(null, ServiceCatalog.Property::defaultValue)
 										.returns(null, ServiceCatalog.Property::deprecation),
 								property -> assertThat(property)
+										.returns(ArtifactCoordinates.parse("org.springframework.boot:spring-boot:4.0.3"), ServiceCatalog.Property::artifact)
 										.returns("spring.application.deprecated", ServiceCatalog.Property::name)
 										.returns("java.lang.Boolean", ServiceCatalog.Property::typeName)
 										.returns(BooleanSchema.instance(), ServiceCatalog.Property::schema)
 										.returns("Deprecated property that is no longer needed.", ServiceCatalog.Property::description)
 										.returns("true", ServiceCatalog.Property::defaultValue)
-										.returns(new Deprecation("No longer needed", null), ServiceCatalog.Property::deprecation)
+										.returns(new Deprecation("No longer needed", null), ServiceCatalog.Property::deprecation),
+								property -> assertThat(property)
+										.returns(ArtifactCoordinates.parse("com.acme:spring-boot-service:1.0.0"), ServiceCatalog.Property::artifact)
+										.returns("com.acme.service.property", ServiceCatalog.Property::name)
+										.returns("java.lang.String", ServiceCatalog.Property::typeName)
+										.returns(StringSchema.instance(), ServiceCatalog.Property::schema)
+										.returns("Local service property.", ServiceCatalog.Property::description)
+										.returns(null, ServiceCatalog.Property::defaultValue)
+										.returns(null, ServiceCatalog.Property::deprecation)
 						)
 				);
 	}
@@ -785,36 +614,41 @@ class ServiceControllerTest extends AbstractControllerTest {
 				.hasStatusOk()
 				.bodyJson()
 				.convertTo(pagedModel(ServiceCatalog.Property.class))
-				.satisfies(it -> assertThat(it.getContent())
-						.hasSize(3)
-						.allSatisfy(property -> assertThat(property.artifact())
-								.returns("org.springframework.boot", ArtifactCoordinates::groupId)
-								.returns("spring-boot", ArtifactCoordinates::artifactId)
-								.returns(Version.of("4.0.3"), ArtifactCoordinates::version)
-						)
-						.satisfiesExactlyInAnyOrder(
-								property -> assertThat(property)
-										.returns("spring.application.name", ServiceCatalog.Property::name)
-										.returns("java.lang.String", ServiceCatalog.Property::typeName)
-										.returns(StringSchema.instance(), ServiceCatalog.Property::schema)
-										.returns("Application name. Typically used with logging to help identify the application.", ServiceCatalog.Property::description)
-										.returns(null, ServiceCatalog.Property::defaultValue)
-										.returns(null, ServiceCatalog.Property::deprecation),
-								property -> assertThat(property)
-										.returns("spring.application.index", ServiceCatalog.Property::name)
-										.returns("java.lang.Integer", ServiceCatalog.Property::typeName)
-										.returns(IntegerSchema.builder().format("int32").build(), ServiceCatalog.Property::schema)
-										.returns("Application index.", ServiceCatalog.Property::description)
-										.returns(null, ServiceCatalog.Property::defaultValue)
-										.returns(null, ServiceCatalog.Property::deprecation),
-								property -> assertThat(property)
-										.returns("spring.application.deprecated", ServiceCatalog.Property::name)
-										.returns("java.lang.Boolean", ServiceCatalog.Property::typeName)
-										.returns(BooleanSchema.instance(), ServiceCatalog.Property::schema)
-										.returns("Deprecated property that is no longer needed.", ServiceCatalog.Property::description)
-										.returns("true", ServiceCatalog.Property::defaultValue)
-										.returns(new Deprecation("No longer needed", null), ServiceCatalog.Property::deprecation)
-						)
+				.extracting(CollectionModel::getContent, InstanceOfAssertFactories.iterable(ServiceCatalog.Property.class))
+				.hasSize(4)
+				.satisfiesExactlyInAnyOrder(
+						property -> assertThat(property)
+								.returns(ArtifactCoordinates.parse("org.springframework.boot:spring-boot:4.0.3"), ServiceCatalog.Property::artifact)
+								.returns("spring.application.name", ServiceCatalog.Property::name)
+								.returns("java.lang.String", ServiceCatalog.Property::typeName)
+								.returns(StringSchema.instance(), ServiceCatalog.Property::schema)
+								.returns("Application name. Typically used with logging to help identify the application.", ServiceCatalog.Property::description)
+								.returns(null, ServiceCatalog.Property::defaultValue)
+								.returns(null, ServiceCatalog.Property::deprecation),
+						property -> assertThat(property)
+								.returns(ArtifactCoordinates.parse("org.springframework.boot:spring-boot:4.0.3"), ServiceCatalog.Property::artifact)
+								.returns("spring.application.index", ServiceCatalog.Property::name)
+								.returns("java.lang.Integer", ServiceCatalog.Property::typeName)
+								.returns(IntegerSchema.builder().format("int32").build(), ServiceCatalog.Property::schema)
+								.returns("Application index.", ServiceCatalog.Property::description)
+								.returns(null, ServiceCatalog.Property::defaultValue)
+								.returns(null, ServiceCatalog.Property::deprecation),
+						property -> assertThat(property)
+								.returns(ArtifactCoordinates.parse("org.springframework.boot:spring-boot:4.0.3"), ServiceCatalog.Property::artifact)
+								.returns("spring.application.deprecated", ServiceCatalog.Property::name)
+								.returns("java.lang.Boolean", ServiceCatalog.Property::typeName)
+								.returns(BooleanSchema.instance(), ServiceCatalog.Property::schema)
+								.returns("Deprecated property that is no longer needed.", ServiceCatalog.Property::description)
+								.returns("true", ServiceCatalog.Property::defaultValue)
+								.returns(new Deprecation("No longer needed", null), ServiceCatalog.Property::deprecation),
+						property -> assertThat(property)
+								.returns(ArtifactCoordinates.parse("com.acme:spring-boot-service:1.0.0"), ServiceCatalog.Property::artifact)
+								.returns("com.acme.service.property", ServiceCatalog.Property::name)
+								.returns("java.lang.String", ServiceCatalog.Property::typeName)
+								.returns(StringSchema.instance(), ServiceCatalog.Property::schema)
+								.returns("Local service property.", ServiceCatalog.Property::description)
+								.returns(null, ServiceCatalog.Property::defaultValue)
+								.returns(null, ServiceCatalog.Property::deprecation)
 				);
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -24,21 +24,210 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
 import static com.konfigyr.data.tables.ServiceConfigurationCatalog.SERVICE_CONFIGURATION_CATALOG;
 import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.within;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 
 class ServiceManifestControllerTest extends AbstractControllerTest {
+
+	// matches the checksum seeded for artifact_versions rows referenced by konfigyr-id's manifest, see artifactory.sql
+	private static final String EXISTING_ARTIFACT_VERSION_CHECKSUM = "ec54eb43a2f17d3fecf5062c987c794ea025da258de0b6ea6483542ef79e3f8a";
 
 	static Artifact konfigyrArtifactoryArtifact = Artifact.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
 	static Artifact konfigyrCryptoApiArtifact = Artifact.of("com.konfigyr", "konfigyr-crypto-api", "1.1.0");
 
 	@Autowired
 	DSLContext context;
+
+	@Test
+	@DisplayName("should retrieve the latest namespace service manifest")
+	void retrieveServiceManifest() {
+		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(Manifest.class)
+				.returns(EntityId.from(1).serialize(), Manifest::id)
+				.returns("Konfigyr ID", Manifest::name)
+				.satisfies(it -> assertThat(it.artifacts())
+						.hasSize(8)
+						.usingRecursiveFieldByFieldElementComparatorIgnoringFields("resolvedAt")
+						.containsExactly(
+								ManifestEntry.builder()
+										.groupId("com.acme")
+										.artifactId("spring-boot-service")
+										.version("1.0.0")
+										.name("Acme Spring Boot service")
+										.description("Spring Boot service")
+										.website("https://acme.com/service")
+										.repository("https://github.com/acme/service")
+										.checksum("6QRgbo04ZnpKhc3o5yZckptP+61bzEBhwNibipufooU=")
+										.source(ArtifactSource.LOCAL)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot")
+										.version("4.0.4")
+										.name("Spring Boot")
+										.description("Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot-actuator")
+										.version("4.0.4")
+										.name("Spring Boot Actuator")
+										.description("Spring Boot Actuator")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot-autoconfigure")
+										.version("4.0.4")
+										.name("Spring Boot AutoConfigure")
+										.description("Spring Boot auto-configuration attempts to automatically configure your Spring applications")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot-jooq")
+										.version("4.0.4")
+										.name("Spring Boot jOOQ")
+										.description("Spring Boot jOOQ support")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot-liquibase")
+										.version("4.0.4")
+										.name("Spring Boot Liquibase")
+										.description("Spring Boot Liquibase support")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.modulith")
+										.artifactId("spring-modulith-core")
+										.version("2.0.3")
+										.name("Spring Modulith Core")
+										.description("Modular monoliths with Spring Boot")
+										.website("https://spring.io/projects/spring-modulith/spring-modulith-core")
+										.repository("https://github.com/spring-projects-experimental/spring-modulith")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.modulith")
+										.artifactId("spring-modulith-moments")
+										.version("2.0.3")
+										.name("Spring Modulith Moments")
+										.description("Modular monoliths with Spring Boot")
+										.website("https://spring.io/projects/spring-modulith/spring-modulith-moments")
+										.repository("https://github.com/spring-projects-experimental/spring-modulith")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build()
+						)
+				)
+				.satisfies(it -> assertThat(it.createdAt())
+						.isCloseTo(Instant.now().minus(3, ChronoUnit.DAYS), within(1, ChronoUnit.HOURS))
+				);
+	}
+
+	@Test
+	@DisplayName("should retrieve an empty manifest for service that was not yet released")
+	void retrieveManifestForUnreleasedService() {
+		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(Manifest.class)
+				.returns(EntityId.from(1).serialize(), Manifest::id)
+				.returns("John Doe Blog", Manifest::name)
+				.returns(List.of(), Manifest::artifacts)
+				.satisfies(it -> assertThat(it.createdAt())
+						.isCloseTo(Instant.now(), within(5, ChronoUnit.MINUTES))
+				);
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve manifest for unknown service")
+	void retrieveManifestForUnknownService() {
+		mvc.get().uri("/namespaces/konfigyr/services/unknown-service/manifest")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound("unknown-service"));
+	}
+
+	@Test
+	@DisplayName("should not retrieve a service manifest for an unknown namespace")
+	void retrieveManifestForUnknownNamespace() {
+		mvc.get().uri("/namespaces/unknown-namespace/services/unknown-service/manifest")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(namespaceNotFound("unknown-namespace"));
+	}
+
+	@Test
+	@DisplayName("should not retrieve service manifest when namespaces:read scope is not present")
+	void retrieveManifestWithoutScope() {
+		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
+				.with(authentication(TestPrincipals.jane()))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.READ_NAMESPACES));
+	}
+
+	@Test
+	@DisplayName("should not retrieve service manifest when user is not a member of a namespace")
+	void retrieveManifestWithoutMembership() {
+		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
 
 	@Test
 	@Transactional
@@ -359,6 +548,101 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@Transactional
+	@DisplayName("should complete a release once every declared artifact has been uploaded")
+	void shouldCompleteRelease() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact, "checksum");
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(metadata))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
+
+		assertThatUpload(release.id(), metadata)
+				.hasStatus(HttpStatus.NO_CONTENT);
+
+		assertThatComplete(release.id())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.RELEASED, ServiceRelease::state)
+				.returns(List.of(), ServiceRelease::errors)
+				.satisfies(completed -> assertThat(completed.publishedAt()).isNotNull());
+
+		assertThat(context.select(SERVICE_RELEASES.STATE, SERVICE_RELEASES.PUBLISHED_AT)
+				.from(SERVICE_RELEASES)
+				.where(SERVICE_RELEASES.ID.eq(EntityId.from(release.id()).get()))
+				.fetchOneMap())
+				.containsEntry(SERVICE_RELEASES.STATE.getName(), ReleaseState.RELEASED.name())
+				.hasEntrySatisfying(SERVICE_RELEASES.PUBLISHED_AT.getName(), it -> assertThat(it).isNotNull());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to complete a release when a declared artifact was never uploaded")
+	void shouldFailToCompleteReleaseWithMissingUpload() {
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum"))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
+
+		assertThatComplete(release.id())
+				.hasStatus(HttpStatus.CONFLICT)
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.FAILED, ServiceRelease::state)
+				.satisfies(completed -> assertThat(completed.errors())
+						.containsExactly("Artifact with coordinates '%s' was not uploaded"
+								.formatted(ArtifactCoordinates.of(konfigyrArtifactoryArtifact).format()))
+				);
+
+		assertThat(context.select(SERVICE_RELEASES.STATE)
+				.from(SERVICE_RELEASES)
+				.where(SERVICE_RELEASES.ID.eq(EntityId.from(release.id()).get()))
+				.fetchOne(SERVICE_RELEASES.STATE))
+				.isEqualTo(ReleaseState.FAILED.name());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to complete a release that is not pending")
+	void shouldRejectCompleteForNotPendingRelease() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact, "checksum");
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(metadata))
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.actual();
+
+		assertThatUpload(release.id(), metadata).hasStatus(HttpStatus.NO_CONTENT);
+		assertThatComplete(release.id()).hasStatusOk();
+
+		assertThatComplete(release.id())
+				.satisfies(problemDetailFor(HttpStatus.CONFLICT, problem -> problem
+						.hasTitle("Release is not pending")
+						.hasDetailContaining("Release is no longer pending")
+				));
+	}
+
+	@Test
+	@DisplayName("should fail to complete an unknown release")
+	void shouldRejectCompleteForUnknownRelease() {
+		assertThatComplete(EntityId.from(999).serialize())
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitle("Release not found")
+						.hasDetailContaining("Could not find a release with the following identifier")
+				));
+	}
+
+	@Test
+	@DisplayName("should fail to complete a release for an unknown service")
+	void shouldRejectCompleteForUnknownService() {
+		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases/{id}/complete", EntityId.from(999).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound("unknown-service"));
+	}
+
+	@Test
 	@DisplayName("should not resolve a release when user is not a member of the namespace")
 	void shouldRejectWhenNotAMember() {
 		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
@@ -433,6 +717,14 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(metadata))
+				.exchange()
+				.assertThat()
+				.apply(log());
+	}
+
+	private MvcTestResultAssert assertThatComplete(String id) {
+		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/complete", id)
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
 				.exchange()
 				.assertThat()
 				.apply(log());

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/manifest/ServiceManifestsTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/manifest/ServiceManifestsTest.java
@@ -5,6 +5,7 @@ import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.Namespace;
 import com.konfigyr.namespace.NamespaceManager;
 import com.konfigyr.namespace.Service;
+import com.konfigyr.namespace.ServiceEvent;
 import com.konfigyr.namespace.Services;
 import com.konfigyr.test.AbstractIntegrationTest;
 import org.jooq.DSLContext;
@@ -12,15 +13,17 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.modulith.test.AssertablePublishedEvents;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
 import static com.konfigyr.data.tables.ServiceConfigurationCatalog.SERVICE_CONFIGURATION_CATALOG;
 import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.*;
 
 class ServiceManifestsTest extends AbstractIntegrationTest {
 
@@ -48,13 +51,15 @@ class ServiceManifestsTest extends AbstractIntegrationTest {
 
 	@Test
 	@Transactional
-	@DisplayName("should open a release and upload artifact metadata for a declared coordinate")
-	void shouldOpenAndUploadArtifactMetadata() {
+	@DisplayName("should open a release and upload artifact metadata for a declared coordinate and complete")
+	void shouldProcessRelease(AssertablePublishedEvents events) {
 		final var metadata = metadata(konfigyrArtifactoryArtifact);
 		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(metadata)));
 
-		assertThat(release.state())
-				.isEqualTo(ReleaseState.PENDING);
+		assertThat(release)
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.returns(List.of(), ServiceRelease::errors)
+				.returns(null, ServiceRelease::publishedAt);
 
 		assertThat(release.artifacts())
 				.hasSize(1)
@@ -77,6 +82,25 @@ class ServiceManifestsTest extends AbstractIntegrationTest {
 						.and(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID.eq(metadata.artifactId()))
 						.and(SERVICE_CONFIGURATION_CATALOG.VERSION.eq(metadata.version()))
 		)).isEqualTo(metadata.properties().size());
+
+		final var completed = manifests.complete(service, EntityId.from(release.id()));
+
+		assertThat(completed)
+				.returns(ReleaseState.RELEASED, ServiceRelease::state)
+				.returns(List.of(), ServiceRelease::errors);
+
+		assertThat(completed.publishedAt())
+				.isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS));
+
+		assertThat(context.select(SERVICE_RELEASES.STATE)
+				.from(SERVICE_RELEASES)
+				.where(SERVICE_RELEASES.ID.eq(EntityId.from(release.id()).get()))
+				.fetchOne(SERVICE_RELEASES.STATE))
+				.isEqualTo(ReleaseState.RELEASED.name());
+
+		events.assertThat()
+				.contains(ServiceEvent.Released.class)
+				.matching(ServiceEvent.Released::get, service);
 	}
 
 	@Test
@@ -109,6 +133,53 @@ class ServiceManifestsTest extends AbstractIntegrationTest {
 				.isThrownBy(() -> manifests.upload(service, EntityId.from(release.id()), metadata))
 				.returns(ReleaseState.RELEASED, ReleaseNotPendingException::getState)
 				.returns(EntityId.from(release.id()), ReleaseNotPendingException::getReleaseId);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to complete a release when a declared artifact was never uploaded")
+	void shouldFailToCompleteReleaseWithMissingUpload(AssertablePublishedEvents events) {
+		final var metadata = metadata(konfigyrArtifactoryArtifact);
+		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(metadata)));
+
+		final var completed = manifests.complete(service, EntityId.from(release.id()));
+
+		assertThat(completed.state()).isEqualTo(ReleaseState.FAILED);
+		assertThat(completed.errors()).containsExactly(
+				"Artifact with coordinates '%s' was not uploaded".formatted(ArtifactCoordinates.of(metadata).format())
+		);
+
+		assertThat(context.select(SERVICE_RELEASES.STATE)
+				.from(SERVICE_RELEASES)
+				.where(SERVICE_RELEASES.ID.eq(EntityId.from(release.id()).get()))
+				.fetchOne(SERVICE_RELEASES.STATE))
+				.isEqualTo(ReleaseState.FAILED.name());
+
+		events.assertThat()
+				.contains(ServiceEvent.ReleaseFailed.class)
+				.matching(ServiceEvent.ReleaseFailed::errors, completed.errors());
+	}
+
+	@Test
+	@DisplayName("should fail to complete a release that does not exist")
+	void shouldRejectCompleteForUnknownRelease() {
+		assertThatExceptionOfType(ReleaseNotFoundException.class)
+				.isThrownBy(() -> manifests.complete(service, EntityId.from(95673678)))
+				.returns(EntityId.from(95673678), ReleaseNotFoundException::getReleaseId);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to complete a release that is not pending")
+	void shouldRejectCompleteForNotPendingRelease() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact);
+		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(metadata)));
+		manifests.upload(service, EntityId.from(release.id()), metadata);
+		manifests.complete(service, EntityId.from(release.id()));
+
+		assertThatExceptionOfType(ReleaseNotPendingException.class)
+				.isThrownBy(() -> manifests.complete(service, EntityId.from(release.id())))
+				.returns(ReleaseState.RELEASED, ReleaseNotPendingException::getState);
 	}
 
 	private static ArtifactMetadata metadata(Artifact artifact) {

--- a/konfigyr-api/src/test/resources/fixtures/com.acme:spring-boot-library:1.1.4.json
+++ b/konfigyr-api/src/test/resources/fixtures/com.acme:spring-boot-library:1.1.4.json
@@ -1,0 +1,32 @@
+{
+  "groupId": "com.acme",
+  "artifactId": "spring-boot-library",
+  "version": "1.1.4",
+  "name": "Acme Spring Boot Library",
+  "description": "Official Acme Spring Boot library",
+  "website": "https://acme.com/library",
+  "repository": "https://github.com/acme/library",
+  "checksum": "Boi1WBsisqtXQOa39tX3LKFZ5XHXxAmUMpyVp+lCft0=",
+  "properties": [
+    {
+      "name": "com.acme.library.imported",
+      "schema": {
+        "type": "string"
+      },
+      "typeName": "java.lang.String",
+      "description": "Imported library property from Artifactory.",
+      "defaultValue": null,
+      "deprecation": null
+    },
+    {
+      "name": "com.acme.library.property",
+      "schema": {
+        "type": "boolean"
+      },
+      "typeName": "java.lang.Boolean",
+      "description": "Local library property.",
+      "defaultValue": "false",
+      "deprecation": null
+    }
+  ]
+}

--- a/konfigyr-data/src/main/resources/migrations/namespaces/namespaces-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/namespaces/namespaces-1.0.0.xml
@@ -356,7 +356,32 @@
 			<column name="checksum" type="text" remarks="SHA-256 hex digest of the uploaded Spring Boot configuration metadata; null while the artifact still needs to be uploaded.">
 				<constraints nullable="true" />
 			</column>
+
+			<column name="name" type="text" remarks="Human-readable name of the artifact; only ever set for LOCAL coordinates, from the uploaded ArtifactMetadata.">
+				<constraints nullable="true" />
+			</column>
+
+			<column name="description" type="text" remarks="Textual description of the artifact; only ever set for LOCAL coordinates, from the uploaded ArtifactMetadata.">
+				<constraints nullable="true" />
+			</column>
+
+			<column name="website" type="text" remarks="Documentation or project website URL of the artifact; only ever set for LOCAL coordinates, from the uploaded ArtifactMetadata.">
+				<constraints nullable="true" />
+			</column>
+
+			<column name="repository" type="text" remarks="Source control repository URL of the artifact; only ever set for LOCAL coordinates, from the uploaded ArtifactMetadata.">
+				<constraints nullable="true" />
+			</column>
+
+			<column name="created_at" type="timestamptz" defaultValue="NOW()" remarks="When this coordinate was first declared for this service; stable across take-overs of the same release.">
+				<constraints nullable="false" />
+			</column>
 		</createTable>
+
+		<sql>
+			ALTER TABLE service_artifacts
+				ADD COLUMN coordinates text GENERATED ALWAYS AS (group_id || ':' || artifact_id || ':' || version) STORED;
+		</sql>
 
 		<addForeignKeyConstraint
 				baseTableName="service_artifacts"
@@ -450,6 +475,11 @@
 			`service_configuration_catalog_default` that would be used as a fallback in case the service specific
 			partition can't be created.
 		</comment>
+
+		<sql>
+			ALTER TABLE service_configuration_catalog
+				ADD COLUMN coordinates text GENERATED ALWAYS AS (group_id || ':' || artifact_id || ':' || version) STORED;
+		</sql>
 
 		<addForeignKeyConstraint
 				baseTableName="service_configuration_catalog"

--- a/konfigyr-test/src/main/resources/data/services.sql
+++ b/konfigyr-test/src/main/resources/data/services.sql
@@ -7,20 +7,24 @@ INSERT INTO service_releases(id, service_id, version, state, created_at) VALUES
 (1, 2, 'latest', 'COMPLETE', now() - interval '3 days'),
 (2, 3, 'latest', 'COMPLETE', now() - interval '2 days');
 
-INSERT INTO service_artifacts(release_id, group_id, artifact_id, version, source) VALUES
-(1, 'org.springframework.boot', 'spring-boot', '4.0.4', 'ARTIFACTORY'),
-(1, 'org.springframework.boot', 'spring-boot-autoconfigure', '4.0.4', 'ARTIFACTORY'),
-(1, 'org.springframework.boot', 'spring-boot-actuator', '4.0.4', 'ARTIFACTORY'),
-(1, 'org.springframework.boot', 'spring-boot-jooq', '4.0.4', 'ARTIFACTORY'),
-(1, 'org.springframework.boot', 'spring-boot-liquibase', '4.0.4', 'ARTIFACTORY'),
-(1, 'org.springframework.modulith', 'spring-modulith-core', '2.0.3', 'ARTIFACTORY'),
-(1, 'org.springframework.modulith', 'spring-modulith-moments', '2.0.3', 'ARTIFACTORY'),
-(2, 'com.konfigyr', 'konfigyr-crypto-api', '1.0.1', 'ARTIFACTORY'),
-(2, 'org.springframework.boot', 'spring-boot', '4.0.4', 'ARTIFACTORY'),
-(2, 'org.springframework.boot', 'spring-boot-jackson', '4.0.4', 'ARTIFACTORY'),
-(2, 'org.springframework.modulith', 'spring-modulith-core', '2.0.4', 'ARTIFACTORY');
+INSERT INTO service_artifacts(release_id, group_id, artifact_id, version, source, checksum, name, description, website, repository) VALUES
+(1, 'org.springframework.boot', 'spring-boot', '4.0.4', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(1, 'org.springframework.boot', 'spring-boot-autoconfigure', '4.0.4', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(1, 'org.springframework.boot', 'spring-boot-actuator', '4.0.4', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(1, 'org.springframework.boot', 'spring-boot-jooq', '4.0.4', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(1, 'org.springframework.boot', 'spring-boot-liquibase', '4.0.4', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(1, 'org.springframework.modulith', 'spring-modulith-core', '2.0.3', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(1, 'org.springframework.modulith', 'spring-modulith-moments', '2.0.3', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(1, 'com.acme', 'spring-boot-service', '1.0.0', 'LOCAL', '6QRgbo04ZnpKhc3o5yZckptP+61bzEBhwNibipufooU=', 'Acme Spring Boot service', 'Spring Boot service', 'https://acme.com/service', 'https://github.com/acme/service'),
+(2, 'com.konfigyr', 'konfigyr-crypto-api', '1.0.1', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(2, 'org.springframework.boot', 'spring-boot', '4.0.4', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(2, 'org.springframework.modulith', 'spring-modulith-core', '2.0.4', 'ARTIFACTORY', NULL, NULL, NULL, NULL, NULL),
+(2, 'com.acme', 'spring-boot-library', '1.1.4', 'LOCAL', 'HX26naW4bSuS+0yUHCyXw83XsVgNAyafKDHD576DyhA=', 'Acme Spring Boot library', 'Spring Boot library', 'https://acme.com/library', 'https://github.com/acme/library');
 
 INSERT INTO service_configuration_catalog(service_id, release_id, group_id, artifact_id, version, name, type_name, schema, description, default_value, deprecation) VALUES
 (2, 1, 'org.springframework.boot', 'spring-boot', '4.0.3', 'spring.application.name', 'java.lang.String', '{"type":"string"}', 'Application name. Typically used with logging to help identify the application.', NULL, NULL),
 (2, 1, 'org.springframework.boot', 'spring-boot', '4.0.3', 'spring.application.index', 'java.lang.Integer', '{"type":"integer","format":"int32"}', 'Application index.', NULL, NULL),
-(2, 1, 'org.springframework.boot', 'spring-boot', '4.0.3', 'spring.application.deprecated', 'java.lang.Boolean', '{"type":"boolean"}', 'Deprecated property that is no longer needed.', 'true', '{"reason":"No longer needed"}');
+(2, 1, 'org.springframework.boot', 'spring-boot', '4.0.3', 'spring.application.deprecated', 'java.lang.Boolean', '{"type":"boolean"}', 'Deprecated property that is no longer needed.', 'true', '{"reason":"No longer needed"}'),
+(2, 1, 'com.acme', 'spring-boot-service', '1.0.0', 'com.acme.service.property', 'java.lang.String', '{"type":"string"}', 'Local service property.', NULL, NULL),
+(3, 2, 'com.acme', 'spring-boot-library', '1.1.4', 'com.acme.library.property', 'java.lang.Boolean', '{"type":"boolean"}', 'Local library property.', 'true', NULL),
+(3, 2, 'com.acme', 'spring-boot-library', '1.1.4', 'com.acme.library.deprecated', 'java.lang.Integer', '{"type":"integer"}', 'Deprecated local library property.', '567889', '{"reason":"Removed without replacement"}');


### PR DESCRIPTION
## Summary

- Adds `POST /namespaces/{namespace}/services/{slug}/releases/{id}/complete`, which validates that every artifact declared for a release has been uploaded. On success the release moves to `RELEASED` and a `ServiceEvent.Released` event is published; on failure it moves to `FAILED`, records the missing coordinates, and publishes a new `ServiceEvent.ReleaseFailed` event.
- Moves the manifest read model (`GET .../manifest`) into `ServiceManifests`/`DefaultServiceManifests`, retiring `Services.manifest()` and its private helpers. `ServiceManifestController` now owns the full release lifecycle: resolve, upload, complete, and read.
- `ServiceCatalogWorker` now promotes a `LOCAL` `service_artifacts` coordinate to `ARTIFACTORY` once that coordinate has been indexed by the Artifactory, before rebuilding the release's catalog. Once indexed there, the Artifactory is the more trustworthy source and should supersede whatever a build plugin uploaded directly. The promotion is scoped per-release and runs inside the worker (not the event listener), since a single Artifactory publication can affect many releases and the worker already processes them one at a time off a debounced queue.
- Adds `name`, `description`, `website`, `repository`, and `created_at` columns to `service_artifacts`, populated from the uploaded `ArtifactMetadata` for `LOCAL` coordinates, plus a generated `coordinates` column on both `service_artifacts` and `service_configuration_catalog` to simplify coordinate comparisons in queries.
- Fixes a bug where `ManifestEntry.resolvedAt()` was read from `ARTIFACTS.CREATED_AT`, which is `null` for `LOCAL` coordinates never indexed by the Artifactory; it now always reads `SERVICE_ARTIFACTS.CREATED_AT`.
