### PR TITLE
Add `GET /releases/{id}` to retrieve a service release

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
@@ -9,6 +9,7 @@ import com.konfigyr.namespace.NamespaceNotFoundException;
 import com.konfigyr.namespace.Service;
 import com.konfigyr.namespace.ServiceNotFoundException;
 import com.konfigyr.namespace.Services;
+import com.konfigyr.namespace.manifest.ReleaseNotFoundException;
 import com.konfigyr.namespace.manifest.ServiceManifests;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
@@ -56,6 +57,26 @@ class ServiceManifestController {
 		);
 
 		return Assemblers.release(ns, service).assemble(manifests.open(service, candidates));
+	}
+
+	@GetMapping("/releases/{id}")
+	@PreAuthorize("isMember(#namespace)")
+	@RequiresScope(OAuthScope.PUBLISH_MANIFESTS)
+	EntityModel<ServiceRelease> release(
+			@PathVariable String namespace,
+			@PathVariable String slug,
+			@PathVariable EntityId id
+	) {
+		final Namespace ns = lookupNamespace(namespace);
+		final Service service = services.get(ns, slug).orElseThrow(
+				() -> new ServiceNotFoundException(namespace, slug)
+		);
+
+		final ServiceRelease release = manifests.get(service, id).orElseThrow(
+				() -> new ReleaseNotFoundException(id)
+		);
+
+		return Assemblers.release(ns, service).assemble(release);
 	}
 
 	@PostMapping("/releases/{id}/artifacts")

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
@@ -343,10 +343,7 @@ class DefaultServiceManifests implements ServiceManifests {
 		final List<ArtifactCoordinates> missing = findMissingArtifactCoordinates(releaseId);
 
 		if (!missing.isEmpty()) {
-			final List<String> errors = missing.stream()
-					.map(ArtifactCoordinates::format)
-					.map("Artifact with coordinates '%s' was not uploaded"::formatted)
-					.toList();
+			final List<String> errors = toMissingArtifactErrors(missing);
 
 			context.update(SERVICE_RELEASES)
 					.set(SERVICE_RELEASES.STATE, ReleaseState.FAILED.name())
@@ -382,6 +379,69 @@ class DefaultServiceManifests implements ServiceManifests {
 				.state(ReleaseState.RELEASED)
 				.publishedAt(publishedAt.toInstant())
 				.build();
+	}
+
+	/**
+	 * Retrieves a previously opened or completed release by its identifier, rebuilding the same
+	 * {@link ServiceRelease} shape {@link #open} and {@link #complete} already return from what is
+	 * currently persisted in {@code service_releases} and {@code service_artifacts}.
+	 * <p>
+	 * Each declared coordinate's {@link ArtifactUploadStatus} is re-derived from its current
+	 * {@code service_artifacts} row: a {@code LOCAL} row with a {@literal null} checksum is still
+	 * {@link ArtifactUploadStatus#UPLOAD_REQUIRED}; anything else — an uploaded {@code LOCAL} row or an
+	 * {@code ARTIFACTORY} row — is {@link ArtifactUploadStatus#SKIP}. For a {@link ReleaseState#FAILED}
+	 * release, {@code service_artifacts} still holds the coordinates that were never uploaded, since
+	 * {@link #complete} does not prune them on failure, so {@link ServiceRelease#errors()} can be
+	 * recomputed the same way {@link #complete} reported them.
+	 *
+	 * @param service the service the release belongs to, can't be {@literal null}.
+	 * @param releaseId the entity identifier of the release to retrieve, can't be {@literal null}.
+	 * @return the matching service release, or {@literal empty} if no release with this identifier
+	 *         exists for this service.
+	 */
+	@Override
+	@Transactional(readOnly = true, label = "service-manifest.get-release")
+	public Optional<ServiceRelease> get(Service service, EntityId releaseId) {
+		final Record record = context.select(SERVICE_RELEASES.STATE, SERVICE_RELEASES.PUBLISHED_AT)
+				.from(SERVICE_RELEASES)
+				.where(DSL.and(
+						SERVICE_RELEASES.ID.eq(releaseId.get()),
+						SERVICE_RELEASES.SERVICE_ID.eq(service.id().get())
+				))
+				.fetchOne();
+
+		if (record == null) {
+			return Optional.empty();
+		}
+
+		final ReleaseState state = ReleaseState.valueOf(record.get(SERVICE_RELEASES.STATE));
+		final OffsetDateTime publishedAt = record.get(SERVICE_RELEASES.PUBLISHED_AT);
+
+		final List<ServiceReleaseEntry> entries = context.select(
+						SERVICE_ARTIFACTS.GROUP_ID,
+						SERVICE_ARTIFACTS.ARTIFACT_ID,
+						SERVICE_ARTIFACTS.VERSION,
+						SERVICE_ARTIFACTS.SOURCE,
+						SERVICE_ARTIFACTS.CHECKSUM
+				)
+				.from(SERVICE_ARTIFACTS)
+				.where(SERVICE_ARTIFACTS.RELEASE_ID.eq(releaseId.get()))
+				.fetch(DefaultServiceManifests::toServiceReleaseEntry);
+
+		final var builder = ServiceRelease.builder()
+				.id(releaseId.serialize())
+				.state(state)
+				.artifacts(entries);
+
+		if (publishedAt != null) {
+			builder.publishedAt(publishedAt.toInstant());
+		}
+
+		if (state == ReleaseState.FAILED) {
+			builder.errors(toMissingArtifactErrors(findMissingArtifactCoordinates(releaseId)));
+		}
+
+		return Optional.of(builder.build());
 	}
 
 	/**
@@ -548,6 +608,48 @@ class DefaultServiceManifests implements ServiceManifests {
 				.fetch(record -> ArtifactCoordinates.parse(
 						record.get(SERVICE_ARTIFACTS.COORDINATES)
 				));
+	}
+
+	/**
+	 * Formats each of the given missing coordinates into the error message reported on
+	 * {@link ServiceRelease#errors()}, shared by {@link #complete} and {@link #get(Service, EntityId)}
+	 * so a {@link ReleaseState#FAILED} release reports the exact same wording however it is reached.
+	 *
+	 * @param missing the coordinates that were never uploaded, can't be {@literal null}.
+	 * @return one formatted error message per missing coordinate, never {@literal null}.
+	 */
+	private static List<String> toMissingArtifactErrors(List<ArtifactCoordinates> missing) {
+		return missing.stream()
+				.map(ArtifactCoordinates::format)
+				.map("Artifact with coordinates '%s' was not uploaded"::formatted)
+				.toList();
+	}
+
+	/**
+	 * Converts a single {@code service_artifacts} row into a {@link ServiceReleaseEntry}, re-deriving
+	 * its {@link ArtifactUploadStatus} the same way {@link #open} does: an {@code ARTIFACTORY} row, or
+	 * a {@code LOCAL} row with a non-null checksum, is {@link ArtifactUploadStatus#SKIP}; a
+	 * {@code LOCAL} row with a {@literal null} checksum is still {@link ArtifactUploadStatus#UPLOAD_REQUIRED}.
+	 *
+	 * @param record the {@code service_artifacts} row to convert, can't be {@literal null}.
+	 * @return the resolved service release entry, never {@literal null}.
+	 */
+	private static ServiceReleaseEntry toServiceReleaseEntry(Record record) {
+		final ArtifactSource source = record.get(SERVICE_ARTIFACTS.SOURCE, ArtifactSource.class);
+		final String checksum = record.get(SERVICE_ARTIFACTS.CHECKSUM);
+
+		final ArtifactUploadStatus status = source == ArtifactSource.ARTIFACTORY || checksum != null
+				? ArtifactUploadStatus.SKIP
+				: ArtifactUploadStatus.UPLOAD_REQUIRED;
+
+		return ServiceReleaseEntry.of(
+				Artifact.of(
+						record.get(SERVICE_ARTIFACTS.GROUP_ID),
+						record.get(SERVICE_ARTIFACTS.ARTIFACT_ID),
+						record.get(SERVICE_ARTIFACTS.VERSION)
+				),
+				status
+		);
 	}
 
 	private Field<List<Artifact>> createServiceArtifactMultiselectField() {

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifests.java
@@ -9,6 +9,7 @@ import com.konfigyr.namespace.Service;
 import org.jspecify.annotations.NonNull;
 
 import java.util.Collection;
+import java.util.Optional;
 
 /**
  * Interface that defines a contract for building a service's Service Configuration Manifest through
@@ -59,6 +60,23 @@ public interface ServiceManifests {
 	 */
 	@NonNull
 	ServiceRelease open(@NonNull Service service, @NonNull Collection<ServiceReleaseCandidate> artifacts);
+
+	/**
+	 * Retrieves a previously opened or completed {@link ServiceRelease} by its identifier.
+	 * <p>
+	 * Returns the same shape {@link #open} and {@link #complete} already return: current
+	 * {@link com.konfigyr.artifactory.ReleaseState}, one {@link com.konfigyr.artifactory.ServiceReleaseEntry}
+	 * per declared artifact with its current {@link com.konfigyr.artifactory.ArtifactUploadStatus}, and,
+	 * for a {@link com.konfigyr.artifactory.ReleaseState#FAILED} release, the coordinates that were never
+	 * uploaded.
+	 *
+	 * @param service the service the release belongs to, can't be {@literal null}.
+	 * @param releaseId the entity identifier of the release to retrieve, can't be {@literal null}.
+	 * @return the matching service release, or {@literal empty} if no release with this identifier
+	 *         exists for this service.
+	 */
+	@NonNull
+	Optional<ServiceRelease> get(@NonNull Service service, @NonNull EntityId releaseId);
 
 	/**
 	 * Records the Spring Boot configuration metadata uploaded by the build plugin for a single artifact

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -643,6 +643,121 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@Transactional
+	@DisplayName("should retrieve a pending release with per-artifact upload status")
+	void shouldRetrievePendingRelease() {
+		final var uploaded = metadata(konfigyrArtifactoryArtifact, "checksum");
+		final var release = assertThatRelease(List.of(
+				ServiceReleaseCandidate.of(uploaded),
+				ServiceReleaseCandidate.of(konfigyrCryptoApiArtifact, "checksum")
+		)).actual();
+
+		assertThatUpload(release.id(), uploaded).hasStatus(HttpStatus.NO_CONTENT);
+
+		assertThatRelease(release.id())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.returns(List.of(), ServiceRelease::errors)
+				.satisfies(retrieved -> assertThat(retrieved.artifacts())
+						.hasSize(2)
+						.satisfiesExactlyInAnyOrder(
+								entry -> assertThat(entry)
+										.returns(ArtifactCoordinates.of(konfigyrArtifactoryArtifact), ArtifactCoordinates::of)
+										.returns(ArtifactUploadStatus.SKIP, ServiceReleaseEntry::status),
+								entry -> assertThat(entry)
+										.returns(ArtifactCoordinates.of(konfigyrCryptoApiArtifact), ArtifactCoordinates::of)
+										.returns(ArtifactUploadStatus.UPLOAD_REQUIRED, ServiceReleaseEntry::status)
+						)
+				);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should retrieve a released release")
+	void shouldRetrieveReleasedRelease() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact, "checksum");
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(metadata)).actual();
+
+		assertThatUpload(release.id(), metadata).hasStatus(HttpStatus.NO_CONTENT);
+		assertThatComplete(release.id()).hasStatusOk();
+
+		assertThatRelease(release.id())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.RELEASED, ServiceRelease::state)
+				.returns(List.of(), ServiceRelease::errors)
+				.satisfies(retrieved -> assertThat(retrieved.publishedAt()).isNotNull());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should retrieve a failed release with the same errors reported by complete")
+	void shouldRetrieveFailedRelease() {
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum")).actual();
+
+		assertThatComplete(release.id()).hasStatus(HttpStatus.CONFLICT);
+
+		assertThatRelease(release.id())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.FAILED, ServiceRelease::state)
+				.satisfies(retrieved -> assertThat(retrieved.errors())
+						.containsExactly("Artifact with coordinates '%s' was not uploaded"
+								.formatted(ArtifactCoordinates.of(konfigyrArtifactoryArtifact).format()))
+				);
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve a release that does not exist")
+	void shouldRejectRetrieveForUnknownRelease() {
+		assertThatRelease(EntityId.from(999).serialize())
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitle("Release not found")
+						.hasDetailContaining("Could not find a release with the following identifier")
+				));
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve a release for an unknown service")
+	void shouldRejectRetrieveForUnknownService() {
+		mvc.get().uri("/namespaces/konfigyr/services/unknown-service/releases/{id}", EntityId.from(999).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound("unknown-service"));
+	}
+
+	@Test
+	@DisplayName("should not retrieve a release when user is not a member of the namespace")
+	void shouldRejectRetrieveWhenNotAMember() {
+		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}", EntityId.from(999).serialize())
+				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_MANIFESTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should not retrieve a release when the publish-manifests scope is not present")
+	void shouldRejectRetrieveWithoutScope() {
+		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/releases/{id}", EntityId.from(999).serialize())
+				.with(authentication(TestPrincipals.john()))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.PUBLISH_MANIFESTS));
+	}
+
+	@Test
 	@DisplayName("should not resolve a release when user is not a member of the namespace")
 	void shouldRejectWhenNotAMember() {
 		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
@@ -710,6 +825,14 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.bodyJson()
 				.convertTo(ServiceRelease.class)
 				.asInstanceOf(InstanceOfAssertFactories.type(ServiceRelease.class));
+	}
+
+	private MvcTestResultAssert assertThatRelease(String id) {
+		return mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}", id)
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_MANIFESTS))
+				.exchange()
+				.assertThat()
+				.apply(log());
 	}
 
 	private MvcTestResultAssert assertThatUpload(String id, ArtifactMetadata metadata) {

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/manifest/ServiceManifestsTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/manifest/ServiceManifestsTest.java
@@ -182,6 +182,96 @@ class ServiceManifestsTest extends AbstractIntegrationTest {
 				.returns(ReleaseState.RELEASED, ReleaseNotPendingException::getState);
 	}
 
+	@Test
+	@Transactional
+	@DisplayName("should retrieve a pending release with per-artifact upload status")
+	void shouldRetrievePendingRelease() {
+		final var uploaded = metadata(konfigyrArtifactoryArtifact);
+		final var pending = metadata(Artifact.of("com.konfigyr", "konfigyr-crypto-api", "1.1.0"));
+
+		final var release = manifests.open(service, List.of(
+				ServiceReleaseCandidate.of(uploaded),
+				ServiceReleaseCandidate.of(pending)
+		));
+
+		manifests.upload(service, EntityId.from(release.id()), uploaded);
+
+		assertThat(manifests.get(service, EntityId.from(release.id())))
+				.isPresent()
+				.get()
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.PENDING, ServiceRelease::state)
+				.returns(null, ServiceRelease::publishedAt)
+				.returns(List.of(), ServiceRelease::errors)
+				.extracting(ServiceRelease::artifacts)
+				.satisfies(entries -> assertThat(entries)
+						.hasSize(2)
+						.satisfiesExactlyInAnyOrder(
+								entry -> assertThat(entry)
+										.returns(ArtifactCoordinates.of(uploaded), ArtifactCoordinates::of)
+										.returns(ArtifactUploadStatus.SKIP, ServiceReleaseEntry::status),
+								entry -> assertThat(entry)
+										.returns(ArtifactCoordinates.of(pending), ArtifactCoordinates::of)
+										.returns(ArtifactUploadStatus.UPLOAD_REQUIRED, ServiceReleaseEntry::status)
+						)
+				);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should retrieve a released release")
+	void shouldRetrieveReleasedRelease() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact);
+		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(metadata)));
+
+		manifests.upload(service, EntityId.from(release.id()), metadata);
+		final var completed = manifests.complete(service, EntityId.from(release.id()));
+
+		assertThat(manifests.get(service, EntityId.from(release.id())))
+				.isPresent()
+				.get()
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.RELEASED, ServiceRelease::state)
+				.returns(completed.publishedAt(), ServiceRelease::publishedAt)
+				.returns(List.of(), ServiceRelease::errors);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should retrieve a failed release with the same errors reported by complete")
+	void shouldRetrieveFailedRelease() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact);
+		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(metadata)));
+
+		final var completed = manifests.complete(service, EntityId.from(release.id()));
+
+		assertThat(manifests.get(service, EntityId.from(release.id())))
+				.isPresent()
+				.get()
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.FAILED, ServiceRelease::state)
+				.returns(completed.errors(), ServiceRelease::errors);
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve a release that does not exist")
+	void shouldNotRetrieveUnknownRelease() {
+		assertThat(manifests.get(service, EntityId.from(95673678))).isEmpty();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to retrieve a release belonging to a different service")
+	void shouldNotRetrieveReleaseForDifferentService() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact);
+		final var release = manifests.open(service, List.of(ServiceReleaseCandidate.of(metadata)));
+
+		final Namespace namespace = namespaces.findBySlug("konfigyr").orElseThrow();
+		final Service otherService = services.get(namespace, "konfigyr-api").orElseThrow();
+
+		assertThat(manifests.get(otherService, EntityId.from(release.id()))).isEmpty();
+	}
+
 	private static ArtifactMetadata metadata(Artifact artifact) {
 		return artifact.toMetadata(List.of(
 				PropertyDescriptor.builder()

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/manifest/ServiceManifestsTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/manifest/ServiceManifestsTest.java
@@ -8,6 +8,7 @@ import com.konfigyr.namespace.Service;
 import com.konfigyr.namespace.ServiceEvent;
 import com.konfigyr.namespace.Services;
 import com.konfigyr.test.AbstractIntegrationTest;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.jooq.DSLContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -232,8 +233,9 @@ class ServiceManifestsTest extends AbstractIntegrationTest {
 				.get()
 				.returns(release.id(), ServiceRelease::id)
 				.returns(ReleaseState.RELEASED, ServiceRelease::state)
-				.returns(completed.publishedAt(), ServiceRelease::publishedAt)
-				.returns(List.of(), ServiceRelease::errors);
+				.returns(List.of(), ServiceRelease::errors)
+				.extracting(ServiceRelease::publishedAt, InstanceOfAssertFactories.INSTANT)
+				.isCloseTo(completed.publishedAt(), within(1, ChronoUnit.SECONDS));
 	}
 
 	@Test
@@ -250,7 +252,8 @@ class ServiceManifestsTest extends AbstractIntegrationTest {
 				.get()
 				.returns(release.id(), ServiceRelease::id)
 				.returns(ReleaseState.FAILED, ServiceRelease::state)
-				.returns(completed.errors(), ServiceRelease::errors);
+				.returns(completed.errors(), ServiceRelease::errors)
+				.returns(null, ServiceRelease::publishedAt);
 	}
 
 	@Test


### PR DESCRIPTION
## Summary

- Adds `GET /namespaces/{namespace}/services/{slug}/releases/{id}`, letting a build plugin (or any other consumer) poll a release's current state and per-artifact upload status without re-declaring every candidate — useful for checking upload progress or recovering after a crash mid-build.
- `ServiceManifests.get(Service, EntityId)` rebuilds the same `ServiceRelease` shape `open()`/`complete()` already return, sourced from persisted state: each artifact's `ArtifactUploadStatus` is re-derived from its `service_artifacts` row (`LOCAL` + null checksum → `UPLOAD_REQUIRED`, everything else → `SKIP`), and a `FAILED` release recomputes the same missing-coordinate errors `complete()` reported, since those rows are left untouched on failure.
- Returns 404 via the existing `ReleaseNotFoundException` when the id is unknown or belongs to a different service.
- Extracted the missing-artifact error formatting out of `complete()` into a shared `toMissingArtifactErrors(...)` helper so both endpoints report identical wording.
