### PR TITLE
Add namespace ownership and visibility to Artifactory artifacts

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-		"-//Puppy Crawl//DTD Check Configuration 1.3//EN"
+		"-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
 		"https://checkstyle.org/dtds/configuration_1_3.dtd">
 <module name="Checker">
     <!-- Suppression filters -->
@@ -11,6 +11,11 @@
 
     <!-- Root Checks -->
     <module name="TreeWalker">
+		<!-- X-Path Suppression filter -->
+		<module name="SuppressionXpathFilter">
+			<property name="file" value="${config_loc}/xpath-suppressions.xml"/>
+		</module>
+
         <!-- Annotations -->
         <module name="com.puppycrawl.tools.checkstyle.checks.annotation.AnnotationUseStyleCheck">
             <property name="elementStyle" value="compact" />

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -1,7 +1,7 @@
-<?xml version="1.0"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE suppressions PUBLIC
-		"-//Checkstyle//DTD SuppressionXpathFilter Experimental Configuration 1.2//EN"
-		"https://checkstyle.org/dtds/suppressions_1_2_xpath_experimental.dtd">
+		"-//Checkstyle//DTD SuppressionFilter Configuration 1.2//EN"
+		"https://checkstyle.org/dtds/suppressions_1_2.dtd">
 <suppressions>
     <suppress files="[\\/]target[\\/]generated-sources[\\/]jooq[\\/]" checks=".*"/>
 

--- a/config/checkstyle/xpath-suppressions.xml
+++ b/config/checkstyle/xpath-suppressions.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE suppressions PUBLIC
+		"-//Checkstyle//DTD SuppressionXpathFilter Configuration 1.2//EN"
+		"https://checkstyle.org/dtds/suppressions_1_2_xpath.dtd">
+<suppressions>
+
+	<!-- @NoArgsConstructor(access = PRIVATE) / @UtilityClass on classes Checkstyle can't see the generated ctor for -->
+	<suppress-xpath checks="HideUtilityClassConstructor"
+					query="//CLASS_DEF[./MODIFIERS/ANNOTATION/IDENT[@text='UtilityClass']]"/>
+
+	<!-- @Value / @Data / @Getter / @Setter / @Builder generate methods with no explicit @Override,
+		 but MissingOverrideCheck only cares about actual overrides, so this is rarely needed —
+		 included for completeness if you ever hand-write a method Lombok also generates -->
+	<suppress-xpath checks="MissingOverride"
+					query="//METHOD_DEF[./MODIFIERS/ANNOTATION/IDENT[@text='Override']]"/>
+
+	<!-- @Builder / @Value / records: JavadocVariableCheck flags public fields with no Javadoc,
+		 but Lombok-generated builder fields or record components are never meant to carry one -->
+	<suppress-xpath checks="JavadocVariable"
+					query="//CLASS_DEF[./MODIFIERS/ANNOTATION/IDENT[@text='Builder' or @text='Value']]//VARIABLE_DEF"/>
+
+	<!-- @EqualsAndHashCode / @Data generate equals()/hashCode() as a pair, but if you ever
+		 hand-write one without the other, CovariantEquals/EqualsHashCode can misfire on the
+		 synthetic pairing — scope to classes carrying the annotation -->
+	<suppress-xpath checks="EqualsHashCode"
+					query="//CLASS_DEF[./MODIFIERS/ANNOTATION/IDENT[@text='EqualsAndHashCode' or @text='Data']]"/>
+
+	<!-- @Slf4j / @Log4j2 / @CommonsLog inject a `log` field with no declared visibility keyword
+		 in a source (Lombok adds it at compile time) — RedundantModifier / RequireThis can sometimes
+		 flag the generated field access pattern if you reference `log` inside inner classes -->
+	<suppress-xpath checks="RequireThis"
+					query="//VARIABLE_DEF[./IDENT[@text='log']]"/>
+
+	<!-- @FieldDefaults(makeFinal = true, level = PRIVATE) or @Value: fields have no explicit
+		 `final`/`private` keyword in a source even though Lombok enforces it — FinalClass /
+		 RedundantModifier checks operating on the visible modifiers can be confused by this -->
+	<suppress-xpath checks="RedundantModifier"
+					query="//CLASS_DEF[./MODIFIERS/ANNOTATION/IDENT[@text='Value' or @text='FieldDefaults']]"/>
+</suppressions>

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactDefinition.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactDefinition.java
@@ -24,8 +24,10 @@ import java.util.Comparator;
  * {@link PropertyDefinition} entities.
  *
  * @param id entity identifier for the artifact, can't be {@literal null}.
+ * @param owner the namespace that owns this artifact, can't be {@literal null}.
  * @param groupId Maven coordinate {@code groupId} of the artifact, can't be {@literal null}.
  * @param artifactId Maven coordinate {@code artifactId} of the artifact, can't be {@literal null}.
+ * @param visibility whether this artifact is readable by every namespace or only its owner, can't be {@literal null}.
  * @param name human-readable name of the artifact, may be {@literal null}.
  * @param description textual description of the artifact, may be {@literal null}.
  * @param website external URL for documentation or homepage, may be {@literal null}.
@@ -38,8 +40,10 @@ import java.util.Comparator;
 @AggregateRoot
 public record ArtifactDefinition(
 	@NonNull @Identity EntityId id,
+	@NonNull Owner owner,
 	@NonNull String groupId,
 	@NonNull String artifactId,
+	@NonNull ArtifactVisibility visibility,
 	@Nullable String name,
 	@Nullable String description,
 	@Nullable URI website,
@@ -92,8 +96,10 @@ public record ArtifactDefinition(
 	 */
 	public static final class Builder {
 		private EntityId id;
+		private Owner owner;
 		private String groupId;
 		private String artifactId;
+		private ArtifactVisibility visibility;
 		private String name;
 		private String description;
 		private URI website;
@@ -140,6 +146,18 @@ public record ArtifactDefinition(
 		}
 
 		/**
+		 * Specify the {@link Owner} namespace for this {@link ArtifactDefinition}.
+		 *
+		 * @param owner the owning namespace
+		 * @return artifact builder
+		 */
+		@NonNull
+		public Builder owner(Owner owner) {
+			this.owner = owner;
+			return this;
+		}
+
+		/**
 		 * Specify the {@code groupId} coordinate for this {@link ArtifactDefinition}.
 		 *
 		 * @param groupId artifact {@code groupId} coordinate
@@ -160,6 +178,19 @@ public record ArtifactDefinition(
 		@NonNull
 		public Builder artifactId(String artifactId) {
 			this.artifactId = artifactId;
+			return this;
+		}
+
+		/**
+		 * Specify whether this {@link ArtifactDefinition} is readable by every namespace or only its
+		 * owner. Defaults to {@link ArtifactVisibility#PRIVATE} when not specified.
+		 *
+		 * @param visibility artifact visibility
+		 * @return artifact builder
+		 */
+		@NonNull
+		public Builder visibility(ArtifactVisibility visibility) {
+			this.visibility = visibility;
 			return this;
 		}
 
@@ -288,13 +319,16 @@ public record ArtifactDefinition(
 		 */
 		public ArtifactDefinition build() {
 			Assert.notNull(id, "Artifact entity identifier can not be null");
+			Assert.notNull(owner, "Artifact owner can not be null");
 			Assert.hasText(groupId, "Artifact groupId can not be null");
 			Assert.hasText(artifactId, "Artifact artifactId can not be null");
 
 			return new ArtifactDefinition(
 					id,
+					owner,
 					groupId,
 					artifactId,
+					visibility == null ? ArtifactVisibility.PRIVATE : visibility,
 					name,
 					description,
 					website,

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactDefinitionNotFoundException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactDefinitionNotFoundException.java
@@ -1,0 +1,68 @@
+package com.konfigyr.artifactory;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serial;
+
+/**
+ * Exception that is thrown when an {@link ArtifactDefinition} is not present in the
+ * {@code Artifactory} Domain.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+public class ArtifactDefinitionNotFoundException extends ArtifactoryException {
+
+	@Serial
+	private static final long serialVersionUID = 6236774637610101542L;
+
+	/**
+	 * Maven {@code groupId} coordinate of the artifact that could not be found.
+	 */
+	private final String groupId;
+
+	/**
+	 * Maven {@code artifactId} coordinate of the artifact that could not be found.
+	 */
+	private final String artifactId;
+
+	/**
+	 * Create a new instance when no artifact exists for the given {@code groupId} and
+	 * {@code artifactId} coordinates.
+	 *
+	 * @param groupId the artifact {@code groupId} coordinate that could not be found, can't be {@literal null}
+	 * @param artifactId the artifact {@code artifactId} coordinate that could not be found, can't be {@literal null}
+	 */
+	public ArtifactDefinitionNotFoundException(@NonNull String groupId, @NonNull String artifactId) {
+		super(HttpStatus.NOT_FOUND, "Can not find artifact with following coordinates: %s:%s".formatted(groupId, artifactId));
+		this.groupId = groupId;
+		this.artifactId = artifactId;
+	}
+
+	@Override
+	public Object[] getDetailMessageArguments() {
+		return new Object[] { groupId, artifactId };
+	}
+
+	/**
+	 * Returns the {@code groupId} coordinate of the artifact that could not be found.
+	 *
+	 * @return the {@code groupId} coordinate, never {@literal null}
+	 */
+	@NonNull
+	public String getGroupId() {
+		return groupId;
+	}
+
+	/**
+	 * Returns the {@code artifactId} coordinate of the artifact that could not be found.
+	 *
+	 * @return the {@code artifactId} coordinate, never {@literal null}
+	 */
+	@NonNull
+	public String getArtifactId() {
+		return artifactId;
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactOwnershipMismatchException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactOwnershipMismatchException.java
@@ -1,0 +1,99 @@
+package com.konfigyr.artifactory;
+
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown when a namespace attempts to publish a new version for, or change the
+ * {@link ArtifactVisibility} of, an artifact that is owned by a different namespace.
+ * <p>
+ * Ownership is a {@code groupId}/{@code artifactId} level concern, not a version level one, so
+ * this exception carries the artifact coordinates without a version.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+public class ArtifactOwnershipMismatchException extends ArtifactoryException {
+
+	@Serial
+	private static final long serialVersionUID = -1523069864217405721L;
+
+	/**
+	 * Maven {@code groupId} coordinate of the artifact owned by a different namespace.
+	 */
+	private final String groupId;
+
+	/**
+	 * Maven {@code artifactId} coordinate of the artifact owned by a different namespace.
+	 */
+	private final String artifactId;
+
+	/**
+	 * The namespace that attempted to publish or change the visibility of the artifact.
+	 */
+	private final Owner owner;
+
+	/**
+	 * Create a new instance when the given {@link Owner} does not match the namespace that
+	 * already owns the artifact identified by the supplied {@code groupId} and {@code artifactId}.
+	 *
+	 * @param groupId the {@code groupId} coordinate of the artifact owned by a different namespace, can't be {@literal null}
+	 * @param artifactId the {@code artifactId} coordinate of the artifact owned by a different namespace, can't be {@literal null}
+	 * @param owner the namespace that attempted to publish or change the visibility of the artifact, can't be {@literal null}
+	 */
+	public ArtifactOwnershipMismatchException(@NonNull String groupId, @NonNull String artifactId, @NonNull Owner owner) {
+		super(HttpStatus.CONFLICT, "Artifact '%s:%s' is owned by a '%s' namespace".formatted(groupId, artifactId, owner.slug()));
+		this.groupId = groupId;
+		this.artifactId = artifactId;
+		this.owner = owner;
+	}
+
+	/**
+	 * Create a new instance when the given {@link Owner} does not match the namespace that
+	 * already owns the artifact identified by the supplied {@link ArtifactCoordinates}.
+	 *
+	 * @param coordinates the coordinates of the artifact owned by a different namespace, can't be {@literal null}
+	 * @param owner the namespace that attempted to publish or change the visibility of the artifact, can't be {@literal null}
+	 */
+	public ArtifactOwnershipMismatchException(@NonNull ArtifactCoordinates coordinates, @NonNull Owner owner) {
+		this(coordinates.groupId(), coordinates.artifactId(), owner);
+	}
+
+	/**
+	 * Returns the {@code groupId} coordinate of the artifact owned by a different namespace.
+	 *
+	 * @return the {@code groupId} coordinate, never {@literal null}
+	 */
+	@NonNull
+	public String getGroupId() {
+		return groupId;
+	}
+
+	/**
+	 * Returns the {@code artifactId} coordinate of the artifact owned by a different namespace.
+	 *
+	 * @return the {@code artifactId} coordinate, never {@literal null}
+	 */
+	@NonNull
+	public String getArtifactId() {
+		return artifactId;
+	}
+
+	/**
+	 * Returns the namespace that attempted to publish or change the visibility of the artifact.
+	 *
+	 * @return the namespace owner, never {@literal null}
+	 */
+	@NonNull
+	public Owner getOwner() {
+		return owner;
+	}
+
+	@Override
+	public Object[] getDetailMessageArguments() {
+		return new Object[] { groupId, artifactId, owner.slug() };
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactVisibility.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactVisibility.java
@@ -1,0 +1,22 @@
+package com.konfigyr.artifactory;
+
+/**
+ * Determines which namespaces are allowed to read an {@link ArtifactDefinition} and its
+ * {@link VersionedArtifact versions}.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+public enum ArtifactVisibility {
+
+	/**
+	 * The artifact can be read by any namespace.
+	 */
+	PUBLIC,
+
+	/**
+	 * The artifact can only be read by its owning namespace.
+	 */
+	PRIVATE
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
@@ -1,8 +1,8 @@
 package com.konfigyr.artifactory;
 
-import com.konfigyr.entity.EntityId;
 import org.jmolecules.event.annotation.DomainEventPublisher;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collection;
 import java.util.List;
@@ -44,6 +44,23 @@ public interface Artifactory {
 	Optional<VersionedArtifact> get(@NonNull ArtifactCoordinates coordinates);
 
 	/**
+	 * Resolves a specific artifact version identified by the provided coordinates, restricted to
+	 * what the given {@code owner} is allowed to see.
+	 * <p>
+	 * A {@link ArtifactVisibility#PUBLIC PUBLIC} artifact is always resolved. A
+	 * {@link ArtifactVisibility#PRIVATE PRIVATE} artifact is only resolved when {@code owner} is its
+	 * owning namespace; otherwise this behaves as if the coordinates did not exist, so that an
+	 * unauthorized caller can't distinguish "private, not yours" from "never existed".
+	 *
+	 * @param owner the namespace on whose behalf this lookup is performed, or {@literal null} if the
+	 *        caller has no namespace context, in which case only {@code PUBLIC} artifacts resolve
+	 * @param coordinates the artifact coordinates identifying the artifact version, can't {@literal null}
+	 * @return the resolved {@link VersionedArtifact}, or {@code empty} if none exists or is visible to {@code owner}
+	 */
+	@NonNull
+	Optional<VersionedArtifact> get(@Nullable Owner owner, @NonNull ArtifactCoordinates coordinates);
+
+	/**
 	 * Returns the property definitions associated with the specified artifact version.
 	 * <p>
 	 * Property definitions describe the configuration schema exposed by the artifact. Each definition specifies
@@ -71,6 +88,17 @@ public interface Artifactory {
 	boolean exists(@NonNull ArtifactCoordinates coordinates);
 
 	/**
+	 * Determines whether an artifact version exists for the given coordinates and is visible to the
+	 * given {@code owner} — see {@link #get(Owner, ArtifactCoordinates)} for the visibility rule.
+	 *
+	 * @param owner the namespace on whose behalf this check is performed, or {@literal null} if the
+	 *        caller has no namespace context, in which case only {@code PUBLIC} artifacts match
+	 * @param coordinates the artifact coordinates identifying the artifact version, can't {@literal null}
+	 * @return {@code true} if an artifact version exists and is visible to {@code owner}, otherwise {@code false}
+	 */
+	boolean exists(@Nullable Owner owner, @NonNull ArtifactCoordinates coordinates);
+
+	/**
 	 * Returns the {@link Publication} for each of the given {@link ArtifactCoordinates} that is already
 	 * indexed by this {@code Artifactory}.
 	 * <p>
@@ -83,12 +111,17 @@ public interface Artifactory {
 	 * are simply omitted from the returned set — they are not reported back as missing or invalid, since
 	 * "not yet indexed" is an expected, non-exceptional outcome for a batch existence check. Callers that
 	 * need to know which of their coordinates are absent should compute the difference against the input.
+	 * <p>
+	 * Only {@link ArtifactVisibility#PUBLIC PUBLIC} artifacts, and {@link ArtifactVisibility#PRIVATE PRIVATE}
+	 * artifacts owned by the given {@code owner}, are considered — a match that is {@code PRIVATE} to a
+	 * different namespace is treated the same as "not yet indexed" and omitted from the result.
 	 *
+	 * @param owner the namespace on whose behalf this batch check is performed, can't be {@literal null}
 	 * @param coordinates coordinates to check, can be empty
 	 * @return the publications matching the given coordinates that exist, never {@literal null}, empty if the input is empty
 	 */
 	@NonNull
-	Set<Publication> existing(@NonNull Collection<ArtifactCoordinates> coordinates);
+	Set<Publication> existing(@NonNull Owner owner, @NonNull Collection<ArtifactCoordinates> coordinates);
 
 	/**
 	 * Publishes a new artifact version based on the provided metadata.
@@ -108,19 +141,37 @@ public interface Artifactory {
 	 * a successful publication.
 	 * <p>
 	 * Publishing is restricted to owners that hold an active verification claim covering the artifact
-	 * {@code groupId}. The {@code ownerId} identifies the publishing namespace and is resolved to its
-	 * owner before the claim is checked.
+	 * {@code groupId}. The caller is expected to have already resolved the publishing namespace to
+	 * its {@link Owner}.
 	 *
-	 * @param ownerId the identifier of the namespace publishing the artifact, can't {@literal null}
+	 * @param owner the namespace publishing the artifact, can't {@literal null}
 	 * @param metadata the metadata describing the artifact version to publish, can't {@literal null}
 	 * @return the resulting {@link VersionedArtifact} representing the published artifact
 	 * @throws ArtifactVersionExistsException when an artifact with the same coordinates already exists
-	 * @throws OwnerNotFoundException when the owner cannot be resolved
-	 *         from the supplied {@code ownerId}
+	 * @throws ArtifactOwnershipMismatchException when the artifact already exists and is owned by a
+	 *         different namespace
 	 * @throws com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException when the owner does not hold
 	 *         an active verification claim covering the artifact {@code groupId}
 	 */
 	@DomainEventPublisher(publishes = "artifactory.artifact-version.publication-created")
-	VersionedArtifact publish(@NonNull EntityId ownerId, @NonNull ArtifactMetadata metadata);
+	VersionedArtifact publish(@NonNull Owner owner, @NonNull ArtifactMetadata metadata);
+
+	/**
+	 * Changes the {@link ArtifactVisibility} of the artifact identified by the given {@code groupId}
+	 * and {@code artifactId}.
+	 * <p>
+	 * Visibility is a {@code groupId}/{@code artifactId} level concern, not a version level one: it
+	 * applies to every {@link VersionedArtifact} published under those coordinates. Only the
+	 * namespace that owns the artifact may change its visibility. The caller is expected to have
+	 * already resolved the requesting namespace to its {@link Owner}.
+	 *
+	 * @param owner the namespace requesting the change, can't be {@literal null}
+	 * @param groupId the artifact {@code groupId} coordinate, can't be {@literal null}
+	 * @param artifactId the artifact {@code artifactId} coordinate, can't be {@literal null}
+	 * @param visibility the visibility to apply, can't be {@literal null}
+	 * @throws ArtifactDefinitionNotFoundException when no artifact exists for the given coordinates
+	 * @throws ArtifactOwnershipMismatchException when the given owner does not own the artifact
+	 */
+	void changeVisibility(@NonNull Owner owner, @NonNull String groupId, @NonNull String artifactId, @NonNull ArtifactVisibility visibility);
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryAutoConfiguration.java
@@ -57,9 +57,8 @@ public class ArtifactoryAutoConfiguration implements WebMvcConfigurer {
 			MetadataStore store,
 			ArtifactoryConverters converters,
 			ApplicationEventPublisher eventPublisher,
-			OwnerResolver ownerResolver,
 			GroupVerifications groupVerifications
 	) {
-		return new DefaultArtifactory(context, store, converters, eventPublisher, ownerResolver, groupVerifications);
+		return new DefaultArtifactory(context, store, converters, eventPublisher, groupVerifications);
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
@@ -19,6 +19,7 @@ import org.jooq.Record;
 import org.jooq.SelectJoinStep;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
@@ -37,6 +38,7 @@ import java.util.Set;
 import static com.konfigyr.data.tables.ArtifactVersionProperties.ARTIFACT_VERSION_PROPERTIES;
 import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
 import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
+import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
 import static com.konfigyr.data.tables.PropertyDefinitions.PROPERTY_DEFINITIONS;
 
 @Slf4j
@@ -47,7 +49,6 @@ class DefaultArtifactory implements Artifactory {
 	private final MetadataStore store;
 	private final ArtifactoryConverters converters;
 	private final ApplicationEventPublisher eventPublisher;
-	private final OwnerResolver ownerResolver;
 	private final GroupVerifications groupVerifications;
 
 	@NonNull
@@ -56,6 +57,15 @@ class DefaultArtifactory implements Artifactory {
 	public Optional<VersionedArtifact> get(@NonNull ArtifactCoordinates coordinates) {
 		return createVersionedArtifactQuery()
 				.where(toCondition(coordinates))
+				.fetchOptional(DefaultArtifactory::toVersionedArtifact);
+	}
+
+	@NonNull
+	@Override
+	@Transactional(readOnly = true, label = "artifactory.get-visible-versioned-artifact")
+	public Optional<VersionedArtifact> get(@Nullable Owner owner, @NonNull ArtifactCoordinates coordinates) {
+		return createVersionedArtifactQuery()
+				.where(DSL.and(toCondition(coordinates), visibilityCondition(owner)))
 				.fetchOptional(DefaultArtifactory::toVersionedArtifact);
 	}
 
@@ -71,10 +81,22 @@ class DefaultArtifactory implements Artifactory {
 		);
 	}
 
+	@Override
+	@Transactional(readOnly = true, label = "artifactory.visible-coordinates-exists")
+	public boolean exists(@Nullable Owner owner, @NonNull ArtifactCoordinates coordinates) {
+		return context.fetchExists(
+				DSL.select(ARTIFACT_VERSIONS.ID)
+						.from(ARTIFACT_VERSIONS)
+						.innerJoin(ARTIFACTS)
+						.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
+						.where(DSL.and(toCondition(coordinates), visibilityCondition(owner)))
+		);
+	}
+
 	@NonNull
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.existing-coordinates")
-	public Set<Publication> existing(@NonNull Collection<ArtifactCoordinates> coordinates) {
+	public Set<Publication> existing(@NonNull Owner owner, @NonNull Collection<ArtifactCoordinates> coordinates) {
 		if (coordinates.isEmpty()) {
 			return Set.of();
 		}
@@ -84,10 +106,13 @@ class DefaultArtifactory implements Artifactory {
 		final String[] versions = coordinates.stream().map(coordinate -> coordinate.version().get()).toArray(String[]::new);
 
 		return createVersionedArtifactQuery()
-				.where(DSL.row(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, ARTIFACT_VERSIONS.VERSION)
-						.in(DSL.select(DSL.field("g", String.class), DSL.field("a", String.class), DSL.field("v", String.class))
-								.from("unnest({0}::text[], {1}::text[], {2}::text[]) AS t(g, a, v)",
-										groupIds, artifactIds, versions)))
+				.where(DSL.and(
+						DSL.row(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, ARTIFACT_VERSIONS.VERSION)
+								.in(DSL.select(DSL.field("g", String.class), DSL.field("a", String.class), DSL.field("v", String.class))
+										.from("unnest({0}::text[], {1}::text[], {2}::text[]) AS t(g, a, v)",
+												groupIds, artifactIds, versions)),
+						visibilityCondition(owner)
+				))
 				.fetchSet(DefaultArtifactory::toVersionedArtifact);
 	}
 
@@ -95,7 +120,7 @@ class DefaultArtifactory implements Artifactory {
 	@Observed(name = "konfigyr.artifactory.release")
 	@Transactional(label = "artifactory.release-artifact-component")
 	public VersionedArtifact publish(
-			@NonNull EntityId ownerId,
+			@NonNull Owner owner,
 			@NonNull
 			@ObservationKeyValue(key = "konfigyr.artifactory.artifact", expression = "#this")
 			ArtifactMetadata metadata
@@ -106,7 +131,8 @@ class DefaultArtifactory implements Artifactory {
 			throw new ArtifactVersionExistsException(coordinates);
 		}
 
-		assertCanRelease(ownerId, metadata.groupId());
+		assertCanRelease(owner, metadata.groupId());
+		assertSameOwner(owner, coordinates);
 
 		final ByteArray checksum;
 		final Resource resource;
@@ -121,12 +147,14 @@ class DefaultArtifactory implements Artifactory {
 			throw new ArtifactoryException("Unexpected error occurred while calculating metadata checksum for artifact: " + coordinates.format(), ex);
 		}
 
-		final Long artifactId = context.insertInto(ARTIFACTS)
+		final Record artifactRecord = context.insertInto(ARTIFACTS)
 				.set(
 						SettableRecord.of(context, ARTIFACTS)
 								.set(ARTIFACTS.ID, EntityId.generate().map(EntityId::get))
+								.set(ARTIFACTS.NAMESPACE_ID, owner.id().get())
 								.set(ARTIFACTS.GROUP_ID, coordinates.groupId())
 								.set(ARTIFACTS.ARTIFACT_ID, coordinates.artifactId())
+								.set(ARTIFACTS.VISIBILITY, ArtifactVisibility.PRIVATE.name())
 								.set(ARTIFACTS.NAME, metadata.name())
 								.set(ARTIFACTS.DESCRIPTION, metadata.description())
 								.set(ARTIFACTS.WEBSITE, metadata.website(), converters.uri())
@@ -142,8 +170,13 @@ class DefaultArtifactory implements Artifactory {
 				.set(ARTIFACTS.WEBSITE, converters.uri().to(metadata.website()))
 				.set(ARTIFACTS.REPOSITORY, converters.uri().to(metadata.repository()))
 				.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
-				.returning(ARTIFACTS.ID)
-				.fetchOne(ARTIFACTS.ID);
+				.returning(ARTIFACTS.ID, ARTIFACTS.VISIBILITY)
+				.fetchOne();
+
+		Assert.state(artifactRecord != null, "Failed to insert new artifact record");
+
+		final Long artifactId = artifactRecord.get(ARTIFACTS.ID);
+		final ArtifactVisibility visibility = artifactRecord.get(ARTIFACTS.VISIBILITY, ArtifactVisibility.class);
 
 		final Long artifactVersionId = context.insertInto(ARTIFACT_VERSIONS)
 				.set(
@@ -172,6 +205,8 @@ class DefaultArtifactory implements Artifactory {
 		return VersionedArtifact.from(metadata)
 				.id(artifactVersionId)
 				.artifact(artifactId)
+				.owner(owner)
+				.visibility(visibility)
 				.state(PublicationState.PENDING)
 				.checksum(checksum.encodeHex())
 				.publishedAt(Instant.now())
@@ -198,6 +233,31 @@ class DefaultArtifactory implements Artifactory {
 				.fetch(record -> toPropertyDefinition(record, converters));
 	}
 
+	@Override
+	@Transactional(label = "artifactory.change-visibility")
+	public void changeVisibility(
+			@NonNull Owner owner,
+			@NonNull String groupId,
+			@NonNull String artifactId,
+			@NonNull ArtifactVisibility visibility
+	) {
+		final Long existingOwnerId = context.select(ARTIFACTS.NAMESPACE_ID)
+				.from(ARTIFACTS)
+				.where(ARTIFACTS.GROUP_ID.eq(groupId), ARTIFACTS.ARTIFACT_ID.eq(artifactId))
+				.fetchOptional(ARTIFACTS.NAMESPACE_ID)
+				.orElseThrow(() -> new ArtifactDefinitionNotFoundException(groupId, artifactId));
+
+		if (!existingOwnerId.equals(owner.id().get())) {
+			throw new ArtifactOwnershipMismatchException(groupId, artifactId, owner);
+		}
+
+		context.update(ARTIFACTS)
+				.set(ARTIFACTS.VISIBILITY, visibility.name())
+				.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
+				.where(ARTIFACTS.GROUP_ID.eq(groupId), ARTIFACTS.ARTIFACT_ID.eq(artifactId))
+				.execute();
+	}
+
 	@NonNull
 	private SelectJoinStep<? extends Record> createVersionedArtifactQuery() {
 		return context.select(
@@ -207,6 +267,9 @@ class DefaultArtifactory implements Artifactory {
 						ARTIFACTS.ID,
 						ARTIFACTS.GROUP_ID,
 						ARTIFACTS.ARTIFACT_ID,
+						ARTIFACTS.VISIBILITY,
+						NAMESPACES.ID,
+						NAMESPACES.SLUG,
 						ARTIFACT_VERSIONS.VERSION,
 						ARTIFACTS.NAME,
 						ARTIFACTS.DESCRIPTION,
@@ -216,14 +279,42 @@ class DefaultArtifactory implements Artifactory {
 				)
 				.from(ARTIFACT_VERSIONS)
 				.innerJoin(ARTIFACTS)
-				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID));
+				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
+				.innerJoin(NAMESPACES)
+				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
 	}
 
-	private void assertCanRelease(EntityId ownerId, String groupId) {
-		final Owner owner = ownerResolver.resolve(ownerId);
-
+	private void assertCanRelease(Owner owner, String groupId) {
 		groupVerifications.findActiveCovering(owner, groupId)
 				.orElseThrow(() -> new GroupIdNotVerifiedException(groupId, owner));
+	}
+
+	private void assertSameOwner(Owner owner, ArtifactCoordinates coordinates) {
+		final boolean ownedByAnotherNamespace = context.fetchExists(
+				DSL.select(ARTIFACTS.ID)
+						.from(ARTIFACTS)
+						.where(
+								ARTIFACTS.GROUP_ID.eq(coordinates.groupId()),
+								ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()),
+								ARTIFACTS.NAMESPACE_ID.ne(owner.id().get())
+						)
+		);
+
+		if (ownedByAnotherNamespace) {
+			throw new ArtifactOwnershipMismatchException(coordinates, owner);
+		}
+	}
+
+	@NonNull
+	static Condition visibilityCondition(@Nullable Owner owner) {
+		if (owner == null) {
+			return ARTIFACTS.VISIBILITY.eq(ArtifactVisibility.PUBLIC.name());
+		}
+
+		return DSL.or(
+				ARTIFACTS.VISIBILITY.eq(ArtifactVisibility.PUBLIC.name()),
+				ARTIFACTS.NAMESPACE_ID.eq(owner.id().get())
+		);
 	}
 
 	@NonNull
@@ -236,11 +327,17 @@ class DefaultArtifactory implements Artifactory {
 	}
 
 	static VersionedArtifact toVersionedArtifact(Record record) {
+		return toVersionedArtifact(record, new Owner(EntityId.from(record.get(NAMESPACES.ID)), record.get(NAMESPACES.SLUG)));
+	}
+
+	static VersionedArtifact toVersionedArtifact(Record record, Owner owner) {
 		return VersionedArtifact.builder()
 				.id(record.get(ARTIFACT_VERSIONS.ID))
 				.artifact(record.get(ARTIFACTS.ID))
+				.owner(owner)
 				.groupId(record.get(ARTIFACTS.GROUP_ID))
 				.artifactId(record.get(ARTIFACTS.ARTIFACT_ID))
+				.visibility(record.get(ARTIFACTS.VISIBILITY, ArtifactVisibility.class))
 				.version(record.get(ARTIFACT_VERSIONS.VERSION))
 				.state(record.get(ARTIFACT_VERSIONS.STATE, PublicationState.class))
 				.checksum(record.get(ARTIFACT_VERSIONS.CHECKSUM, Converter.from(ByteArray.class, String.class, ByteArray::encodeHex)))

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/VersionedArtifact.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/VersionedArtifact.java
@@ -28,7 +28,9 @@ import java.util.List;
  *
  * @param id entity identifier for the artifact version, can't be {@literal null}.
  * @param artifact entity identifier for the artifact, can't be {@literal null}.
+ * @param owner the namespace that owns this artifact, can't be {@literal null}.
  * @param coordinates Maven coordinates of the artifact, can't be {@literal null}.
+ * @param visibility whether this artifact is readable by every namespace or only its owner, can't be {@literal null}.
  * @param name human-readable name of the artifact, may be {@literal null}.
  * @param description textual description of the artifact, may be {@literal null}.
  * @param state current publication state of the artifact version, can't be {@literal null}.
@@ -43,7 +45,9 @@ import java.util.List;
 public record VersionedArtifact(
 		@NonNull @Identity EntityId id,
 		@NonNull @Association(aggregateType = ArtifactDefinition.class) EntityId artifact,
+		@NonNull Owner owner,
 		@NonNull ArtifactCoordinates coordinates,
+		@NonNull ArtifactVisibility visibility,
 		@NonNull PublicationState state,
 		@Nullable String checksum,
 		@Nullable String name,
@@ -112,6 +116,20 @@ public record VersionedArtifact(
 	}
 
 	/**
+	 * Creates a new {@link VersionedArtifact} builder instance that uses the attributes from the
+	 * {@link ArtifactDefinition}, including its {@link Owner} and {@link ArtifactVisibility}.
+	 *
+	 * @param definition the artifact definition to copy the attributes from, can't be {@literal null}.
+	 * @return the versioned artifact builder, never {@literal null}.
+	 **/
+	@NonNull
+	public static Builder from(@NonNull ArtifactDefinition definition) {
+		return from((ArtifactDescriptor) definition)
+				.owner(definition.owner())
+				.visibility(definition.visibility());
+	}
+
+	/**
 	 * Creates a new {@link VersionedArtifact} builder instance.
 	 *
 	 * @return the versioned artifact builder, never {@literal null}.
@@ -130,9 +148,36 @@ public record VersionedArtifact(
 	public static final class Builder extends PublicationBuilder<VersionedArtifact, Builder> {
 		private EntityId id;
 		private EntityId artifact;
+		private Owner owner;
+		private ArtifactVisibility visibility;
 
 		private Builder() {
 			// use the builder static method
+		}
+
+		/**
+		 * Specify the {@link Owner} namespace for this {@link VersionedArtifact}.
+		 *
+		 * @param owner the owning namespace
+		 * @return versioned artifact builder
+		 */
+		@NonNull
+		public Builder owner(Owner owner) {
+			this.owner = owner;
+			return this;
+		}
+
+		/**
+		 * Specify whether this {@link VersionedArtifact} is readable by every namespace or only its
+		 * owner. Defaults to {@link ArtifactVisibility#PRIVATE} when not specified.
+		 *
+		 * @param visibility artifact visibility
+		 * @return versioned artifact builder
+		 */
+		@NonNull
+		public Builder visibility(ArtifactVisibility visibility) {
+			this.visibility = visibility;
+			return this;
 		}
 
 		/**
@@ -213,7 +258,7 @@ public record VersionedArtifact(
 		 */
 		@NonNull
 		public Builder publishedAt(OffsetDateTime publishedAt) {
-			return this.publishedAt(publishedAt == null ? null : publishedAt.toInstant());
+			return this.publishedAt(publishedAt.toInstant());
 		}
 
 		/**
@@ -227,12 +272,14 @@ public record VersionedArtifact(
 		public VersionedArtifact instantiate() {
 			Assert.notNull(id, "Versioned artifact entity identifier can not be null");
 			Assert.notNull(artifact, "Artifact entity identifier can not be null");
+			Assert.notNull(owner, "Artifact owner can not be null");
 			Assert.hasText(groupId, "Artifact groupId can not be null");
 			Assert.hasText(artifactId, "Artifact artifactId can not be null");
 			Assert.notNull(version, "Artifact version can not be null");
 			Assert.notNull(publishedAt, "Created date can not be null");
 
-			return new VersionedArtifact(id, artifact, ArtifactCoordinates.of(groupId, artifactId, version),
+			return new VersionedArtifact(id, artifact, owner, ArtifactCoordinates.of(groupId, artifactId, version),
+					visibility == null ? ArtifactVisibility.PRIVATE : visibility,
 					state == null ? PublicationState.PENDING : state, checksum, name, description, website,
 					repository, publishedAt);
 		}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
@@ -1,7 +1,6 @@
 package com.konfigyr.artifactory.controller;
 
 import com.konfigyr.artifactory.*;
-import com.konfigyr.entity.EntityId;
 import com.konfigyr.hateoas.CollectionModel;
 import com.konfigyr.hateoas.EntityModel;
 import com.konfigyr.security.AuthenticatedPrincipal;
@@ -18,6 +17,7 @@ import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -38,6 +38,7 @@ import java.util.Optional;
 class ArtifactoryController {
 
 	private final Artifactory artifactory;
+	private final OwnerResolver resolver;
 
 	@GetMapping("/{groupId}/{artifactId}/{version}")
 	EntityModel<VersionedArtifact> artifact(
@@ -46,7 +47,7 @@ class ArtifactoryController {
 			@PathVariable String version
 	) {
 		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(groupId, artifactId, version);
-		final VersionedArtifact artifact = artifactory.get(coordinates).orElseThrow(
+		final VersionedArtifact artifact = artifactory.get(resolveOwner().orElse(null), coordinates).orElseThrow(
 				() -> new ArtifactVersionNotFoundException(coordinates)
 		);
 
@@ -60,7 +61,7 @@ class ArtifactoryController {
 			@PathVariable String version
 	) {
 		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(groupId, artifactId, version);
-		final HttpStatus status = artifactory.exists(coordinates) ? HttpStatus.OK : HttpStatus.NOT_FOUND;
+		final HttpStatus status = artifactory.exists(resolveOwner().orElse(null), coordinates) ? HttpStatus.OK : HttpStatus.NOT_FOUND;
 
 		return ResponseEntity.status(status).build();
 	}
@@ -74,13 +75,14 @@ class ArtifactoryController {
 			@RequestBody @Validated ArtifactPublication publication,
 			BindingResult errors
 	) throws BindException {
-		final EntityId namespaceId = retrieveNamespaceIdentifier()
-				.orElseThrow(() -> new ArtifactoryException(HttpStatus.BAD_REQUEST, "Namespace id is not available for current principal"));
+		final Owner owner = resolveOwner().orElseThrow(() -> new AuthenticationCredentialsNotFoundException(
+				"Could not extract namespace identifier from the current authenticated principal"
+		));
 
 		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(groupId, artifactId, version);
 		publication.validate(coordinates, errors);
 
-		return EntityModel.of(artifactory.publish(namespaceId, publication.toArtifactMetadata()));
+		return EntityModel.of(artifactory.publish(owner, publication.toArtifactMetadata()));
 	}
 
 	@GetMapping("/{groupId}/{artifactId}/{version}/properties")
@@ -93,13 +95,27 @@ class ArtifactoryController {
 		return Assemblers.property(coordinates).assemble(artifactory.properties(coordinates));
 	}
 
-	static Optional<EntityId> retrieveNamespaceIdentifier() {
+	@PutMapping("/{groupId}/{artifactId}/visibility")
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@RequiresScope(OAuthScope.PUBLISH_ARTIFACTS)
+	void changeVisibility(
+			@PathVariable String groupId,
+			@PathVariable String artifactId,
+			@RequestBody @Validated ChangeVisibilityRequest request
+	) {
+		final Owner owner = resolveOwner().orElseThrow(() -> new AuthenticationCredentialsNotFoundException(
+				"Could not extract namespace identifier from the current authenticated principal"
+		));
+
+		artifactory.changeVisibility(owner, groupId, artifactId, request.visibility());
+	}
+
+	private Optional<Owner> resolveOwner() {
 		final AuthenticatedPrincipal principal = AuthenticatedPrincipal.resolve();
-
 		if (principal instanceof NamespacedPrincipal namespacedPrincipal) {
-			return namespacedPrincipal.getNamespaceId();
+			return namespacedPrincipal.getNamespaceId()
+					.map(resolver::resolve);
 		}
-
 		return Optional.empty();
 	}
 
@@ -180,4 +196,7 @@ class ArtifactoryController {
 		}
 
 	}
+
+	@NullUnmarked
+	record ChangeVisibilityRequest(@NotNull ArtifactVisibility visibility) { /* noop */ }
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/DefaultServiceManifests.java
@@ -89,6 +89,7 @@ class DefaultServiceManifests implements ServiceManifests {
 	private final Artifactory artifactory;
 	private final ArtifactoryConverters converters;
 	private final ApplicationEventPublisher publisher;
+	private final OwnerResolver ownerResolver;
 
 	@Override
 	@Transactional(readOnly = true, label = "service-manifest.get")
@@ -110,6 +111,7 @@ class DefaultServiceManifests implements ServiceManifests {
 		log.debug("Attempting to open a service manifest for {} with: {}", service, artifacts);
 
 		final EntityId releaseId = upsertRelease(service);
+		final Owner owner = ownerResolver.resolve(service.namespace());
 
 		// Convert the incoming candidates to their ArtifactCoordinates pairs...
 		final List<CandidateArtifact> candidates = artifacts.stream().map(CandidateArtifact::new).toList();
@@ -118,7 +120,7 @@ class DefaultServiceManifests implements ServiceManifests {
 		// overriding a real, previously uploaded checksum already recorded for this release: a
 		// LOCAL row with a non-null checksum is settled and must win over merely being indexed.
 		final Map<ArtifactCoordinates, ExistingArtifact> existing = new LinkedHashMap<>();
-		existing.putAll(loadExistingPublications(artifacts));
+		existing.putAll(loadExistingPublications(owner, artifacts));
 		existing.putAll(loadExistingServiceArtifacts(releaseId));
 
 		final OffsetDateTime timestamp = OffsetDateTime.now();
@@ -529,10 +531,11 @@ class DefaultServiceManifests implements ServiceManifests {
 	 * available. Candidates with no matching {@link Publication} are simply absent from the result,
 	 * since they haven't been indexed yet.
 	 *
+	 * @param owner the namespace on whose behalf the release is being resolved, can't be {@literal null}.
 	 * @param candidates the release candidates to resolve against the Artifactory, can't be {@literal null}.
 	 * @return existing publications keyed by their coordinates, never {@literal null}.
 	 */
-	private Map<ArtifactCoordinates, ExistingArtifact> loadExistingPublications(Collection<ServiceReleaseCandidate> candidates) {
+	private Map<ArtifactCoordinates, ExistingArtifact> loadExistingPublications(Owner owner, Collection<ServiceReleaseCandidate> candidates) {
 		final Map<ArtifactCoordinates, ExistingArtifact> existing = new LinkedHashMap<>();
 
 		if (candidates.isEmpty()) {
@@ -544,7 +547,7 @@ class DefaultServiceManifests implements ServiceManifests {
 			coordinates.add(ArtifactCoordinates.of(candidate));
 		}
 
-		for (Publication publication : artifactory.existing(coordinates)) {
+		for (Publication publication : artifactory.existing(owner, coordinates)) {
 			existing.put(ArtifactCoordinates.of(publication), new ExistingArtifact(publication));
 		}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/manifest/ServiceManifestConfiguration.java
@@ -2,6 +2,7 @@ package com.konfigyr.namespace.manifest;
 
 import com.konfigyr.artifactory.Artifactory;
 import com.konfigyr.artifactory.ArtifactoryConverters;
+import com.konfigyr.artifactory.OwnerResolver;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
 import org.springframework.context.ApplicationEventPublisher;
@@ -15,8 +16,13 @@ public class ServiceManifestConfiguration {
 	private final DSLContext context;
 
 	@Bean
-	ServiceManifests serviceManifests(Artifactory artifactory, ArtifactoryConverters converters, ApplicationEventPublisher publisher) {
-		return new DefaultServiceManifests(context, artifactory, converters, publisher);
+	ServiceManifests serviceManifests(
+			Artifactory artifactory,
+			ArtifactoryConverters converters,
+			ApplicationEventPublisher publisher,
+			OwnerResolver ownerResolver
+	) {
+		return new DefaultServiceManifests(context, artifactory, converters, publisher, ownerResolver);
 	}
 
 }

--- a/konfigyr-api/src/main/resources/messages/problem-detail.properties
+++ b/konfigyr-api/src/main/resources/messages/problem-detail.properties
@@ -303,6 +303,14 @@ problemDetail.title.com.konfigyr.artifactory.ArtifactVersionExistsException=Arti
 problemDetail.com.konfigyr.artifactory.ArtifactVersionExistsException=You attempted to create a new artifact with \
   coordinates ''{0}'' that already exists. Please use a different release version and try again.
 
+problemDetail.title.com.konfigyr.artifactory.ArtifactOwnershipMismatchException=Artifact ownership conflict
+problemDetail.com.konfigyr.artifactory.ArtifactOwnershipMismatchException=The artifact ''{0}:{1}'' is owned by a different \
+  namespace and cannot be published to or modified by ''{2}''.
+
+problemDetail.title.com.konfigyr.artifactory.ArtifactDefinitionNotFoundException=Artifact not found
+problemDetail.com.konfigyr.artifactory.ArtifactDefinitionNotFoundException=Could not find an artifact with the following \
+  coordinates: ''{0}:{1}''.
+
 ## Service manifest module exceptions ##
 
 problemDetail.title.com.konfigyr.namespace.manifest.UndeclaredArtifactException=Artifact not declared for this release

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactTest.java
@@ -20,6 +20,7 @@ class ArtifactTest {
 	void createArtifact() {
 		final var artifact = ArtifactDefinition.builder()
 				.id(93645L)
+				.owner(Owners.konfigyr())
 				.groupId("com.konfigyr")
 				.artifactId("konfigyr-api")
 				.name("Konfigyr API")
@@ -32,8 +33,10 @@ class ArtifactTest {
 
 		assertThat(artifact)
 				.returns(EntityId.from(93645L), ArtifactDefinition::id)
+				.returns(Owners.konfigyr(), ArtifactDefinition::owner)
 				.returns("com.konfigyr", ArtifactDefinition::groupId)
 				.returns("konfigyr-api", ArtifactDefinition::artifactId)
+				.returns(ArtifactVisibility.PRIVATE, ArtifactDefinition::visibility)
 				.returns("Konfigyr API", ArtifactDefinition::name)
 				.returns("Konfigyr REST API artifact", ArtifactDefinition::description)
 				.returns(URI.create("https://api.konfigyr.com"), ArtifactDefinition::website)
@@ -57,8 +60,9 @@ class ArtifactTest {
 		doReturn(URI.create("https://api.konfigyr.com")).when(descriptor).website();
 		doReturn(URI.create("https://github.com/konfigyr/konfigyr-project")).when(descriptor).repository();
 
-		assertThat(ArtifactDefinition.from(descriptor).id("000005KK96ZZP").build())
+		assertThat(ArtifactDefinition.from(descriptor).id("000005KK96ZZP").owner(Owners.konfigyr()).build())
 				.returns(EntityId.from(192846987254L), ArtifactDefinition::id)
+				.returns(Owners.konfigyr(), ArtifactDefinition::owner)
 				.returns("com.konfigyr", ArtifactDefinition::groupId)
 				.returns("konfigyr-api", ArtifactDefinition::artifactId)
 				.returns("Konfigyr API", ArtifactDefinition::name)
@@ -73,7 +77,7 @@ class ArtifactTest {
 	@Test
 	@DisplayName("should sort artifacts by groupId and artifactId")
 	void sortArtifacts() {
-		final var builder = ArtifactDefinition.builder().id(93645L);
+		final var builder = ArtifactDefinition.builder().id(93645L).owner(Owners.konfigyr());
 
 		final var springMail = builder.groupId("org.springframework.boot")
 				.artifactId("spring-boot-starter-mail")
@@ -97,6 +101,7 @@ class ArtifactTest {
 	void createVersionedArtifactFromDescriptor() {
 		final var artifact = ArtifactDefinition.builder()
 				.id(93645L)
+				.owner(Owners.konfigyr())
 				.groupId("com.konfigyr")
 				.artifactId("konfigyr-api")
 				.name("Konfigyr API")
@@ -118,6 +123,8 @@ class ArtifactTest {
 				.returns(EntityId.from(192846987254L), VersionedArtifact::artifact)
 				.returns(artifact.groupId(), VersionedArtifact::groupId)
 				.returns(artifact.artifactId(), VersionedArtifact::artifactId)
+				.returns(artifact.owner(), VersionedArtifact::owner)
+				.returns(artifact.visibility(), VersionedArtifact::visibility)
 				.returns(artifact.name(), VersionedArtifact::name)
 				.returns(artifact.description(), VersionedArtifact::description)
 				.returns(artifact.website(), VersionedArtifact::website)

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
@@ -6,6 +6,7 @@ import com.konfigyr.entity.EntityId;
 import com.konfigyr.io.ByteArray;
 import com.konfigyr.test.AbstractIntegrationTest;
 import org.assertj.core.api.InstanceOfAssertFactories;
+import org.jooq.DSLContext;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,7 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
+import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
 import static org.assertj.core.api.Assertions.*;
 
 class ArtifactoryTest extends AbstractIntegrationTest {
@@ -28,6 +30,9 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 
 	@Autowired
 	MetadataStore store;
+
+	@Autowired
+	DSLContext context;
 
 	@Test
 	@DisplayName("should retrieve versioned artifact by coordinates")
@@ -80,7 +85,7 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 		final var artifact = TestArtifacts.artifact(builder -> builder.version("3.0.0"));
 		final var metadata = TestArtifacts.metadata(artifact);
 
-		assertThat(artifactory.publish(EntityId.from(2L), metadata))
+		assertThat(artifactory.publish(Owners.konfigyr(), metadata))
 				.isNotNull()
 				.returns(artifact.groupId(), VersionedArtifact::groupId)
 				.returns(artifact.artifactId(), VersionedArtifact::artifactId)
@@ -112,7 +117,7 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 		final var metadata = TestArtifacts.metadata(coordinates);
 
 		assertThatExceptionOfType(ArtifactVersionExistsException.class)
-				.isThrownBy(() -> artifactory.publish(EntityId.from(2L), metadata))
+				.isThrownBy(() -> artifactory.publish(Owners.konfigyr(), metadata))
 				.withMessageContaining("Artifact version already exists for following coordinates: %s", coordinates)
 				.returns(coordinates, ArtifactVersionExistsException::getCoordinates)
 				.withNoCause();
@@ -133,7 +138,7 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 		final var metadata = TestArtifacts.metadata(coordinates);
 
 		assertThatExceptionOfType(GroupIdNotVerifiedException.class)
-				.isThrownBy(() -> artifactory.publish(EntityId.from(2L), metadata))
+				.isThrownBy(() -> artifactory.publish(Owners.konfigyr(), metadata))
 				.returns("com.unverified", GroupIdNotVerifiedException::getGroupId)
 				.returns("konfigyr", ex -> ex.getOwner().slug())
 				.returns(HttpStatus.BAD_REQUEST, GroupIdNotVerifiedException::getStatusCode);
@@ -145,16 +150,6 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 		assertThat(events.ofType(ArtifactoryEvent.PublicationCreated.class))
 				.as("Should not publish any release event when ownership is not verified")
 				.isEmpty();
-	}
-
-	@Test
-	@DisplayName("should fail to release an artifact when the owner cannot be resolved")
-	void shouldRejectPublishForUnknownOwner() {
-		final var coordinates = ArtifactCoordinates.parse("com.unverified:some-artifact:1.0.0");
-		final var metadata = TestArtifacts.metadata(coordinates);
-
-		assertThatExceptionOfType(OwnerNotFoundException.class)
-				.isThrownBy(() -> artifactory.publish(EntityId.from(9999L), metadata));
 	}
 
 	@Test
@@ -209,7 +204,7 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 		final var unknownVersion = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:9.0.0");
 		final var unknownArtifact = ArtifactCoordinates.parse("com.konfigyr:konfigyr-unknown:1.0.0");
 
-		assertThat(artifactory.existing(List.of(existing, alsoExisting, unknownVersion, unknownArtifact)))
+		assertThat(artifactory.existing(Owners.konfigyr(), List.of(existing, alsoExisting, unknownVersion, unknownArtifact)))
 				.extracting(ArtifactCoordinates::of)
 				.containsExactlyInAnyOrder(existing, alsoExisting);
 	}
@@ -219,15 +214,162 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 	void shouldResolveNoExistingCoordinates() {
 		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-unknown:1.0.0");
 
-		assertThat(artifactory.existing(List.of(coordinates)))
+		assertThat(artifactory.existing(Owners.konfigyr(), List.of(coordinates)))
 				.isEmpty();
 	}
 
 	@Test
 	@DisplayName("should resolve an empty set of existing coordinates without querying when given an empty collection")
 	void shouldResolveExistingCoordinatesForEmptyCollection() {
-		assertThat(artifactory.existing(List.of()))
+		assertThat(artifactory.existing(Owners.konfigyr(), List.of()))
 				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should retrieve a public versioned artifact for any owner")
+	void shouldRetrieveVisiblePublicVersionedArtifact() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.0");
+
+		assertThat(artifactory.get(Owners.johnDoe(), coordinates))
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
+				.returns(ArtifactVisibility.PUBLIC, VersionedArtifact::visibility);
+
+		assertThat(artifactory.get(null, coordinates))
+				.as("a caller with no namespace context should still see a public artifact")
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
+				.returns(ArtifactVisibility.PUBLIC, VersionedArtifact::visibility);
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve a versioned artifact for any owner when no such version exists")
+	void shouldRetrieveNoVisibleVersionedArtifactWhenUnknown() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:99.0.0");
+
+		assertThat(artifactory.get(Owners.konfigyr(), coordinates))
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should only retrieve a private versioned artifact for its owning namespace")
+	void shouldRetrieveVisiblePrivateVersionedArtifactOnlyForOwner() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-internal-secrets:1.0.0");
+
+		assertThat(artifactory.get(Owners.konfigyr(), coordinates))
+				.as("the owning namespace should see its own private artifact")
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
+				.returns(ArtifactVisibility.PRIVATE, VersionedArtifact::visibility);
+
+		assertThat(artifactory.get(Owners.johnDoe(), coordinates))
+				.as("a different namespace should not see a private artifact it doesn't own")
+				.isEmpty();
+
+		assertThat(artifactory.get(null, coordinates))
+				.as("a caller with no namespace context should not see a private artifact")
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should determine existence of a public artifact version for any owner")
+	void shouldDetermineExistenceOfVisiblePublicVersionedArtifact() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.0");
+
+		assertThat(artifactory.exists(Owners.johnDoe(), coordinates)).isTrue();
+
+		assertThat(artifactory.exists(null, coordinates))
+				.as("a caller with no namespace context should still see a public artifact exists")
+				.isTrue();
+	}
+
+	@Test
+	@DisplayName("should determine non-existence of an unknown artifact version for any owner")
+	void shouldDetermineNoExistenceOfVisibleVersionedArtifactWhenUnknown() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:99.0.0");
+
+		assertThat(artifactory.exists(Owners.konfigyr(), coordinates)).isFalse();
+	}
+
+	@Test
+	@DisplayName("should only determine existence of a private artifact version for its owning namespace")
+	void shouldDetermineExistenceOfVisiblePrivateVersionedArtifactOnlyForOwner() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-internal-secrets:1.0.0");
+
+		assertThat(artifactory.exists(Owners.konfigyr(), coordinates))
+				.as("the owning namespace should see its own private artifact exists")
+				.isTrue();
+
+		assertThat(artifactory.exists(Owners.johnDoe(), coordinates))
+				.as("a different namespace should not see a private artifact it doesn't own")
+				.isFalse();
+
+		assertThat(artifactory.exists(null, coordinates))
+				.as("a caller with no namespace context should not see a private artifact exists")
+				.isFalse();
+	}
+
+	@Test
+	@DisplayName("should reject publishing a new version when the existing artifact is owned by a different namespace")
+	void shouldRejectPublishWhenExistingArtifactOwnedByDifferentNamespace() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:reclaimed-artifact:1.0.0");
+		final var metadata = TestArtifacts.metadata(coordinates);
+
+		assertThatExceptionOfType(ArtifactOwnershipMismatchException.class)
+				.isThrownBy(() -> artifactory.publish(Owners.konfigyr(), metadata))
+				.returns("com.konfigyr", ArtifactOwnershipMismatchException::getGroupId)
+				.returns("reclaimed-artifact", ArtifactOwnershipMismatchException::getArtifactId)
+				.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode);
+
+		assertThat(artifactory.exists(coordinates))
+				.as("no new version should have been created for the rejected publish attempt")
+				.isFalse();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should change visibility of an owned artifact")
+	void shouldChangeVisibilityForOwnedArtifact() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-internal-secrets:1.0.0");
+
+		assertThat(artifactory.get(Owners.johnDoe(), coordinates))
+				.as("should not yet be visible to a different namespace while still private")
+				.isEmpty();
+
+		artifactory.changeVisibility(Owners.konfigyr(), "com.konfigyr", "konfigyr-internal-secrets", ArtifactVisibility.PUBLIC);
+
+		assertThat(artifactory.get(Owners.johnDoe(), coordinates))
+				.as("should now be visible to a different namespace after becoming public")
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
+				.returns(ArtifactVisibility.PUBLIC, VersionedArtifact::visibility);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should reject changing visibility when the caller does not own the artifact")
+	void shouldRejectChangeVisibilityForDifferentOwner() {
+		assertThatExceptionOfType(ArtifactOwnershipMismatchException.class)
+				.isThrownBy(() -> artifactory.changeVisibility(Owners.johnDoe(), "com.konfigyr", "konfigyr-internal-secrets", ArtifactVisibility.PUBLIC))
+				.returns("com.konfigyr", ArtifactOwnershipMismatchException::getGroupId)
+				.returns("konfigyr-internal-secrets", ArtifactOwnershipMismatchException::getArtifactId)
+				.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode);
+
+		assertThat(artifactory.get(Owners.konfigyr(), ArtifactCoordinates.parse("com.konfigyr:konfigyr-internal-secrets:1.0.0")))
+				.as("visibility must remain unchanged after a rejected attempt")
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
+				.returns(ArtifactVisibility.PRIVATE, VersionedArtifact::visibility);
+	}
+
+	@Test
+	@DisplayName("should reject changing visibility for an unknown artifact")
+	void shouldRejectChangeVisibilityForUnknownArtifact() {
+		assertThatExceptionOfType(ArtifactDefinitionNotFoundException.class)
+				.isThrownBy(() -> artifactory.changeVisibility(Owners.konfigyr(), "com.konfigyr", "konfigyr-does-not-exist", ArtifactVisibility.PUBLIC))
+				.returns("com.konfigyr", ArtifactDefinitionNotFoundException::getGroupId)
+				.returns("konfigyr-does-not-exist", ArtifactDefinitionNotFoundException::getArtifactId)
+				.returns(HttpStatus.NOT_FOUND, ArtifactDefinitionNotFoundException::getStatusCode);
 	}
 
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
@@ -20,7 +20,6 @@ import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 
-import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
 import static org.assertj.core.api.Assertions.*;
 
 class ArtifactoryTest extends AbstractIntegrationTest {

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/Owners.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/Owners.java
@@ -1,0 +1,18 @@
+package com.konfigyr.artifactory;
+
+import com.konfigyr.entity.EntityId;
+
+public final class Owners {
+
+	private static final Owner JOHN_DOE = new Owner(EntityId.from(1), "john-doe");
+	private static final Owner KONFIGYR = new Owner(EntityId.from(2), "konfigyr");
+
+	public static Owner konfigyr() {
+		return KONFIGYR;
+	}
+
+	public static Owner johnDoe() {
+		return JOHN_DOE;
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/Owners.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/Owners.java
@@ -1,7 +1,9 @@
 package com.konfigyr.artifactory;
 
 import com.konfigyr.entity.EntityId;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 public final class Owners {
 
 	private static final Owner JOHN_DOE = new Owner(EntityId.from(1), "john-doe");

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactoryControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactoryControllerTest.java
@@ -120,6 +120,64 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@DisplayName("should retrieve a private artifact for its owning namespace but not for another namespace")
+	void shouldRetrievePrivateArtifactOnlyForOwningNamespace() {
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-internal-secrets", "1.0.0");
+
+		mvc.get().uri(uriForArtifact(coordinates).toUri())
+				.with(readingAs(EntityId.from(2L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk();
+
+		mvc.get().uri(uriForArtifact(coordinates).toUri())
+				.with(readingAs(EntityId.from(1L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(hasFailedWithException(ArtifactVersionNotFoundException.class, ex -> ex
+						.returns(coordinates, ArtifactVersionNotFoundException::getCoordinates)
+				));
+
+		mvc.get().uri(uriForArtifact(coordinates).toUri())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(hasFailedWithException(ArtifactVersionNotFoundException.class, ex -> ex
+						.returns(coordinates, ArtifactVersionNotFoundException::getCoordinates)
+				));
+	}
+
+	@Test
+	@DisplayName("should perform an artifact existence check for a private artifact scoped to its owning namespace")
+	void shouldCheckPrivateArtifactExistenceOnlyForOwningNamespace() {
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-internal-secrets", "1.0.0");
+
+		mvc.head().uri(uriForArtifact(coordinates).toUri())
+				.with(readingAs(EntityId.from(2L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk();
+
+		mvc.head().uri(uriForArtifact(coordinates).toUri())
+				.with(readingAs(EntityId.from(1L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND);
+
+		mvc.head().uri(uriForArtifact(coordinates).toUri())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
 	@Transactional
 	@DisplayName("should upload new artifact and create a publication")
 	void shouldUploadNewArtifact() {
@@ -285,6 +343,35 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@DisplayName("should fail to upload a new version when the existing artifact is owned by a different namespace")
+	void uploadArtifactOwnedByDifferentNamespace() {
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "reclaimed-artifact", "1.0.0");
+		final var metadata = TestArtifacts.metadata(coordinates);
+
+		mvc.post().uri(uriForArtifact(coordinates).toUri())
+				.with(publishingTo(EntityId.from(2L)))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(metadata))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(hasFailedWithException(ArtifactOwnershipMismatchException.class, ex -> ex
+						.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode)
+						.returns("com.konfigyr", ArtifactOwnershipMismatchException::getGroupId)
+						.returns("reclaimed-artifact", ArtifactOwnershipMismatchException::getArtifactId)
+				))
+				.satisfies(problemDetailFor(HttpStatus.CONFLICT, problem -> problem
+						.hasTitleContaining("Artifact ownership conflict")
+						.hasDetailContaining("The artifact 'com.konfigyr:reclaimed-artifact' is owned by a different " +
+								"namespace and cannot be published to or modified by 'konfigyr'.")
+				));
+
+		assertThat(store.get(coordinates))
+				.as("Should not store property descriptor when the artifact is owned by a different namespace")
+				.isEmpty();
+	}
+
+	@Test
 	@DisplayName("should fail to publish an artifact when the artifactory:publish scope is not present")
 	void uploadArtifactWithoutScope() {
 		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-api", "3.0.0");
@@ -304,6 +391,95 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 		assertThat(store.get(coordinates))
 				.as("Should not store property descriptor when the scope is missing")
 				.isEmpty();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should change the visibility of an owned artifact")
+	void shouldChangeArtifactVisibility() {
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-internal-secrets", "1.0.0");
+
+		mvc.put().uri(uriForVisibility("com.konfigyr", "konfigyr-internal-secrets").toUri())
+				.with(publishingTo(EntityId.from(2L)))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ArtifactoryController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NO_CONTENT);
+
+		mvc.get().uri(uriForArtifact(coordinates).toUri())
+				.with(readingAs(EntityId.from(1L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to change visibility when the caller does not own the artifact")
+	void shouldRejectChangeArtifactVisibilityForDifferentOwner() {
+		mvc.put().uri(uriForVisibility("com.konfigyr", "konfigyr-internal-secrets").toUri())
+				.with(publishingTo(EntityId.from(1L)))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ArtifactoryController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(hasFailedWithException(ArtifactOwnershipMismatchException.class, ex -> ex
+						.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode)
+						.returns("com.konfigyr", ArtifactOwnershipMismatchException::getGroupId)
+						.returns("konfigyr-internal-secrets", ArtifactOwnershipMismatchException::getArtifactId)
+				))
+				.satisfies(problemDetailFor(HttpStatus.CONFLICT, problem -> problem
+						.hasTitleContaining("Artifact ownership conflict")
+						.hasDetailContaining("The artifact 'com.konfigyr:konfigyr-internal-secrets' is owned by a different " +
+								"namespace and cannot be published to or modified by 'john-doe'.")
+				));
+
+		mvc.get().uri(uriForArtifact(ArtifactCoordinates.of("com.konfigyr", "konfigyr-internal-secrets", "1.0.0")).toUri())
+				.with(readingAs(EntityId.from(1L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("should fail to change visibility for an unknown artifact")
+	void shouldRejectChangeArtifactVisibilityForUnknownArtifact() {
+		mvc.put().uri(uriForVisibility("com.konfigyr", "unknown").toUri())
+				.with(publishingTo(EntityId.from(2L)))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ArtifactoryController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(hasFailedWithException(ArtifactDefinitionNotFoundException.class, ex -> ex
+						.returns(HttpStatus.NOT_FOUND, ArtifactDefinitionNotFoundException::getStatusCode)
+						.returns("com.konfigyr", ArtifactDefinitionNotFoundException::getGroupId)
+						.returns("unknown", ArtifactDefinitionNotFoundException::getArtifactId)
+				))
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitleContaining("Artifact not found")
+						.hasDetailContaining("Could not find an artifact with the following coordinates: 'com.konfigyr:unknown'.")
+				));
+	}
+
+	@Test
+	@DisplayName("should fail to change visibility when the artifactory:publish scope is not present")
+	void shouldRejectChangeArtifactVisibilityWithoutScope() {
+		mvc.put().uri(uriForVisibility("com.konfigyr", "konfigyr-internal-secrets").toUri())
+				.with(authentication(claims -> claims
+						.subject(TestAccounts.jane().build().id().serialize())
+						.claim(KonfigyrClaimNames.NAMESPACE, EntityId.from(2L).serialize())))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ArtifactoryController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.PUBLISH_ARTIFACTS));
 	}
 
 	@Test
@@ -391,10 +567,31 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 				.claim(OAuth2ParameterNames.SCOPE, OAuthScopes.of(OAuthScope.PUBLISH_ARTIFACTS).toString()));
 	}
 
+	/**
+	 * Creates an authentication post-processor whose access token carries the {@code namespace} claim,
+	 * so the reading principal resolves to the given namespace owner, and the {@code artifactory:read}
+	 * scope required by the read endpoints. Used to exercise visibility checks against a specific
+	 * namespace, as opposed to {@link TestPrincipals#john()} which carries no namespace claim at all.
+	 *
+	 * @param namespace the namespace identifier to embed as the reading owner, can't be {@literal null}
+	 * @return the authentication post-processor, never {@literal null}
+	 */
+	static RequestPostProcessor readingAs(EntityId namespace) {
+		return authentication(claims -> claims
+				.subject(TestAccounts.jane().build().id().serialize())
+				.claim(KonfigyrClaimNames.NAMESPACE, namespace.serialize())
+				.claim(OAuth2ParameterNames.SCOPE, OAuthScopes.of(OAuthScope.READ_ARTIFACTS).toString()));
+	}
+
 	static UriComponents uriForArtifact(ArtifactCoordinates coordinates, String... path) {
 		return UriComponentsBuilder.fromPath("/artifacts/{groupId}/{artifactId}/{version}")
 				.pathSegment(path)
 				.buildAndExpand(coordinates.groupId(), coordinates.artifactId(), coordinates.version().get());
+	}
+
+	static UriComponents uriForVisibility(String groupId, String artifactId) {
+		return UriComponentsBuilder.fromPath("/artifacts/{groupId}/{artifactId}/visibility")
+				.buildAndExpand(groupId, artifactId);
 	}
 
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/DefaultGroupVerificationsTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/DefaultGroupVerificationsTest.java
@@ -1,6 +1,6 @@
 package com.konfigyr.artifactory.ownership;
 
-import com.konfigyr.artifactory.Owner;
+import com.konfigyr.artifactory.Owners;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.support.SearchQuery;
 import com.konfigyr.test.AbstractIntegrationTest;
@@ -33,7 +33,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should find active covering by group id and owner")
 	void shouldFundActiveCoveringByIdAndOwner() {
-		final var owner = new Owner(EntityId.from(2), "konfigyr");
+		final var owner = Owners.konfigyr();
 		final var groupId = "com.konfigyr";
 		final var result = verifications.findActiveCovering(owner, groupId);
 
@@ -51,7 +51,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should return empty result for the unrelated groupId")
 	void shouldReturnEmptyResultForUnrelatedGroupId() {
-		final var owner = new Owner(EntityId.from(2), "konfigyr");
+		final var owner = Owners.konfigyr();
 		final var groupId = "com.config";
 		final var result = verifications.findActiveCovering(owner, groupId);
 
@@ -61,7 +61,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should find covering by owner")
 	void shouldFindCoveringByOwner() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var result = verifications.findByOwner(owner, SearchQuery.of(Pageable.ofSize(10)));
 
 		assertThat(result.stream())
@@ -73,7 +73,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should find claims by owner filtered by state")
 	void shouldFindByOwnerFilteredByState() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 
 		final var pending = verifications.findByOwner(owner, SearchQuery.builder()
 				.pageable(Pageable.ofSize(10))
@@ -99,7 +99,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should find claims by owner filtered by search term")
 	void shouldFindByOwnerFilteredByTerm() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 
 		final var both = verifications.findByOwner(owner, SearchQuery.builder()
 				.pageable(Pageable.ofSize(10))
@@ -125,7 +125,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should return empty page when no claims match state filter")
 	void shouldReturnEmptyPageForUnmatchedStateFilter() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 
 		final var result = verifications.findByOwner(owner, SearchQuery.builder()
 				.pageable(Pageable.ofSize(10))
@@ -138,7 +138,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should find claims by owner filtered by state and search term")
 	void shouldFindByOwnerFilteredByStateAndTerm() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 
 		final var result = verifications.findByOwner(owner, SearchQuery.builder()
 				.pageable(Pageable.ofSize(10))
@@ -155,7 +155,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should find covering by group id")
 	void shouldFindCoveringByGroupId() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var groupId = "org.springframework.boot";
 		final var result = verifications.findByGroupId(owner, groupId);
 
@@ -171,7 +171,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should find active challenge")
 	void shouldFindActiveChallenge() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var groupId = "org.springframework.boot";
 		final var groupVerification = GroupVerification.builder()
 				.id(EntityId.from(3))
@@ -193,7 +193,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should find overlapping active claims for parent group ids")
 	void findAnyOverlapping() {
-		final var owner = new Owner(EntityId.from(2), "konfigyr");
+		final var owner = Owners.konfigyr();
 		final var groupId = "com.konfigyr";
 		final var verification = verifications.findActiveCovering(owner, groupId);
 
@@ -212,7 +212,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should reject duplicate active claims for the same groupId")
 	void shouldRejectDuplicateActiveClaim() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		assertThatThrownBy(() -> verifications.claim(owner, "com.konfigyr", VerificationMethod.DNS))
 				.isInstanceOf(GroupIdAlreadyClaimedException.class);
 	}
@@ -221,7 +221,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should create a new claim, activate and revoke with DNA activation method")
 	void shouldCreateActivateAndRevokeClaimWithDns() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var method = VerificationMethod.DNS;
 		final var groupId = "com.mycompany";
 		final var domain = "mycompany.com";
@@ -277,7 +277,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should claim a new verification challenge for an existing failed claim")
 	void shouldReclaimExistingClaim() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var groupId = "org.springframework.ai";
 		final var method = VerificationMethod.DNS;
 
@@ -309,7 +309,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should revoke claim in pending state")
 	void shouldRevokeClaimInPendingState() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var method = VerificationMethod.DNS;
 		final var groupId = "com.pending-company";
 
@@ -333,7 +333,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should fail to revoke claim in revoked state")
 	void shouldFailToRevokeClaimInPendingState() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var method = VerificationMethod.DNS;
 		final var groupId = "com.revoked-company";
 
@@ -356,7 +356,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should create a new claim, activate and revoke with SOURCE_CODE activation method")
 	void shouldCreateActivateAndRevokeClaimWithSourceCode() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var method = VerificationMethod.SOURCE_CODE;
 		final var groupId = "io.gitlab.john-doe";
 
@@ -409,7 +409,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should fail to execute the DNS verification challenge")
 	void shouldFailToVerifyDnsVerificationChallenge() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var groupId = "com.my-third-company";
 
 		final var pendingVerification = assertThat(verifications.claim(owner, groupId, VerificationMethod.DNS))
@@ -439,7 +439,7 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should fail to execute the SOURCE_COSE verification challenge")
 	void shouldFailToVerifySourceCodeVerificationChallenge() {
-		final var owner = new Owner(EntityId.from(1), "john-doe");
+		final var owner = Owners.johnDoe();
 		final var groupId = "io.gitlab.john-doe";
 
 		final var pendingVerification = assertThat(verifications.claim(owner, groupId, VerificationMethod.SOURCE_CODE))

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ServiceCatalogWorkerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ServiceCatalogWorkerTest.java
@@ -368,8 +368,10 @@ class ServiceCatalogWorkerTest extends AbstractIntegrationTest {
 
 	private void insertArtifactMetadataPublication(ArtifactMetadata metadata) {
 		final Long artifactId = context.insertInto(ARTIFACTS)
+				.set(ARTIFACTS.NAMESPACE_ID, 2L)
 				.set(ARTIFACTS.GROUP_ID, metadata.groupId())
 				.set(ARTIFACTS.ARTIFACT_ID, metadata.artifactId())
+				.set(ARTIFACTS.VISIBILITY, ArtifactVisibility.PRIVATE.name())
 				.set(ARTIFACTS.NAME, metadata.name())
 				.set(ARTIFACTS.DESCRIPTION, metadata.description())
 				.set(ARTIFACTS.WEBSITE, Objects.toString(metadata.website(), null))

--- a/konfigyr-data/src/main/resources/migrations/artifactory/artifactory-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/artifactory/artifactory-1.0.0.xml
@@ -18,11 +18,19 @@
 				<constraints primaryKey="true" nullable="false" />
 			</column>
 
+			<column name="namespace_id" type="bigint" remarks="The namespace that owns this artifact.">
+				<constraints nullable="false" />
+			</column>
+
 			<column name="group_id" type="varchar" remarks="The Maven coordinate `groupId` field.">
 				<constraints nullable="false" />
 			</column>
 
 			<column name="artifact_id" type="varchar" remarks="The Maven coordinate `artifactId` field.">
+				<constraints nullable="false" />
+			</column>
+
+			<column name="visibility" type="varchar(16)" remarks="Whether this artifact is readable by every namespace (PUBLIC) or only its owner (PRIVATE).">
 				<constraints nullable="false" />
 			</column>
 
@@ -56,6 +64,19 @@
 				columnNames="group_id,artifact_id"
 				constraintName="unique_artifact"
 		/>
+
+		<addForeignKeyConstraint
+				baseTableName="artifacts"
+				baseColumnNames="namespace_id"
+				constraintName="fk_artifact_owner"
+				referencedTableName="namespaces"
+				referencedColumnNames="id"
+				onDelete="CASCADE"
+		/>
+
+		<createIndex tableName="artifacts" indexName="idx_artifacts_owner">
+			<column name="namespace_id" />
+		</createIndex>
 	</changeSet>
 
 	<changeSet author="vspasic" id="1.0.0-create-artifact-versions-table" context="api">

--- a/konfigyr-test/src/main/resources/data/artifactory.sql
+++ b/konfigyr-test/src/main/resources/data/artifactory.sql
@@ -1,16 +1,21 @@
-INSERT INTO artifacts(id, group_id, artifact_id, name, description, website, repository, created_at, updated_at) VALUES
-(1, 'doe.john', 'website', 'Johns Website', 'Personal website', 'john.doe', NULL,now() - interval '3 days', now() - interval '1 days'),
-(2, 'com.konfigyr', 'konfigyr-crypto-api', 'Konfigyr Crypto API', 'Spring Boot Crypto API library', NULL, 'https://github.com/konfigyr/konfigyr-crypto', now() - interval '7 days', now() - interval '1 days'),
-(3, 'com.konfigyr', 'konfigyr-crypto-tink', 'Konfigyr Crypto Tink', 'Tink support Konfigyr Crypto API library', NULL, 'https://github.com/konfigyr/konfigyr-crypto', now() - interval '5 days', now() - interval '2 days'),
-(4, 'com.konfigyr', 'konfigyr-licences', 'Konfigyr Licences', 'Private repository', NULL, NULL, now() - interval '1 days', now() - interval '1 hours'),
-(5, 'com.konfigyr', 'konfigyr-api', 'Konfigyr API', 'Private REST API', 'konfigyr.api', 'https://github.com/konfigyr/konfigyr-project', now() - interval '1 days', now() - interval '1 hours'),
-(6, 'org.springframework.boot', 'spring-boot', 'Spring Boot', 'Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 days'),
-(7, 'org.springframework.boot', 'spring-boot-autoconfigure', 'Spring Boot AutoConfigure', 'Spring Boot auto-configuration attempts to automatically configure your Spring applications', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 hours'),
-(8, 'org.springframework.boot', 'spring-boot-actuator', 'Spring Boot Actuator', 'Spring Boot Actuator', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 hours'),
-(9, 'org.springframework.modulith', 'spring-modulith-core', 'Spring Modulith Core', 'Modular monoliths with Spring Boot', 'https://spring.io/projects/spring-modulith/spring-modulith-core', 'https://github.com/spring-projects-experimental/spring-modulith', now() - interval '10 days', now() - interval '9 days'),
-(10, 'org.springframework.modulith', 'spring-modulith-moments', 'Spring Modulith Moments', 'Modular monoliths with Spring Boot', 'https://spring.io/projects/spring-modulith/spring-modulith-moments', 'https://github.com/spring-projects-experimental/spring-modulith', now() - interval '10 days', now() - interval '9 days'),
-(11, 'org.springframework.boot', 'spring-boot-jooq', 'Spring Boot jOOQ', 'Spring Boot jOOQ support', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 hours'),
-(12, 'org.springframework.boot', 'spring-boot-liquibase', 'Spring Boot Liquibase', 'Spring Boot Liquibase support', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 hours');
+INSERT INTO artifacts(id, namespace_id, group_id, artifact_id, visibility, name, description, website, repository, created_at, updated_at) VALUES
+(1, 1, 'doe.john', 'website', 'PUBLIC', 'Johns Website', 'Personal website', 'john.doe', NULL,now() - interval '3 days', now() - interval '1 days'),
+(2, 2, 'com.konfigyr', 'konfigyr-crypto-api', 'PUBLIC', 'Konfigyr Crypto API', 'Spring Boot Crypto API library', NULL, 'https://github.com/konfigyr/konfigyr-crypto', now() - interval '7 days', now() - interval '1 days'),
+(3, 2, 'com.konfigyr', 'konfigyr-crypto-tink', 'PUBLIC', 'Konfigyr Crypto Tink', 'Tink support Konfigyr Crypto API library', NULL, 'https://github.com/konfigyr/konfigyr-crypto', now() - interval '5 days', now() - interval '2 days'),
+(4, 2, 'com.konfigyr', 'konfigyr-licences', 'PUBLIC', 'Konfigyr Licences', 'Private repository', NULL, NULL, now() - interval '1 days', now() - interval '1 hours'),
+(5, 2, 'com.konfigyr', 'konfigyr-api', 'PUBLIC', 'Konfigyr API', 'Private REST API', 'konfigyr.api', 'https://github.com/konfigyr/konfigyr-project', now() - interval '1 days', now() - interval '1 hours'),
+(6, 2, 'org.springframework.boot', 'spring-boot', 'PUBLIC', 'Spring Boot', 'Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 days'),
+(7, 2, 'org.springframework.boot', 'spring-boot-autoconfigure', 'PUBLIC', 'Spring Boot AutoConfigure', 'Spring Boot auto-configuration attempts to automatically configure your Spring applications', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 hours'),
+(8, 2, 'org.springframework.boot', 'spring-boot-actuator', 'PUBLIC', 'Spring Boot Actuator', 'Spring Boot Actuator', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 hours'),
+(9, 2, 'org.springframework.modulith', 'spring-modulith-core', 'PUBLIC', 'Spring Modulith Core', 'Modular monoliths with Spring Boot', 'https://spring.io/projects/spring-modulith/spring-modulith-core', 'https://github.com/spring-projects-experimental/spring-modulith', now() - interval '10 days', now() - interval '9 days'),
+(10, 2, 'org.springframework.modulith', 'spring-modulith-moments', 'PUBLIC', 'Spring Modulith Moments', 'Modular monoliths with Spring Boot', 'https://spring.io/projects/spring-modulith/spring-modulith-moments', 'https://github.com/spring-projects-experimental/spring-modulith', now() - interval '10 days', now() - interval '9 days'),
+(11, 2, 'org.springframework.boot', 'spring-boot-jooq', 'PUBLIC', 'Spring Boot jOOQ', 'Spring Boot jOOQ support', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 hours'),
+(12, 2, 'org.springframework.boot', 'spring-boot-liquibase', 'PUBLIC', 'Spring Boot Liquibase', 'Spring Boot Liquibase support', 'https://spring.io/projects/spring-boot', 'https://github.com/spring-projects/spring-boot', now() - interval '6 days', now() - interval '1 hours'),
+/* private fixtures, one per namespace, used to exercise artifact visibility scenarios */
+(13, 1, 'doe.john', 'private-notes', 'PRIVATE', 'Johns Private Notes', 'A private personal artifact only visible to the john-doe namespace', NULL, NULL, now() - interval '2 days', now() - interval '2 days'),
+(14, 2, 'com.konfigyr', 'konfigyr-internal-secrets', 'PRIVATE', 'Konfigyr Internal Secrets', 'Internal configuration properties, private to the konfigyr namespace', NULL, NULL, now() - interval '2 days', now() - interval '2 days'),
+/* owned by john-doe under a groupId now actively claimed by konfigyr: owner namespace_id doesn't match the current active GroupVerification holder, used to exercise publish-time ownership mismatch */
+(15, 1, 'com.konfigyr', 'reclaimed-artifact', 'PRIVATE', 'Reclaimed Artifact', 'Owned by john-doe under a groupId whose active claim now belongs to a different namespace', NULL, NULL, now() - interval '30 days', now() - interval '30 days');
 
 INSERT INTO artifact_versions(id, artifact_id, version, state, checksum, released_at) VALUES
 (1, 1, '1.0.0', 'PUBLISHED', decode('lmUgkxFN4ru/3vuoTkcrYdf2Z5IfcSnmmtfnZJh+Lwo=', 'base64'), now() - interval '1 days'),
@@ -28,7 +33,11 @@ INSERT INTO artifact_versions(id, artifact_id, version, state, checksum, release
 (13, 12, '4.0.4', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '6 hours'),
 /* no artifact_version_properties attached: exercises the "declared version has no indexed property descriptors yet" catalog scenario */
 (14, 9, '2.0.3', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '10 days'),
-(15, 10, '2.0.3', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '10 days');
+(15, 10, '2.0.3', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '10 days'),
+/* private fixtures, one per namespace */
+(16, 13, '1.0.0', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '2 days'),
+(17, 14, '1.0.0', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '2 days'),
+(18, 14, '1.1.0', 'PUBLISHED', decode('7FTrQ6LxfT/s9QYsmHx5TqAl2iWN4LbqZINULveeP4o=', 'base64'), now() - interval '1 days');
 
 INSERT INTO property_definitions(id, artifact_id, checksum, name, type_name, schema, default_value, description, deprecation, occurrences, first_seen, last_seen) VALUES
 (1, 2, decode('cRJ8jlPpTPmTJEoZEZNDSjvdqafG05QkzNJplXyu9J0=', 'base64'), 'spring.application.name', 'java.lang.String', convert_to('{"type":"string"}', 'UTF-8'), NULL, 'Application name. Typically used with logging to help identify the application.', NULL, 1, '1.0.1', '1.0.1'),
@@ -50,7 +59,14 @@ INSERT INTO property_definitions(id, artifact_id, checksum, name, type_name, sch
 (13, 10, decode('vfWkFvWqOO2AH/j1J1L/8q1t0XDR5DE6bkGsGWlpXrs=', 'base64'), 'spring.modulith.moments.enable-time-machine', 'java.lang.Boolean', convert_to('{"type":"boolean"}', 'UTF-8'), 'false', NULL, NULL, 1, '2.0.4', '2.0.4'),
 (14, 10, decode('SMWccCBOl+JJOAD028wbsyESb+QscbuqbqF1Xm270Qk=', 'base64'), 'spring.modulith.moments.granularity', 'org.springframework.modulith.moments.support.MomentsProperties$Granularity', convert_to('{"enum":["DAYS","HOURS"],"type":"string"}', 'UTF-8'), 'hours', NULL, NULL, 1, '2.0.4', '2.0.4'),
 (15, 10, decode('sPa3aP2xi0pWOOqKc1o2BnAO5Vi2n/7CNwopYSmucIs=', 'base64'), 'spring.modulith.moments.locale', 'java.util.Locale', convert_to('{"format":"language","type":"string"}', 'UTF-8'), NULL, NULL, NULL, 1, '2.0.4', '2.0.4'),
-(16, 10, decode('tTlj+7N0mkLnn4uYgrmK4XDaCz72NCLR3z23D/DiTtc=', 'base64'), 'spring.modulith.moments.zone-id', 'java.time.ZoneId', convert_to('{"format":"time-zone","type":"string"}', 'UTF-8'), NULL, NULL, NULL, 1, '2.0.4', '2.0.4');
+(16, 10, decode('tTlj+7N0mkLnn4uYgrmK4XDaCz72NCLR3z23D/DiTtc=', 'base64'), 'spring.modulith.moments.zone-id', 'java.time.ZoneId', convert_to('{"format":"time-zone","type":"string"}', 'UTF-8'), NULL, NULL, NULL, 1, '2.0.4', '2.0.4'),
+/* John Doe private notes properties */
+(17, 13, decode('isIG+jszkxwwEC3TYxdq4fWYmsL3zGIAKPEe8j8ORjY=', 'base64'), 'doe.john.private-notes.secret-key', 'java.lang.String', convert_to('{"type":"string"}', 'UTF-8'), NULL, 'Secret key used by the private notes service.', NULL, 1, '1.0.0', '1.0.0'),
+(18, 13, decode('/g5YYP3OPjNWHsG798Lp2S2pJC2W2xRKmlPFVsYUlJo=', 'base64'), 'doe.john.private-notes.enabled', 'java.lang.Boolean', convert_to('{"type":"boolean"}', 'UTF-8'), 'true', 'Whether the private notes feature is enabled.', NULL, 1, '1.0.0', '1.0.0'),
+/* konfigyr-internal-secrets properties */
+(19, 14, decode('c81bzP9j0m8+6FyDQ76cgXwui4f78h7zFl6OQOR4zTc=', 'base64'), 'konfigyr.internal.encryption-key', 'java.lang.String', convert_to('{"type":"string"}', 'UTF-8'), NULL, 'Internal encryption key used by Konfigyr services.', NULL, 2, '1.0.0', '1.1.0'),
+(20, 14, decode('sNDSqTexnHiB+U95MxtoDkGpXqmlra5a6PaINpFZWlE=', 'base64'), 'konfigyr.internal.debug-mode', 'java.lang.Boolean', convert_to('{"type":"boolean"}', 'UTF-8'), 'false', 'Enables verbose internal debug logging.', NULL, 2, '1.0.0', '1.1.0'),
+(21, 14, decode('3psKDxrd7yVmtKFgXnORBg6Z8GjLoTheksQsGq7QHMI=', 'base64'), 'konfigyr.internal.audit-log-enabled', 'java.lang.Boolean', convert_to('{"type":"boolean"}', 'UTF-8'), 'false', 'Enables audit logging for internal secret access.', NULL, 1, '1.1.0', '1.1.0');
 
 INSERT INTO artifact_version_properties(artifact_version_id, property_definition_id) VALUES
 (3, 1),
@@ -73,7 +89,17 @@ INSERT INTO artifact_version_properties(artifact_version_id, property_definition
 (11, 13),
 (11, 14),
 (11, 15),
-(11, 16);
+(11, 16),
+/* Johns private notes 1.0.0 properties */
+(16, 17),
+(16, 18),
+/* Konfigyr internal secrets 1.0.0 properties */
+(17, 19),
+(17, 20),
+/* Konfigyr internal secrets 1.1.0 properties: carries the 1.0.0 properties forward plus the new one */
+(18, 19),
+(18, 20),
+(18, 21);
 
 INSERT INTO group_verifications(id, namespace_id, group_id, state, created_at, verified_at, revoked_at) VALUES
 (1, 2, 'com.konfigyr', 'ACTIVE', now() - interval '7 days', now() - interval '6 days', NULL),


### PR DESCRIPTION
## Summary
- Artifacts had no link to an owning namespace: any authenticated caller with `READ_ARTIFACTS` scope could resolve any artifact regardless of who published it, and a namespace whose `groupId` claim was revoked and later reclaimed by a different namespace could silently take over and overwrite an existing artifact it never owned.
- Adds an immutable owner (namespace) and a `PUBLIC`/`PRIVATE` visibility to each artifact. New artifacts default to `PRIVATE`; the owning namespace opts in to `PUBLIC` via a new visibility toggle endpoint.
- Enforces visibility on every read path (`get`/`exists`/`properties`) and on batch release resolution (`DefaultServiceManifests`), so a `PRIVATE` artifact is only ever visible to its owner.
- Rejects publishing a new version to an artifact owned by a different namespace (`ArtifactOwnershipMismatchException`, 409) instead of silently overwriting it — this can happen when a `groupId` claim is revoked and reclaimed by someone else.
- Adds `ArtifactDefinitionNotFoundException` (404) for the visibility-toggle-on-unknown-artifact case, with matching `problem-detail` message bundle entries for both new exceptions.
