### PR TITLE
Add REST API for requesting, listing, accepting, rejecting and cancelling artifact ownership transfers

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactOwnershipTransfersController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactOwnershipTransfersController.java
@@ -33,27 +33,32 @@ class ArtifactOwnershipTransfersController {
 	private final ArtifactOwnershipTransfers transfers;
 	private final OwnerResolver ownerResolver;
 
-	@GetMapping
+	@GetMapping("/incoming")
 	@PreAuthorize("isAdmin(#namespace)")
 	@RequiresScope(OAuthScope.READ_NAMESPACES)
-	PagedModel<EntityModel<ArtifactOwnershipTransfer>> getArtifactOwnershipTransfers(
+	PagedModel<EntityModel<ArtifactOwnershipTransfer>> getIncomingTransfers(
 			@PathVariable String namespace,
-			@RequestParam Direction direction,
 			@Nullable @RequestParam(required = false) String term,
 			Pageable pageable
 	) {
 		final Owner owner = ownerResolver.resolve(namespace);
+		final SearchQuery query = SearchQuery.builder().pageable(pageable).term(term).build();
 
-		final SearchQuery query = SearchQuery.builder()
-				.pageable(pageable)
-				.term(term)
-				.build();
+		return Assemblers.artifactOwnershipTransfer(owner).assemble(transfers.findIncoming(owner, query));
+	}
 
-		final var page = direction == Direction.INCOMING
-				? transfers.findIncoming(owner, query)
-				: transfers.findOutgoing(owner, query);
+	@GetMapping("/outgoing")
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.READ_NAMESPACES)
+	PagedModel<EntityModel<ArtifactOwnershipTransfer>> getOutgoingTransfers(
+			@PathVariable String namespace,
+			@Nullable @RequestParam(required = false) String term,
+			Pageable pageable
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final SearchQuery query = SearchQuery.builder().pageable(pageable).term(term).build();
 
-		return Assemblers.artifactOwnershipTransfer(owner).assemble(page);
+		return Assemblers.artifactOwnershipTransfer(owner).assemble(transfers.findOutgoing(owner, query));
 	}
 
 	@GetMapping("/{id}")
@@ -131,11 +136,6 @@ class ArtifactOwnershipTransfersController {
 		}
 
 		return transfer;
-	}
-
-	enum Direction {
-		INCOMING,
-		OUTGOING
 	}
 
 	record TransferRequest(@NotBlank String groupId, @NotBlank String fromNamespace) { /* noop */ }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactOwnershipTransfersController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactOwnershipTransfersController.java
@@ -1,0 +1,143 @@
+package com.konfigyr.artifactory.controller;
+
+import com.konfigyr.artifactory.Owner;
+import com.konfigyr.artifactory.OwnerResolver;
+import com.konfigyr.artifactory.transfer.ArtifactOwnershipTransfer;
+import com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferAlreadyResolvedException;
+import com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferNotFoundException;
+import com.konfigyr.artifactory.transfer.ArtifactOwnershipTransfers;
+import com.konfigyr.artifactory.transfer.TransferState;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.hateoas.EntityModel;
+import com.konfigyr.hateoas.PagedModel;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.security.oauth.RequiresScope;
+import com.konfigyr.support.SearchQuery;
+import jakarta.validation.constraints.NotBlank;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@NullMarked
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/namespaces/{namespace}/artifact-transfers")
+class ArtifactOwnershipTransfersController {
+
+	private final ArtifactOwnershipTransfers transfers;
+	private final OwnerResolver ownerResolver;
+
+	@GetMapping
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.READ_NAMESPACES)
+	PagedModel<EntityModel<ArtifactOwnershipTransfer>> getArtifactOwnershipTransfers(
+			@PathVariable String namespace,
+			@RequestParam Direction direction,
+			@Nullable @RequestParam(required = false) String term,
+			Pageable pageable
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+
+		final SearchQuery query = SearchQuery.builder()
+				.pageable(pageable)
+				.term(term)
+				.build();
+
+		final var page = direction == Direction.INCOMING
+				? transfers.findIncoming(owner, query)
+				: transfers.findOutgoing(owner, query);
+
+		return Assemblers.artifactOwnershipTransfer(owner).assemble(page);
+	}
+
+	@GetMapping("/{id}")
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.READ_NAMESPACES)
+	EntityModel<ArtifactOwnershipTransfer> getArtifactOwnershipTransfer(@PathVariable String namespace, @PathVariable EntityId id) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactOwnershipTransfer transfer = findTransfer(owner, id);
+
+		return Assemblers.artifactOwnershipTransfer(owner).assemble(transfer);
+	}
+
+	@PostMapping
+	@PreAuthorize("isAdmin(#namespace)")
+	@ResponseStatus(HttpStatus.CREATED)
+	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
+	EntityModel<ArtifactOwnershipTransfer> request(@PathVariable String namespace, @RequestBody @Validated TransferRequest request) {
+		final Owner to = ownerResolver.resolve(namespace);
+		final Owner from = ownerResolver.resolve(request.fromNamespace());
+
+		return Assemblers.artifactOwnershipTransfer(to)
+				.assemble(transfers.request(to, request.groupId(), from));
+	}
+
+	@PostMapping("/{id}/accept")
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
+	EntityModel<ArtifactOwnershipTransfer> accept(@PathVariable String namespace, @PathVariable EntityId id) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactOwnershipTransfer transfer = findTransfer(owner, id);
+
+		if (!owner.equals(transfer.from())) {
+			throw new AccessDeniedException("Only the '%s' namespace may accept this transfer".formatted(transfer.from().slug()));
+		}
+
+		return Assemblers.artifactOwnershipTransfer(owner).assemble(transfers.accept(requirePending(transfer)));
+	}
+
+	@PostMapping("/{id}/reject")
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
+	EntityModel<ArtifactOwnershipTransfer> reject(@PathVariable String namespace, @PathVariable EntityId id) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactOwnershipTransfer transfer = findTransfer(owner, id);
+
+		if (!owner.equals(transfer.from())) {
+			throw new AccessDeniedException("Only the '%s' namespace may reject this transfer".formatted(transfer.from().slug()));
+		}
+
+		return Assemblers.artifactOwnershipTransfer(owner).assemble(transfers.reject(requirePending(transfer)));
+	}
+
+	@DeleteMapping("/{id}")
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
+	EntityModel<ArtifactOwnershipTransfer> cancel(@PathVariable String namespace, @PathVariable EntityId id) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactOwnershipTransfer transfer = findTransfer(owner, id);
+
+		if (!owner.equals(transfer.to())) {
+			throw new AccessDeniedException("Only the '%s' namespace may cancel this transfer".formatted(transfer.to().slug()));
+		}
+
+		return Assemblers.artifactOwnershipTransfer(owner).assemble(transfers.cancel(requirePending(transfer)));
+	}
+
+	private ArtifactOwnershipTransfer findTransfer(Owner owner, EntityId id) {
+		return transfers.findById(owner, id)
+				.orElseThrow(() -> new ArtifactOwnershipTransferNotFoundException(owner, id));
+	}
+
+	private static ArtifactOwnershipTransfer requirePending(ArtifactOwnershipTransfer transfer) {
+		if (transfer.state() != TransferState.PENDING) {
+			throw new ArtifactOwnershipTransferAlreadyResolvedException(transfer);
+		}
+
+		return transfer;
+	}
+
+	enum Direction {
+		INCOMING,
+		OUTGOING
+	}
+
+	record TransferRequest(@NotBlank String groupId, @NotBlank String fromNamespace) { /* noop */ }
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
@@ -6,6 +6,7 @@ import com.konfigyr.artifactory.PropertyDefinition;
 import com.konfigyr.artifactory.VersionedArtifact;
 import com.konfigyr.artifactory.ownership.GroupVerification;
 import com.konfigyr.artifactory.ownership.VerificationChallenge;
+import com.konfigyr.artifactory.transfer.ArtifactOwnershipTransfer;
 import com.konfigyr.hateoas.EntityModel;
 import com.konfigyr.hateoas.Link;
 import com.konfigyr.hateoas.LinkBuilder;
@@ -38,6 +39,13 @@ interface Assemblers {
 		);
 	}
 
+	static RepresentationModelAssembler<ArtifactOwnershipTransfer, EntityModel<ArtifactOwnershipTransfer>> artifactOwnershipTransfer(Owner owner) {
+		return transfer -> EntityModel.of(transfer, linkBuilder(owner, transfer).selfRel())
+				.add(linkBuilder(owner, transfer).method(HttpMethod.POST).path("accept").rel("Accept ownership transfer request"))
+				.add(linkBuilder(owner, transfer).method(HttpMethod.POST).path("reject").rel("Reject ownership transfer request"))
+				.add(linkBuilder(owner, transfer).method(HttpMethod.DELETE).rel("Cancel ownership transfer request"));
+	}
+
 	static LinkBuilder linkBuilder(ArtifactCoordinates coordinates) {
 		return Link.builder()
 				.path("artifacts")
@@ -52,5 +60,13 @@ interface Assemblers {
 				.path(owner.slug())
 				.path("group-verifications")
 				.path(verification.groupId());
+	}
+
+	static LinkBuilder linkBuilder(Owner owner, ArtifactOwnershipTransfer transfer) {
+		return Link.builder()
+				.path("namespaces")
+				.path(owner.slug())
+				.path("artifact-transfers")
+				.path(transfer.id().serialize());
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupIdNotVerifiedException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupIdNotVerifiedException.java
@@ -44,4 +44,9 @@ public class GroupIdNotVerifiedException extends ArtifactoryException {
 		return owner;
 	}
 
+	@Override
+	public Object[] getDetailMessageArguments() {
+		return new Object[] { groupId };
+	}
+
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/ArtifactOwnershipTransferAlreadyResolvedException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/ArtifactOwnershipTransferAlreadyResolvedException.java
@@ -1,0 +1,69 @@
+package com.konfigyr.artifactory.transfer;
+
+import com.konfigyr.artifactory.ArtifactoryException;
+import com.konfigyr.entity.EntityId;
+import org.jspecify.annotations.NonNull;
+import org.springframework.http.HttpStatus;
+
+import java.io.Serial;
+
+/**
+ * Exception thrown when an {@link ArtifactOwnershipTransfer} is accepted, rejected or cancelled while
+ * it is no longer in the {@link TransferState#PENDING} state.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+public class ArtifactOwnershipTransferAlreadyResolvedException extends ArtifactoryException {
+
+	@Serial
+	private static final long serialVersionUID = 6289104537019084415L;
+
+	/**
+	 * The identifier of the transfer that has already been resolved.
+	 */
+	private final EntityId id;
+
+	/**
+	 * The current state of the transfer that has already been resolved.
+	 */
+	private final TransferState state;
+
+	/**
+	 * Create a new instance when the given {@link ArtifactOwnershipTransfer} is no longer
+	 * {@link TransferState#PENDING}.
+	 *
+	 * @param transfer the transfer that has already been resolved, can't be {@literal null}
+	 */
+	public ArtifactOwnershipTransferAlreadyResolvedException(@NonNull ArtifactOwnershipTransfer transfer) {
+		super(HttpStatus.CONFLICT, "Artifact ownership transfer '%s' has already been resolved with state '%s'"
+				.formatted(transfer.id(), transfer.state()));
+		this.id = transfer.id();
+		this.state = transfer.state();
+	}
+
+	/**
+	 * Returns the identifier of the transfer that has already been resolved.
+	 *
+	 * @return the transfer identifier, never {@literal null}
+	 */
+	@NonNull
+	public EntityId getId() {
+		return id;
+	}
+
+	/**
+	 * Returns the current state of the transfer that has already been resolved.
+	 *
+	 * @return the transfer state, never {@literal null}
+	 */
+	@NonNull
+	public TransferState getState() {
+		return state;
+	}
+
+	@Override
+	public Object[] getDetailMessageArguments() {
+		return new Object[] { id, state };
+	}
+}

--- a/konfigyr-api/src/main/resources/messages/problem-detail.properties
+++ b/konfigyr-api/src/main/resources/messages/problem-detail.properties
@@ -307,6 +307,35 @@ problemDetail.title.com.konfigyr.artifactory.ArtifactOwnershipMismatchException=
 problemDetail.com.konfigyr.artifactory.ArtifactOwnershipMismatchException=The artifact ''{0}:{1}'' is owned by a different \
   namespace and cannot be published to or modified by ''{2}''.
 
+problemDetail.title.com.konfigyr.artifactory.OwnerNotFoundException=Organization not found
+problemDetail.com.konfigyr.artifactory.OwnerNotFoundException=The namespace you're trying to access doesn't exist \
+  or is no longer available. Double-check the organization identifier or slug and try again.
+
+problemDetail.title.com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException=GroupId is not verified
+problemDetail.com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException=GroupId ''{0}'' is not verified for publishing. \
+  This namespace does not hold an active verification claim covering the requested groupId. Claim and verify it before \
+  publishing to it or requesting artifacts under it.
+
+problemDetail.title.com.konfigyr.artifactory.ownership.GroupVerificationNotFoundException=Group verification not found
+problemDetail.com.konfigyr.artifactory.ownership.GroupVerificationNotFoundException=We couldn't find a groupId \
+  verification claim matching your request. Make sure the claim exists and try again.
+
+problemDetail.title.com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferNotFoundException=Ownership transfer not found
+problemDetail.com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferNotFoundException=We couldn''t find an artifact \
+  ownership transfer visible to the ''{0}'' namespace. Make sure the transfer exists and that this namespace is a party to it.
+
+problemDetail.title.com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferAlreadyRequestedException=Transfer already requested
+problemDetail.com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferAlreadyRequestedException=A pending ownership \
+  transfer for groupId ''{0}'' from ''{1}'' to ''{2}'' already exists. Cancel or resolve it before requesting a new one.
+
+problemDetail.title.com.konfigyr.artifactory.transfer.NoArtifactsToTransferException=No artifacts to transfer
+problemDetail.com.konfigyr.artifactory.transfer.NoArtifactsToTransferException=The ''{1}'' namespace does not own any \
+  artifacts under groupId ''{0}''. There is nothing to transfer.
+
+problemDetail.title.com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferAlreadyResolvedException=Transfer already resolved
+problemDetail.com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferAlreadyResolvedException=The artifact ownership \
+  transfer has already been resolved with a ''{1}'' status and can no longer be accepted, rejected, or cancelled.
+
 problemDetail.title.com.konfigyr.artifactory.ArtifactDefinitionNotFoundException=Artifact not found
 problemDetail.com.konfigyr.artifactory.ArtifactDefinitionNotFoundException=Could not find an artifact with the following \
   coordinates: ''{0}:{1}''.

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactOwnershipTransfersControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactOwnershipTransfersControllerTest.java
@@ -30,7 +30,7 @@ class ArtifactOwnershipTransfersControllerTest extends AbstractControllerTest {
 	@Test
 	@DisplayName("should fail to list transfers for an unknown namespace")
 	void shouldFailFindOwner() {
-		mvc.get().uri("/namespaces/{namespace}/artifact-transfers?direction=INCOMING", "fake-namespace")
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers/incoming", "fake-namespace")
 				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
 				.exchange()
 				.assertThat()
@@ -45,7 +45,7 @@ class ArtifactOwnershipTransfersControllerTest extends AbstractControllerTest {
 	@Test
 	@DisplayName("should list incoming transfers for a namespace")
 	void shouldListIncomingTransfers() {
-		mvc.get().uri("/namespaces/{namespace}/artifact-transfers?direction=INCOMING", "konfigyr")
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers/incoming", "konfigyr")
 				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
 				.exchange()
 				.assertThat()
@@ -61,7 +61,7 @@ class ArtifactOwnershipTransfersControllerTest extends AbstractControllerTest {
 	@Test
 	@DisplayName("should list outgoing transfers for a namespace")
 	void shouldListOutgoingTransfers() {
-		mvc.get().uri("/namespaces/{namespace}/artifact-transfers?direction=OUTGOING", "ebf")
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers/outgoing", "ebf")
 				.with(authentication(TestPrincipals.max(), OAuthScope.READ_NAMESPACES))
 				.exchange()
 				.assertThat()
@@ -77,7 +77,7 @@ class ArtifactOwnershipTransfersControllerTest extends AbstractControllerTest {
 	@Test
 	@DisplayName("should list transfers filtered by search term")
 	void shouldListTransfersFilteredByTerm() {
-		mvc.get().uri("/namespaces/{namespace}/artifact-transfers?direction=INCOMING&term=billing", "konfigyr")
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers/incoming?term=billing", "konfigyr")
 				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
 				.exchange()
 				.assertThat()
@@ -91,16 +91,14 @@ class ArtifactOwnershipTransfersControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
-	@DisplayName("should fail to list transfers without direction query parameter")
-	void shouldFailListingWithoutDirection() {
+	@DisplayName("should not support listing transfers on the base collection path")
+	void shouldFailListingOnBasePath() {
 		mvc.get().uri("/namespaces/{namespace}/artifact-transfers", "konfigyr")
 				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
 				.exchange()
 				.assertThat()
 				.apply(log())
-				.satisfies(problemDetailFor(HttpStatus.BAD_REQUEST, problem -> problem
-						.hasTitle("Bad Request")
-						.hasDetailContaining("Required parameter 'direction' is not present")));
+				.hasStatus(HttpStatus.METHOD_NOT_ALLOWED);
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactOwnershipTransfersControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactOwnershipTransfersControllerTest.java
@@ -1,0 +1,291 @@
+package com.konfigyr.artifactory.controller;
+
+import com.konfigyr.artifactory.OwnerNotFoundException;
+import com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException;
+import com.konfigyr.artifactory.transfer.ArtifactOwnershipTransfer;
+import com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferAlreadyResolvedException;
+import com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferNotFoundException;
+import com.konfigyr.artifactory.transfer.TransferState;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.test.AbstractControllerTest;
+import com.konfigyr.test.TestPrincipals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+
+/**
+ * Tests reuse the pre-seeded {@code artifact-ownership-transfers.sql} fixture wherever possible:
+ * transfer {@code 1} (PENDING, from=konfigyr, to=ebf) backs the accept/reject/cancel scenarios, and
+ * transfer {@code 2} (ACCEPTED, from=john-doe, to=konfigyr) backs the already-resolved conflict case.
+ * Only the "request" endpoint itself needs to create new data, since that's the behavior under test.
+ */
+class ArtifactOwnershipTransfersControllerTest extends AbstractControllerTest {
+
+	@Test
+	@DisplayName("should fail to list transfers for an unknown namespace")
+	void shouldFailFindOwner() {
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers?direction=INCOMING", "fake-namespace")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitle("Organization not found")
+						.hasDetailContaining("The namespace you're trying to access doesn't exist")
+				).andThen(hasFailedWithException(OwnerNotFoundException.class, ex -> ex
+						.hasMessageContaining("Could not find an owner with the following name: fake-namespace"))));
+	}
+
+	@Test
+	@DisplayName("should list incoming transfers for a namespace")
+	void shouldListIncomingTransfers() {
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers?direction=INCOMING", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(ArtifactOwnershipTransfer.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(ArtifactOwnershipTransfer::id)
+						.containsExactlyInAnyOrder(EntityId.from(1), EntityId.from(3)));
+	}
+
+	@Test
+	@DisplayName("should list outgoing transfers for a namespace")
+	void shouldListOutgoingTransfers() {
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers?direction=OUTGOING", "ebf")
+				.with(authentication(TestPrincipals.max(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(ArtifactOwnershipTransfer.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(ArtifactOwnershipTransfer::id)
+						.containsExactlyInAnyOrder(EntityId.from(1), EntityId.from(4)));
+	}
+
+	@Test
+	@DisplayName("should list transfers filtered by search term")
+	void shouldListTransfersFilteredByTerm() {
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers?direction=INCOMING&term=billing", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(ArtifactOwnershipTransfer.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(ArtifactOwnershipTransfer::id)
+						.containsExactly(EntityId.from(1)));
+	}
+
+	@Test
+	@DisplayName("should fail to list transfers without direction query parameter")
+	void shouldFailListingWithoutDirection() {
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(problemDetailFor(HttpStatus.BAD_REQUEST, problem -> problem
+						.hasTitle("Bad Request")
+						.hasDetailContaining("Required parameter 'direction' is not present")));
+	}
+
+	@Test
+	@DisplayName("should fetch a transfer visible to either party")
+	void shouldFetchTransferById() {
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers/{id}", "konfigyr", EntityId.from(2).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ArtifactOwnershipTransfer.class)
+				.returns(EntityId.from(2), ArtifactOwnershipTransfer::id)
+				.returns(TransferState.ACCEPTED, ArtifactOwnershipTransfer::state);
+	}
+
+	@Test
+	@DisplayName("should return 404 fetching a transfer not visible to the requesting namespace")
+	void shouldFailFetchingTransferForUninvolvedNamespace() {
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers/{id}", "ebf", EntityId.from(2).serialize())
+				.with(authentication(TestPrincipals.max(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitle("Ownership transfer not found")
+						.hasDetailContaining("visible to the 'ebf' namespace")
+				).andThen(hasFailedWithException(ArtifactOwnershipTransferNotFoundException.class)));
+	}
+
+	@Test
+	@DisplayName("should return 404 fetching an unknown transfer")
+	void shouldFailFetchingUnknownTransfer() {
+		mvc.get().uri("/namespaces/{namespace}/artifact-transfers/{id}", "konfigyr", EntityId.from(999_999).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitle("Ownership transfer not found")
+						.hasDetailContaining("visible to the 'konfigyr' namespace")
+				).andThen(hasFailedWithException(ArtifactOwnershipTransferNotFoundException.class)));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should request a new transfer")
+	void shouldRequestTransfer() {
+		request("konfigyr", "ebf", "com.konfigyr");
+	}
+
+	@Test
+	@DisplayName("should fail to request a transfer for a non-admin of the requesting namespace")
+	void shouldFailRequestForNonAdmin() {
+		mvc.post().uri("/namespaces/{namespace}/artifact-transfers", "konfigyr")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"groupId\":\"com.konfigyr\",\"fromNamespace\":\"ebf\"}")
+				.with(authentication(TestPrincipals.max(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(problem -> problem
+						.hasTitle("Access Denied")
+						.hasDetailContaining("It looks like you do not have the necessary roles or permissions")));
+	}
+
+	@Test
+	@DisplayName("should fail to request a transfer when the requester has no active claim on the groupId")
+	void shouldFailRequestWithoutActiveClaim() {
+		mvc.post().uri("/namespaces/{namespace}/artifact-transfers", "ebf")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"groupId\":\"com.konfigyr\",\"fromNamespace\":\"john-doe\"}")
+				.with(authentication(TestPrincipals.max(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(problemDetailFor(HttpStatus.BAD_REQUEST, problem -> problem
+						.hasTitle("GroupId is not verified")
+						.hasDetailContaining("does not hold an active verification claim")
+				).andThen(hasFailedWithException(GroupIdNotVerifiedException.class)));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should accept a pending transfer as the current owner")
+	void shouldAcceptTransfer() {
+		mvc.post().uri("/namespaces/{namespace}/artifact-transfers/{id}/accept", "konfigyr", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ArtifactOwnershipTransfer.class)
+				.returns(EntityId.from(1), ArtifactOwnershipTransfer::id)
+				.returns(TransferState.ACCEPTED, ArtifactOwnershipTransfer::state);
+	}
+
+	@Test
+	@DisplayName("should fail to accept a transfer as the requesting namespace instead of the current owner")
+	void shouldFailAcceptForWrongParty() {
+		mvc.post().uri("/namespaces/{namespace}/artifact-transfers/{id}/accept", "ebf", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.max(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(problem -> problem
+						.hasTitle("Access Denied")
+						.hasDetailContaining("It looks like you do not have the necessary permissions")));
+	}
+
+	@Test
+	@DisplayName("should fail to accept a transfer that was already resolved")
+	void shouldFailAcceptingAlreadyResolvedTransfer() {
+		mvc.post().uri("/namespaces/{namespace}/artifact-transfers/{id}/accept", "john-doe", EntityId.from(2).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(problemDetailFor(HttpStatus.CONFLICT, problem -> problem
+						.hasTitle("Transfer already resolved")
+						.hasDetailContaining("has already been resolved with a 'ACCEPTED' status")
+				).andThen(hasFailedWithException(ArtifactOwnershipTransferAlreadyResolvedException.class, ex -> ex
+						.returns(EntityId.from(2), ArtifactOwnershipTransferAlreadyResolvedException::getId)
+						.returns(TransferState.ACCEPTED, ArtifactOwnershipTransferAlreadyResolvedException::getState))));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should reject a pending transfer as the current owner")
+	void shouldRejectTransfer() {
+		mvc.post().uri("/namespaces/{namespace}/artifact-transfers/{id}/reject", "konfigyr", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ArtifactOwnershipTransfer.class)
+				.returns(TransferState.REJECTED, ArtifactOwnershipTransfer::state);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should cancel a pending transfer as the requesting namespace")
+	void shouldCancelTransfer() {
+		mvc.delete().uri("/namespaces/{namespace}/artifact-transfers/{id}", "ebf", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.max(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ArtifactOwnershipTransfer.class)
+				.returns(TransferState.CANCELLED, ArtifactOwnershipTransfer::state);
+	}
+
+	@Test
+	@DisplayName("should fail to cancel a transfer as the current owner instead of the requesting namespace")
+	void shouldFailCancelForWrongParty() {
+		mvc.delete().uri("/namespaces/{namespace}/artifact-transfers/{id}", "konfigyr", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(problem -> problem
+						.hasTitle("Access Denied")
+						.hasDetailContaining("It looks like you do not have the necessary permissions")));
+	}
+
+	private ArtifactOwnershipTransfer request(String to, String from, String groupId) {
+		return mvc.post().uri("/namespaces/{namespace}/artifact-transfers", to)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"groupId\":\"" + groupId + "\",\"fromNamespace\":\"" + from + "\"}")
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.CREATED)
+				.bodyJson()
+				.convertTo(ArtifactOwnershipTransfer.class)
+				.returns(groupId, ArtifactOwnershipTransfer::groupId)
+				.returns(TransferState.PENDING, ArtifactOwnershipTransfer::state)
+				.actual();
+	}
+
+}


### PR DESCRIPTION
Adds the REST API for the artifact ownership transfer workflow: request, list (incoming/outgoing), fetch by id, accept, reject, and cancel, mirroring `GroupVerificationsController`'s existing shape. Also backfills missing `problem-detail.properties` translations for the ownership/transfer exceptions this endpoint surfaces.

The `ArtifactOwnershipTransfers` service (aggregate, lifecycle, jOOQ persistence) was already in place but had no HTTP surface. Namespace admins need a way to request, review, and resolve a transfer without touching the database directly.

- `ArtifactOwnershipTransfersController` mounted at `/namespaces/{namespace}/artifact-transfers`, with `@PreAuthorize("isAdmin(#namespace)")` + `@RequiresScope` on every endpoint.
- Transfers are a two-party handshake (`from` = current owner, `to` = requesting namespace). The controller enforces who can call what: `accept`/`reject` only by `from`, `cancel` only by `to` — wrong-party calls raise a `403` via a plain `AccessDeniedException`.
- A transfer must be `PENDING` to be resolved; a second accept/reject/cancel raises a new `409 Conflict` (`ArtifactOwnershipTransferAlreadyResolvedException`) instead of leaking a `500` from the service's internal `IllegalStateException` guard.
- `Assemblers` gained an `artifactOwnershipTransfer(Owner)` HAL assembler with self/accept/reject/cancel links.
- Added missing `problem-detail.properties` entries for `OwnerNotFoundException`, `GroupVerificationNotFoundException`, `GroupIdNotVerifiedException`, `ArtifactOwnershipTransferNotFoundException`, `ArtifactOwnershipTransferAlreadyRequestedException`, `NoArtifactsToTransferException`, and the new `ArtifactOwnershipTransferAlreadyResolvedException`; these were previously falling back to raw exception messages with no friendly title/detail. `GroupIdNotVerifiedException` needed a `getDetailMessageArguments()` override so its translated message still carries the dynamic groupId.
