### PR TITLE
Harden OIDC login: discover JWS algorithms and add HTTP client timeouts

### DIFF
--- a/konfigyr-identity/build.gradle.kts
+++ b/konfigyr-identity/build.gradle.kts
@@ -28,6 +28,8 @@ dependencies {
 
     implementation("org.springframework.retry:spring-retry")
 
+    implementation("org.apache.httpcomponents.client5:httpclient5")
+
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
     implementation("nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect")

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AuthenticationConfiguration.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AuthenticationConfiguration.java
@@ -20,18 +20,25 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.util.Lazy;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.converter.FormHttpMessageConverter;
 import org.springframework.security.core.userdetails.UserCache;
 import org.springframework.security.core.userdetails.cache.SpringCacheBasedUserCache;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.endpoint.*;
 import org.springframework.security.oauth2.client.http.OAuth2ErrorResponseErrorHandler;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.http.converter.OAuth2AccessTokenResponseHttpMessageConverter;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory;
+import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestOperations;
 
 import java.util.concurrent.TimeUnit;
@@ -102,6 +109,11 @@ public class AuthenticationConfiguration {
 	}
 
 	@Bean
+	JwtDecoderFactory<ClientRegistration> oidcTokenDecoderFactory(RestTemplateBuilder builder) {
+		return new OidcTokenDecoderFactory(builder.build(), properties.getOidc().getJwtClockSkew());
+	}
+
+	@Bean
 	AccountIdentityListener accountIdentityListener(Mailer mailer) {
 		return new AccountIdentityListener(mailer);
 	}
@@ -114,6 +126,54 @@ public class AuthenticationConfiguration {
 		service.setRestOperations(operations);
 
 		return service;
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	static class AccessTokenResponseClientConfiguration {
+
+		private final RestClient restClient;
+
+		AccessTokenResponseClientConfiguration(ClientHttpRequestFactory clientHttpRequestFactory) {
+			this.restClient = RestClient.builder()
+					.requestFactory(clientHttpRequestFactory)
+					.defaultStatusHandler(new OAuth2ErrorResponseErrorHandler())
+					.configureMessageConverters((messageConverters) -> {
+						messageConverters.addCustomConverter(new FormHttpMessageConverter());
+						messageConverters.addCustomConverter(new OAuth2AccessTokenResponseHttpMessageConverter());
+					}).build();
+		}
+
+		@Bean
+		OAuth2AccessTokenResponseClient<OAuth2AuthorizationCodeGrantRequest> authorizationCodeTokenResponseClient() {
+			return customize(new RestClientAuthorizationCodeTokenResponseClient());
+		}
+
+		@Bean
+		OAuth2AccessTokenResponseClient<OAuth2ClientCredentialsGrantRequest> clientCredentialsTokenResponseClient() {
+			return customize(new RestClientClientCredentialsTokenResponseClient());
+		}
+
+		@Bean
+		OAuth2AccessTokenResponseClient<OAuth2RefreshTokenGrantRequest> refreshTokenTokenResponseClient() {
+			return customize(new RestClientRefreshTokenTokenResponseClient());
+		}
+
+		@Bean
+		OAuth2AccessTokenResponseClient<TokenExchangeGrantRequest> tokenExchangeTokenResponseClient() {
+			return customize(new RestClientTokenExchangeTokenResponseClient());
+		}
+
+		@Bean
+		OAuth2AccessTokenResponseClient<JwtBearerGrantRequest> jwtBearerTokenResponseClient() {
+			return customize(new RestClientJwtBearerTokenResponseClient());
+		}
+
+		<T extends AbstractOAuth2AuthorizationGrantRequest> OAuth2AccessTokenResponseClient<T> customize(
+				AbstractRestClientOAuth2AccessTokenResponseClient<T> client
+		) {
+			client.setRestClient(restClient);
+			return client;
+		}
 	}
 
 }

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AuthenticationProperties.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/AuthenticationProperties.java
@@ -1,11 +1,16 @@
 package com.konfigyr.identity.authentication;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.time.DurationMin;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+import org.springframework.boot.convert.DurationUnit;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
 
 /**
  * Configuration properties for the Konfigyr Identity authentication domain.
@@ -21,6 +26,10 @@ public class AuthenticationProperties {
 	@Valid
 	@NestedConfigurationProperty
 	private RememberMe rememberMe = new RememberMe();
+
+	@Valid
+	@NestedConfigurationProperty
+	private Oidc oidc = new Oidc();
 
 	@Getter
 	@Setter
@@ -42,4 +51,19 @@ public class AuthenticationProperties {
 
 	}
 
+	@Getter
+	@Setter
+	public static class Oidc {
+
+		/**
+		 * The clock skew of the JWT token, used to ensure that the token is not expired.
+		 * Defaults to 60 seconds.
+		 *
+		 * @see OidcTokenDecoderFactory
+		 */
+		@DurationMin(seconds = 0)
+		@DurationUnit(ChronoUnit.SECONDS)
+		private Duration jwtClockSkew = Duration.ofSeconds(60);
+
+	}
 }

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/OidcTokenDecoderFactory.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authentication/OidcTokenDecoderFactory.java
@@ -1,0 +1,79 @@
+package com.konfigyr.identity.authentication;
+
+import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenValidator;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2TokenValidator;
+import org.springframework.security.oauth2.core.converter.ClaimTypeConverter;
+import org.springframework.security.oauth2.jwt.*;
+import org.springframework.util.Assert;
+import org.springframework.web.client.RestOperations;
+
+import java.time.Duration;
+
+/**
+ * A {@link JwtDecoderFactory} that resolves the JWS algorithms accepted for an OIDC ID Token
+ * from the {@link ClientRegistration}'s JWK Set instead of assuming a fixed {@code RS256} algorithm.
+ * <p>
+ * When a JWK Set URI is present, the accepted algorithms are discovered from the signature keys
+ * published at that URI. When it is absent, decoding is delegated to a {@link OidcIdTokenDecoderFactory}
+ * configured with the same {@link #clockSkew}.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see OidcIdTokenDecoderFactory
+ * @see NimbusJwtDecoder.JwkSetUriJwtDecoderBuilder#discoverJwsAlgorithms()
+ */
+@NullMarked
+final class OidcTokenDecoderFactory implements JwtDecoderFactory<ClientRegistration> {
+
+	private final RestOperations restOperations;
+
+	private final Duration clockSkew;
+
+	private final JwtDecoderFactory<ClientRegistration> delegate;
+
+	private final ClaimTypeConverter claimTypeConverter = OidcIdTokenDecoderFactory.createDefaultClaimTypeConverter();
+
+	OidcTokenDecoderFactory(RestOperations restOperations, Duration clockSkew) {
+		this.restOperations = restOperations;
+		this.clockSkew = clockSkew;
+		this.delegate = createDefaultDecoderFactory(clockSkew);
+	}
+
+	@Override
+	public JwtDecoder createDecoder(ClientRegistration clientRegistration) {
+		Assert.notNull(clientRegistration, "clientRegistration cannot be null");
+
+		final String jwkSetUri = clientRegistration.getProviderDetails().getJwkSetUri();
+
+		if (StringUtils.isBlank(jwkSetUri)) {
+			return delegate.createDecoder(clientRegistration);
+		}
+
+		final NimbusJwtDecoder decoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri)
+				.restOperations(restOperations)
+				.discoverJwsAlgorithms()
+				.build();
+
+		decoder.setClaimSetConverter(claimTypeConverter);
+		decoder.setJwtValidator(createTokenValidator(clientRegistration, clockSkew));
+		return decoder;
+	}
+
+	private static OAuth2TokenValidator<Jwt> createTokenValidator(ClientRegistration clientRegistration, Duration clockSkew) {
+		final OidcIdTokenValidator oidcIdTokenValidator = new OidcIdTokenValidator(clientRegistration);
+		oidcIdTokenValidator.setClockSkew(clockSkew);
+
+		return JwtValidators.createDefaultWithValidators(oidcIdTokenValidator, new JwtTimestampValidator(clockSkew));
+	}
+
+	private static JwtDecoderFactory<ClientRegistration> createDefaultDecoderFactory(Duration clockSkew) {
+		final OidcIdTokenDecoderFactory decoderFactory = new OidcIdTokenDecoderFactory();
+		decoderFactory.setJwtValidatorFactory(clientRegistration -> createTokenValidator(clientRegistration, clockSkew));
+		return decoderFactory;
+	}
+
+}

--- a/konfigyr-identity/src/main/resources/application.yml
+++ b/konfigyr-identity/src/main/resources/application.yml
@@ -11,6 +11,11 @@ spring:
     change-log: classpath:migrations/changelog.xml
     contexts: identity
 
+  http:
+    clients:
+      connect-timeout: 5s
+      read-timeout: 2s
+
   messages:
     basename: messages/messages, messages/mail
 

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authentication/OidcTokenDecoderFactoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authentication/OidcTokenDecoderFactoryTest.java
@@ -1,0 +1,187 @@
+package com.konfigyr.identity.authentication;
+
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
+import com.konfigyr.identity.TestClients;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSAlgorithm;
+import com.nimbusds.jose.JWSHeader;
+import com.nimbusds.jose.crypto.ECDSASigner;
+import com.nimbusds.jose.crypto.RSASSASigner;
+import com.nimbusds.jose.jwk.Curve;
+import com.nimbusds.jose.jwk.ECKey;
+import com.nimbusds.jose.jwk.JWK;
+import com.nimbusds.jose.jwk.JWKSet;
+import com.nimbusds.jose.jwk.KeyUse;
+import com.nimbusds.jose.jwk.RSAKey;
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator;
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator;
+import com.nimbusds.jwt.JWTClaimsSet;
+import com.nimbusds.jwt.SignedJWT;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class OidcTokenDecoderFactoryTest {
+
+	static final String REGISTRATION_ID = "test-issuer";
+	static final String CLIENT_ID = "konfigyr";
+	static final String SUBJECT = "konfigyr-user";
+
+	@RegisterExtension
+	static WireMockExtension wiremock = WireMockExtension.newInstance()
+			.options(WireMockConfiguration.wireMockConfig().dynamicPort())
+			.configureStaticDsl(true)
+			.build();
+
+	RSAKey rsaKey;
+	ECKey ecKey;
+
+	@BeforeEach
+	void setup() throws JOSEException {
+		rsaKey = new RSAKeyGenerator(2048)
+				.keyID(UUID.randomUUID().toString())
+				.keyUse(KeyUse.SIGNATURE)
+				.algorithm(JWSAlgorithm.RS256)
+				.generate();
+
+		ecKey = new ECKeyGenerator(Curve.P_256)
+				.keyID(UUID.randomUUID().toString())
+				.keyUse(KeyUse.SIGNATURE)
+				.algorithm(JWSAlgorithm.ES256)
+				.generate();
+
+		wiremock.stubFor(get(urlPathEqualTo("/jwks.json"))
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+						.withBody(new JWKSet(List.of(rsaKey.toPublicJWK(), ecKey.toPublicJWK())).toString(true))
+				));
+	}
+
+	@Test
+	@DisplayName("should verify a token signed with RS256")
+	void verifiesRs256SignedToken() {
+		final var decoder = factory(Duration.ofSeconds(60)).createDecoder(clientRegistration());
+
+		final var jwt = decoder.decode(sign(rsaKey, JWSAlgorithm.RS256, Instant.now().plusSeconds(300)));
+
+		assertThat(jwt.getClaimAsString(JwtClaimNames.SUB)).isEqualTo(SUBJECT);
+	}
+
+	@Test
+	@DisplayName("should verify a token signed with ES256 instead of assuming a hardcoded RS256 algorithm")
+	void verifiesEs256SignedToken() {
+		final var decoder = factory(Duration.ofSeconds(60)).createDecoder(clientRegistration());
+
+		final var jwt = decoder.decode(sign(ecKey, JWSAlgorithm.ES256, Instant.now().plusSeconds(300)));
+
+		assertThat(jwt.getClaimAsString(JwtClaimNames.SUB)).isEqualTo(SUBJECT);
+	}
+
+	@Test
+	@DisplayName("should reject a token signed with an algorithm that is not present in the JWK Set")
+	void rejectsTokenSignedWithUndiscoveredAlgorithm() throws JOSEException {
+		final var otherKey = new RSAKeyGenerator(2048)
+				.keyID(UUID.randomUUID().toString())
+				.keyUse(KeyUse.SIGNATURE)
+				.algorithm(JWSAlgorithm.RS256)
+				.generate();
+
+		final var decoder = factory(Duration.ofSeconds(60)).createDecoder(clientRegistration());
+
+		assertThatExceptionOfType(JwtException.class)
+				.isThrownBy(() -> decoder.decode(sign(otherKey, JWSAlgorithm.RS256, Instant.now().plusSeconds(300))));
+	}
+
+	@Test
+	@DisplayName("should delegate to the default decoder factory when no JWKS URI is configured")
+	void fallsBackWhenJwkSetUriIsMissing() {
+		final var registration = registration().jwkSetUri(null).build();
+
+		assertThatExceptionOfType(OAuth2AuthenticationException.class)
+				.isThrownBy(() -> factory(Duration.ofSeconds(60)).createDecoder(registration))
+				.satisfies(ex -> assertThat(ex.getError().getErrorCode()).isEqualTo("missing_signature_verifier"));
+	}
+
+	@Test
+	@DisplayName("should reject an expired token once outside the configured clock skew")
+	void rejectsExpiredTokenOutsideClockSkew() {
+		final var decoder = factory(Duration.ofSeconds(5)).createDecoder(clientRegistration());
+
+		final var token = sign(rsaKey, JWSAlgorithm.RS256, Instant.now().minusSeconds(30));
+
+		assertThatExceptionOfType(JwtException.class).isThrownBy(() -> decoder.decode(token));
+	}
+
+	@Test
+	@DisplayName("should accept a token that is expired within the configured clock skew")
+	void acceptsExpiredTokenWithinClockSkew() {
+		final var decoder = factory(Duration.ofSeconds(60)).createDecoder(clientRegistration());
+
+		final var token = sign(rsaKey, JWSAlgorithm.RS256, Instant.now().minusSeconds(30));
+
+		assertThatNoException().isThrownBy(() -> decoder.decode(token));
+	}
+
+	private OidcTokenDecoderFactory factory(Duration clockSkew) {
+		return new OidcTokenDecoderFactory(new RestTemplate(), clockSkew);
+	}
+
+	private ClientRegistration clientRegistration() {
+		return registration().build();
+	}
+
+	private ClientRegistration.Builder registration() {
+		return TestClients.clientRegistration(REGISTRATION_ID)
+				.authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
+				.redirectUri(wiremock.baseUrl() + "/login/oauth2/code/" + REGISTRATION_ID)
+				.authorizationUri(wiremock.baseUrl() + "/authorize")
+				.issuerUri(wiremock.baseUrl())
+				.jwkSetUri(wiremock.baseUrl() + "/jwks.json");
+	}
+
+	private String sign(JWK key, JWSAlgorithm algorithm, Instant expiresAt) {
+		final var header = new JWSHeader.Builder(algorithm).keyID(key.getKeyID()).build();
+		final var claims = new JWTClaimsSet.Builder()
+				.issuer(wiremock.baseUrl())
+				.subject(SUBJECT)
+				.audience(CLIENT_ID)
+				.issueTime(Date.from(expiresAt.minusSeconds(300)))
+				.expirationTime(Date.from(expiresAt))
+				.build();
+
+		final var jwt = new SignedJWT(header, claims);
+
+		try {
+			jwt.sign(key instanceof RSAKey rsa ? new RSASSASigner(rsa) : new ECDSASigner((ECKey) key));
+		} catch (JOSEException e) {
+			throw new IllegalStateException("Failed to sign JWT", e);
+		}
+
+		return jwt.serialize();
+	}
+
+}


### PR DESCRIPTION
## Summary

- Replace the hardcoded `RS256` assumption used to verify OIDC ID tokens with algorithm discovery from each provider's own JWK Set (`OidcTokenDecoderFactory`), so identity providers signing with `PS256`/`ES256`/etc. are no longer rejected. Falls back to the default decoder factory when a provider has no JWKS URI configured.
- Add a configurable `konfigyr.identity.authentication.oidc.jwt-clock-skew` property (defaults to 60s) used by both the ID token expiry validator and the timestamp validator.
- Switch the OAuth2 access token response clients (authorization code, client credentials, refresh token, token exchange, JWT bearer) to `RestClient`, and give both that client and the new JWKS-fetching client bounded connect/read timeouts via `spring.http.clients`, so a slow or unreachable identity provider can no longer hang a login request.
