### PR TITLE
Surface pre-existing groupId conflicts at claim/verify time

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
@@ -1,5 +1,7 @@
 package com.konfigyr.artifactory.controller;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.konfigyr.artifactory.ArtifactCoordinates;
 import com.konfigyr.artifactory.Owner;
 import com.konfigyr.artifactory.PropertyDefinition;
@@ -12,6 +14,9 @@ import com.konfigyr.hateoas.Link;
 import com.konfigyr.hateoas.LinkBuilder;
 import com.konfigyr.hateoas.RepresentationModelAssembler;
 import org.springframework.http.HttpMethod;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 
 interface Assemblers {
 
@@ -27,6 +32,15 @@ interface Assemblers {
 
 	static RepresentationModelAssembler<GroupVerification, EntityModel<GroupVerification>> groupVerification(Owner owner) {
 		return verification -> EntityModel.of(verification, linkBuilder(owner, verification).selfRel())
+				.add(linkBuilder(owner, verification).method(HttpMethod.GET).path("challenges").rel("list verification challenges"))
+				.add(linkBuilder(owner, verification).method(HttpMethod.POST).path("verify").rel("verify"))
+				.add(linkBuilder(owner, verification).method(HttpMethod.DELETE).rel("revoke"));
+	}
+
+	static RepresentationModelAssembler<GroupVerification, EntityModel<GroupVerificationRepresentation>> groupVerification(Owner owner, Set<Owner> conflictingOwners) {
+		final Set<String> conflicts = conflictingOwners.stream().map(Owner::slug).collect(Collectors.toUnmodifiableSet());
+
+		return verification -> EntityModel.of(new GroupVerificationRepresentation(verification, conflicts), linkBuilder(owner, verification).selfRel())
 				.add(linkBuilder(owner, verification).method(HttpMethod.GET).path("challenges").rel("list verification challenges"))
 				.add(linkBuilder(owner, verification).method(HttpMethod.POST).path("verify").rel("verify"))
 				.add(linkBuilder(owner, verification).method(HttpMethod.DELETE).rel("revoke"));
@@ -69,4 +83,17 @@ interface Assemblers {
 				.path("artifact-transfers")
 				.path(transfer.id().serialize());
 	}
+
+	/**
+	 * Enriched {@link GroupVerification} representation returned by the {@code claim} and {@code verify}
+	 * endpoints, adding the {@code conflictingOwners} field alongside the verification's own fields.
+	 *
+	 * @param verification the claimed or verified {@link GroupVerification}
+	 * @param conflictingOwners slugs of namespaces, other than the caller, that already own artifacts under
+	 *        {@link GroupVerification#groupId()}
+	 */
+	record GroupVerificationRepresentation(
+			@JsonUnwrapped GroupVerification verification,
+			@JsonInclude(JsonInclude.Include.NON_EMPTY) Set<String> conflictingOwners
+	) { }
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/GroupVerificationsController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/GroupVerificationsController.java
@@ -65,11 +65,12 @@ class GroupVerificationsController {
 	@PreAuthorize("isAdmin(#namespace)")
 	@ResponseStatus(HttpStatus.CREATED)
 	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
-	EntityModel<GroupVerification> claim(@PathVariable String namespace, @RequestBody @Validated ClaimRequest request) {
+	EntityModel<Assemblers.GroupVerificationRepresentation> claim(@PathVariable String namespace, @RequestBody @Validated ClaimRequest request) {
 		final Owner owner = ownerResolver.resolve(namespace);
+		final GroupVerification verification = groupVerifications.claim(owner, request.groupId(), request.verificationMethod());
 
-		return Assemblers.groupVerification(owner)
-				.assemble(groupVerifications.claim(owner, request.groupId(), request.verificationMethod()));
+		return Assemblers.groupVerification(owner, groupVerifications.findOwners(request.groupId(), owner))
+				.assemble(verification);
 	}
 
 	@GetMapping("/{groupId}/challenges")
@@ -87,14 +88,15 @@ class GroupVerificationsController {
 	@PostMapping("/{groupId}/verify")
 	@PreAuthorize("isAdmin(#namespace)")
 	@RequiresScope(OAuthScope.WRITE_NAMESPACES)
-	EntityModel<GroupVerification> verify(
+	EntityModel<Assemblers.GroupVerificationRepresentation> verify(
 			@PathVariable String namespace,
 			@PathVariable String groupId
 	) {
 		final Owner owner = ownerResolver.resolve(namespace);
+		final GroupVerification verification = groupVerifications.verify(owner, groupId);
 
-		return Assemblers.groupVerification(owner)
-				.assemble(groupVerifications.verify(owner, groupId));
+		return Assemblers.groupVerification(owner, groupVerifications.findOwners(groupId, owner))
+				.assemble(verification);
 	}
 
 	@DeleteMapping("/{groupId}")

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/DefaultGroupVerifications.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/DefaultGroupVerifications.java
@@ -24,7 +24,9 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
+import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
 import static com.konfigyr.data.tables.GroupVerificationChallenges.GROUP_VERIFICATION_CHALLENGES;
 import static com.konfigyr.data.tables.GroupVerifications.GROUP_VERIFICATIONS;
 import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
@@ -102,6 +104,17 @@ class DefaultGroupVerifications implements GroupVerifications {
 				.where(GROUP_VERIFICATIONS.NAMESPACE_ID.eq(owner.id().get()))
 				.and(GROUP_VERIFICATIONS.GROUP_ID.eq(groupId))
 				.fetchOptional(DefaultGroupVerifications::toGroupVerification);
+	}
+
+	@Override
+	@Transactional(readOnly = true, label = "group-verifications.find-owners")
+	public Set<Owner> findOwners(String groupId, Owner excluding) {
+		return context.selectDistinct(ARTIFACTS.NAMESPACE_ID, NAMESPACES.SLUG)
+				.from(ARTIFACTS)
+				.innerJoin(NAMESPACES).on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID))
+				.where(ARTIFACTS.GROUP_ID.eq(groupId))
+				.and(ARTIFACTS.NAMESPACE_ID.ne(excluding.id().get()))
+				.fetchSet(DefaultGroupVerifications::toOwner);
 	}
 
 	@Override
@@ -256,49 +269,6 @@ class DefaultGroupVerifications implements GroupVerifications {
 				.where(condition);
 	}
 
-	private static Condition prefixOf(String groupId) {
-		return DSL.val(groupId)
-				.like(DSL.concat(GROUP_VERIFICATIONS.GROUP_ID, DSL.val(".%")))
-				.or(GROUP_VERIFICATIONS.GROUP_ID.eq(groupId));
-	}
-
-	private static Condition overlaps(String groupId) {
-		return prefixOf(groupId)
-				.or(GROUP_VERIFICATIONS.GROUP_ID.like(DSL.concat(DSL.val(groupId), DSL.val(".%"))));
-	}
-
-	private static GroupVerification toGroupVerification(Record record) {
-		return toGroupVerification(record, new Owner(
-				record.get(GROUP_VERIFICATIONS.NAMESPACE_ID, EntityId.class),
-				record.get(NAMESPACES.SLUG)
-		));
-	}
-
-	private static GroupVerification toGroupVerification(Record record, Owner owner) {
-		return GroupVerification.builder()
-				.id(record.get(GROUP_VERIFICATIONS.ID, EntityId.class))
-				.owner(owner)
-				.groupId(record.get(GROUP_VERIFICATIONS.GROUP_ID))
-				.state(record.get(GROUP_VERIFICATIONS.STATE, VerificationState.class))
-				.createdAt(record.get(GROUP_VERIFICATIONS.CREATED_AT))
-				.verifiedAt(record.get(GROUP_VERIFICATIONS.VERIFIED_AT))
-				.revokedAt(record.get(GROUP_VERIFICATIONS.REVOKED_AT))
-				.build();
-	}
-
-	private static VerificationChallenge toVerificationChallenge(Record record) {
-		return VerificationChallenge.builder()
-				.id(record.get(GROUP_VERIFICATION_CHALLENGES.ID))
-				.verificationId(record.get(GROUP_VERIFICATION_CHALLENGES.GROUP_VERIFICATION_ID, EntityId.class))
-				.method(record.get(GROUP_VERIFICATION_CHALLENGES.VERIFICATION_METHOD, VerificationMethod.class))
-				.token(record.get(GROUP_VERIFICATION_CHALLENGES.CHALLENGE_TOKEN))
-				.state(record.get(GROUP_VERIFICATION_CHALLENGES.STATE, ChallengeState.class))
-				.createdAt(record.get(GROUP_VERIFICATION_CHALLENGES.CREATED_AT))
-				.verifiedAt(record.get(GROUP_VERIFICATION_CHALLENGES.VERIFIED_AT))
-				.expiresAt(record.get(GROUP_VERIFICATION_CHALLENGES.EXPIRES_AT))
-				.build();
-	}
-
 	private void expireActiveChallenges(GroupVerification verification) {
 		final int expired = context.update(GROUP_VERIFICATION_CHALLENGES)
 				.set(GROUP_VERIFICATION_CHALLENGES.STATE, ChallengeState.EXPIRED.name())
@@ -370,6 +340,56 @@ class DefaultGroupVerifications implements GroupVerifications {
 				updated.owner().slug(), updated.owner().id(), updated.groupId(), challenge.method(), challenge.state());
 
 		return updated;
+	}
+
+	private static Condition prefixOf(String groupId) {
+		return DSL.val(groupId)
+				.like(DSL.concat(GROUP_VERIFICATIONS.GROUP_ID, DSL.val(".%")))
+				.or(GROUP_VERIFICATIONS.GROUP_ID.eq(groupId));
+	}
+
+	private static Condition overlaps(String groupId) {
+		return prefixOf(groupId)
+				.or(GROUP_VERIFICATIONS.GROUP_ID.like(DSL.concat(DSL.val(groupId), DSL.val(".%"))));
+	}
+
+	private static Owner toOwner(Record record) {
+		return new Owner(
+				record.get(ARTIFACTS.NAMESPACE_ID, EntityId.class),
+				record.get(NAMESPACES.SLUG)
+		);
+	}
+
+	private static GroupVerification toGroupVerification(Record record) {
+		return toGroupVerification(record, new Owner(
+				record.get(GROUP_VERIFICATIONS.NAMESPACE_ID, EntityId.class),
+				record.get(NAMESPACES.SLUG)
+		));
+	}
+
+	private static GroupVerification toGroupVerification(Record record, Owner owner) {
+		return GroupVerification.builder()
+				.id(record.get(GROUP_VERIFICATIONS.ID, EntityId.class))
+				.owner(owner)
+				.groupId(record.get(GROUP_VERIFICATIONS.GROUP_ID))
+				.state(record.get(GROUP_VERIFICATIONS.STATE, VerificationState.class))
+				.createdAt(record.get(GROUP_VERIFICATIONS.CREATED_AT))
+				.verifiedAt(record.get(GROUP_VERIFICATIONS.VERIFIED_AT))
+				.revokedAt(record.get(GROUP_VERIFICATIONS.REVOKED_AT))
+				.build();
+	}
+
+	private static VerificationChallenge toVerificationChallenge(Record record) {
+		return VerificationChallenge.builder()
+				.id(record.get(GROUP_VERIFICATION_CHALLENGES.ID))
+				.verificationId(record.get(GROUP_VERIFICATION_CHALLENGES.GROUP_VERIFICATION_ID, EntityId.class))
+				.method(record.get(GROUP_VERIFICATION_CHALLENGES.VERIFICATION_METHOD, VerificationMethod.class))
+				.token(record.get(GROUP_VERIFICATION_CHALLENGES.CHALLENGE_TOKEN))
+				.state(record.get(GROUP_VERIFICATION_CHALLENGES.STATE, ChallengeState.class))
+				.createdAt(record.get(GROUP_VERIFICATION_CHALLENGES.CREATED_AT))
+				.verifiedAt(record.get(GROUP_VERIFICATION_CHALLENGES.VERIFIED_AT))
+				.expiresAt(record.get(GROUP_VERIFICATION_CHALLENGES.EXPIRES_AT))
+				.build();
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupVerifications.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/GroupVerifications.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Service for managing Maven {@code groupId} ownership claims and their verification attempts.
@@ -104,6 +105,22 @@ public interface GroupVerifications {
 	 * @return the matching claim if present; otherwise an empty optional
 	 */
 	Optional<GroupVerification> findByGroupId(Owner owner, String groupId);
+
+	/**
+	 * Returns the distinct namespaces, other than {@code excluding}, that own at least one artifact under
+	 * the given {@code groupId}.
+	 * <p>
+	 * Used to surface pre-existing ownership conflicts: by {@link #claim(Owner, String, VerificationMethod)}
+	 * and {@link #verify(Owner, String)} callers to inform a namespace claiming or verifying a {@code groupId}
+	 * that another namespace already owns artifacts under it, and by
+	 * {@code com.konfigyr.artifactory.transfer.ArtifactOwnershipTransfers#request} to validate that the
+	 * requested {@code from} namespace actually owns something worth transferring.
+	 *
+	 * @param groupId the Maven group identifier to inspect
+	 * @param excluding the namespace to exclude from the result
+	 * @return the distinct owning namespaces other than {@code excluding}, never {@literal null}, empty if none exist
+	 */
+	Set<Owner> findOwners(String groupId, Owner excluding);
 
 	/**
 	 * Finds the single {@link ChallengeState#UNVERIFIED} challenge attached to a verification claim.

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfers.java
@@ -27,7 +27,6 @@ import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import static com.konfigyr.data.tables.ArtifactOwnershipTransfers.ARTIFACT_OWNERSHIP_TRANSFERS;
 import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
@@ -43,16 +42,18 @@ import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
  * {@link Record records} into the aggregate, and each mutation re-reads the resulting state from the
  * database rather than trusting the in-memory copy.
  * <p>
- * Two of those methods also read or write {@code ARTIFACTS.NAMESPACE_ID} directly: {@link #findArtifactOwners(String, Owner)}
- * resolves the candidate owners a {@link #request(Owner, String, Owner) request} can be made against, and
- * {@link #transferArtifacts(Owner, Owner, String)} performs the bulk reassignment once
- * {@link #accept(ArtifactOwnershipTransfer)} has confirmed the transition is valid. Elsewhere in this module,
- * {@code com.konfigyr.artifactory.DefaultArtifactory} is the sole writer of that column; it is bypassed here
- * on purpose. Exposing a generic "move these artifacts" method on the public {@code Artifactory} interface
- * would let any holder of that interface reassign ownership outside this two-party consent flow entirely,
- * which is exactly the failure mode this aggregate exists to prevent. Keeping both operations private to this
- * class means the only path to a bulk ownership move is through an {@link ArtifactOwnershipTransfer} that has
- * actually been accepted.
+ * {@link #transferArtifacts(Owner, Owner, String)} writes {@code ARTIFACTS.NAMESPACE_ID} directly, performing
+ * the bulk reassignment once {@link #accept(ArtifactOwnershipTransfer)} has confirmed the transition is valid.
+ * Elsewhere in this module, {@code com.konfigyr.artifactory.DefaultArtifactory} is the sole writer of that
+ * column; it is bypassed here on purpose. Exposing a generic "move these artifacts" method on the public
+ * {@code Artifactory} interface would let any holder of that interface reassign ownership outside this
+ * two-party consent flow entirely, which is exactly the failure mode this aggregate exists to prevent. Keeping
+ * this operation private to this class means the only path to a bulk ownership move is through an
+ * {@link ArtifactOwnershipTransfer} that has actually been accepted. The read side of the same question —
+ * which namespaces currently own artifacts under a {@code groupId} — is answered by
+ * {@link GroupVerifications#findOwners(String, Owner)} instead, since {@link #request(Owner, String, Owner)}
+ * is not its only caller: {@code com.konfigyr.artifactory.controller.GroupVerificationsController} also uses
+ * it to surface pre-existing ownership conflicts at claim/verify time.
  * <p>
  * {@link #accept(ArtifactOwnershipTransfer)} performs its state transition and the {@link #transferArtifacts(Owner, Owner, String)}
  * write in the same database transaction, and only publishes {@link ArtifactoryEvent.OwnershipTransferAccepted}
@@ -114,7 +115,7 @@ class DefaultArtifactOwnershipTransfers implements ArtifactOwnershipTransfers {
 		groupVerifications.findActiveCovering(to, groupId)
 				.orElseThrow(() -> new GroupIdNotVerifiedException(groupId, to));
 
-		if (!findArtifactOwners(groupId, to).contains(from)) {
+		if (!groupVerifications.findOwners(groupId, to).contains(from)) {
 			throw new NoArtifactsToTransferException(groupId, from);
 		}
 
@@ -200,28 +201,6 @@ class DefaultArtifactOwnershipTransfers implements ArtifactOwnershipTransfers {
 				.execute();
 
 		return resolved;
-	}
-
-	/**
-	 * Returns the distinct namespaces, other than {@code excluding}, that own at least one artifact under
-	 * the given {@code groupId}.
-	 * <p>
-	 * Called from {@link #request(Owner, String, Owner)} to validate that the requested {@code from}
-	 * namespace actually owns something worth transferring before a {@link ArtifactOwnershipTransfer} is
-	 * created for it.
-	 *
-	 * @param groupId the Maven group identifier to inspect
-	 * @param excluding the namespace to exclude from the result, namely the requesting {@code to} namespace
-	 * @return the distinct owning namespaces other than {@code excluding}, never {@literal null}, empty if none exist
-	 */
-	private Set<Owner> findArtifactOwners(String groupId, Owner excluding) {
-		return context.selectDistinct(ARTIFACTS.NAMESPACE_ID, NAMESPACES.SLUG)
-				.from(ARTIFACTS)
-				.innerJoin(NAMESPACES)
-				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID))
-				.where(ARTIFACTS.GROUP_ID.eq(groupId))
-				.and(ARTIFACTS.NAMESPACE_ID.ne(excluding.id().get()))
-				.fetchSet(record -> new Owner(EntityId.from(record.get(ARTIFACTS.NAMESPACE_ID)), record.get(NAMESPACES.SLUG)));
 	}
 
 	/**

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/GroupVerificationsControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/GroupVerificationsControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
 import javax.naming.directory.InitialDirContext;
+import java.util.Set;
 
 import static com.konfigyr.artifactory.ownership.VerificationStrategyTestUtils.*;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -174,6 +175,82 @@ class GroupVerificationsControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@DisplayName("should surface conflicting owners when claiming a groupId with pre-existing artifacts from another namespace")
+	@Transactional
+	void shouldSurfaceConflictingOwnersOnClaim() {
+		mvc.post().uri("/namespaces/{namespace}/group-verifications", "konfigyr")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"groupId\":\"com.acme.widgets\",\"verificationMethod\":\"DNS\"}")
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.CREATED)
+				.bodyJson()
+				.convertTo(ClaimResponse.class)
+				.returns("com.acme.widgets", ClaimResponse::groupId)
+				.returns(Set.of("ebf"), ClaimResponse::conflictingOwners);
+	}
+
+	@Test
+	@DisplayName("should not surface any conflicting owners when nobody else owns artifacts under the groupId")
+	@Transactional
+	void shouldNotSurfaceConflictingOwnersWhenNoneExist() {
+		mvc.post().uri("/namespaces/{namespace}/group-verifications", "konfigyr")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"groupId\":\"com.company.claim\",\"verificationMethod\":\"DNS\"}")
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.CREATED)
+				.bodyJson()
+				.convertTo(ClaimResponse.class)
+				.returns(null, ClaimResponse::conflictingOwners);
+	}
+
+	@Test
+	@DisplayName("should surface conflicting owners when verifying a groupId with pre-existing artifacts from another namespace")
+	@Transactional
+	void shouldSurfaceConflictingOwnersOnVerify() {
+		final String namespace = "konfigyr";
+		final String groupId = "com.acme.widgets";
+
+		mvc.post().uri("/namespaces/{namespace}/group-verifications", namespace)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"groupId\":\"" + groupId + "\",\"verificationMethod\":\"DNS\"}")
+				.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.hasStatus(HttpStatus.CREATED);
+
+		final String token = mvc.get().uri("/namespaces/{namespace}/group-verifications/{groupId}/challenges", namespace, groupId)
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.bodyJson()
+				.convertTo(collectionModel(VerificationChallenge.class))
+				.actual()
+				.getContent()
+				.iterator().next()
+				.token();
+
+		try (MockedConstruction<InitialDirContext> ignored = mockDns("acme.com", "some-other-record", "konfigyr-verification=" + token)) {
+			mvc.post().uri("/namespaces/{namespace}/group-verifications/{groupId}/verify", namespace, groupId)
+					.with(authentication(TestPrincipals.john(), OAuthScope.WRITE_NAMESPACES))
+					.exchange()
+					.assertThat()
+					.apply(log())
+					.hasStatusOk()
+					.bodyJson()
+					.convertTo(ClaimResponse.class)
+					.returns(groupId, ClaimResponse::groupId)
+					.returns(VerificationState.ACTIVE, ClaimResponse::state)
+					.returns(Set.of("ebf"), ClaimResponse::conflictingOwners);
+		}
+	}
+
+	@Test
 	@DisplayName("should fetch claim by group id")
 	void shouldFetchClaimByGroupId() {
 		mvc.get().uri("/namespaces/{namespace}/group-verifications/{groupId}", "john-doe", "org.springframework.ai")
@@ -304,4 +381,6 @@ class GroupVerificationsControllerTest extends AbstractControllerTest {
 				.returns(VerificationState.PENDING, GroupVerification::state)
 				.satisfies(it -> assertThat(it.createdAt()).isNotNull());
 	}
+
+	private record ClaimResponse(String groupId, VerificationState state, Set<String> conflictingOwners) { }
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/DefaultGroupVerificationsTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ownership/DefaultGroupVerificationsTest.java
@@ -59,6 +59,30 @@ class DefaultGroupVerificationsTest extends AbstractIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("should find owners of artifacts under a groupId, excluding the given namespace")
+	void shouldFindOwnersExcludingGivenNamespace() {
+		final var result = verifications.findOwners("com.konfigyr", Owners.konfigyr());
+
+		assertThat(result).containsExactlyInAnyOrder(Owners.johnDoe(), Owners.ebf());
+	}
+
+	@Test
+	@DisplayName("should never include the excluded namespace among the owners it holds itself")
+	void shouldNeverIncludeExcludedNamespaceAmongOwners() {
+		final var result = verifications.findOwners("com.konfigyr", Owners.johnDoe());
+
+		assertThat(result).containsExactlyInAnyOrder(Owners.konfigyr(), Owners.ebf());
+	}
+
+	@Test
+	@DisplayName("should return an empty result when no artifacts exist under the groupId")
+	void shouldReturnEmptyOwnersForUnknownGroupId() {
+		final var result = verifications.findOwners("com.unknown", Owners.konfigyr());
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
 	@DisplayName("should find covering by owner")
 	void shouldFindCoveringByOwner() {
 		final var owner = Owners.johnDoe();

--- a/konfigyr-api/src/test/resources/data/artifact-ownership-transfers.sql
+++ b/konfigyr-api/src/test/resources/data/artifact-ownership-transfers.sql
@@ -1,6 +1,8 @@
 /* owned by an uninvolved namespace (ebf) under the same groupId as the reclaimed-artifact fixture (see konfigyr-test's artifactory.sql): used to verify that accepting an ownership transfer only moves the requested 'from' namespace's artifacts, leaving other owners under that groupId untouched */
 INSERT INTO artifacts(id, namespace_id, group_id, artifact_id, visibility, name, description, website, repository, created_at, updated_at) VALUES
-(16, 3, 'com.konfigyr', 'ebf-artifact', 'PRIVATE', 'EBF Artifact', 'Owned by the ebf namespace, uninvolved in any ownership transfer request', NULL, NULL, now() - interval '1 days', now() - interval '1 days');
+(16, 3, 'com.konfigyr', 'ebf-artifact', 'PRIVATE', 'EBF Artifact', 'Owned by the ebf namespace, uninvolved in any ownership transfer request', NULL, NULL, now() - interval '1 days', now() - interval '1 days'),
+/* owned by ebf under a groupId nobody has an active claim on yet: used to verify that claiming or verifying a fresh groupId surfaces this pre-existing owner as a conflictingOwner */
+(17, 3, 'com.acme.widgets', 'widget-lib', 'PRIVATE', 'Widget Lib', 'Owned by ebf under a groupId nobody has claimed yet', NULL, NULL, now() - interval '10 days', now() - interval '10 days');
 
 /* one transfer request per TransferState, using groupId/namespace combinations that the dynamic test scenarios never request, so they can't collide with the partial unique index on (group_id, from_namespace_id, to_namespace_id) WHERE state = 'PENDING' */
 INSERT INTO artifact_ownership_transfers(id, group_id, from_namespace_id, to_namespace_id, state, requested_at, resolved_at) VALUES


### PR DESCRIPTION
- Enriches `POST /namespaces/{namespace}/group-verifications` (`claim`) and `POST /namespaces/{namespace}/group-verifications/{groupId}/verify` (`verify`) responses with a `conflictingOwners` field, listing any *other* namespace that already owns artifacts under the claimed/verified `groupId`. It's purely informational and never blocks the claim/verify call.
- Lets a namespace admin proactively file an ownership transfer request the moment they claim or verify a `groupId`, instead of discovering the conflict weeks later via a publish-time `ArtifactOwnershipMismatchException` with no context.
- Promotes the owner-lookup query to `GroupVerifications.findOwners(groupId, excluding)`, consolidating the copy that previously lived only as a private method inside `DefaultArtifactOwnershipTransfers` (used by `request(...)`). Both existing consumers already depended on `GroupVerifications`, so no new wiring was needed anywhere.
- `GET` list/detail endpoints for group verifications are intentionally left unchanged — this is scoped to the write-path enrichment right after a claim/verify action.
