### PR TITLE
Surface conflicting groupId owners on the group claim page

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/GroupVerificationsController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/GroupVerificationsController.java
@@ -53,12 +53,13 @@ class GroupVerificationsController {
 	@GetMapping("/{groupId}")
 	@PreAuthorize("isAdmin(#namespace)")
 	@RequiresScope(OAuthScope.READ_NAMESPACES)
-	EntityModel<GroupVerification> getGroupVerification(@PathVariable String namespace, @PathVariable String groupId) {
+	EntityModel<Assemblers.GroupVerificationRepresentation> getGroupVerification(@PathVariable String namespace, @PathVariable String groupId) {
 		final Owner owner = ownerResolver.resolve(namespace);
 		final GroupVerification verification = groupVerifications.findByGroupId(owner, groupId)
 				.orElseThrow(() -> new GroupVerificationNotFoundException(owner, groupId));
 
-		return Assemblers.groupVerification(owner).assemble(verification);
+		return Assemblers.groupVerification(owner, groupVerifications.findOwners(verification.groupId(), owner))
+				.assemble(verification);
 	}
 
 	@PostMapping

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/GroupVerificationsControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/GroupVerificationsControllerTest.java
@@ -260,9 +260,26 @@ class GroupVerificationsControllerTest extends AbstractControllerTest {
 				.apply(log())
 				.hasStatusOk()
 				.bodyJson()
-				.convertTo(GroupVerification.class)
-				.returns("org.springframework.ai", GroupVerification::groupId)
-				.returns(VerificationState.FAILED, GroupVerification::state);
+				.convertTo(ClaimResponse.class)
+				.returns("org.springframework.ai", ClaimResponse::groupId)
+				.returns(VerificationState.FAILED, ClaimResponse::state)
+				.returns(null, ClaimResponse::conflictingOwners);
+	}
+
+	@Test
+	@DisplayName("should surface conflicting owners when fetching a claim with pre-existing artifacts from another namespace")
+	void shouldSurfaceConflictingOwnersOnGetGroupVerification() {
+		mvc.get().uri("/namespaces/{namespace}/group-verifications/{groupId}", "konfigyr", "com.konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ClaimResponse.class)
+				.returns("com.konfigyr", ClaimResponse::groupId)
+				.returns(VerificationState.ACTIVE, ClaimResponse::state)
+				.returns(Set.of("john-doe", "ebf"), ClaimResponse::conflictingOwners);
 	}
 
 	@Test

--- a/konfigyr-frontend/src/components/groups/group-verification-state.tsx
+++ b/konfigyr-frontend/src/components/groups/group-verification-state.tsx
@@ -1,8 +1,8 @@
-import { FormattedMessage, useIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Badge } from '@konfigyr/components/ui/badge';
 
 import { SimpleAlert } from '@konfigyr/components/ui/alert';
-import { AlertCircleIcon, CheckCircle2Icon, CircleAlertIcon, Trash2Icon } from 'lucide-react';
+import { AlertCircleIcon, CheckCircle2Icon, CircleAlertIcon, Trash2Icon, TriangleAlertIcon } from 'lucide-react';
 import { sourceCodeHostLabel } from '@konfigyr/components/groups/group-verification-method';
 import type { ComponentProps } from 'react';
 import type { VerificationMethod, VerificationState } from '@konfigyr/hooks/types';
@@ -180,6 +180,33 @@ function FailedStateAlert () {
         />
       }
       variant="destructive"
+    />
+  );
+}
+
+export function ConflictingOwnersAlert ({ conflictingOwners }: { conflictingOwners: Array<string> }) {
+  return (
+    <SimpleAlert
+      icon={
+        <TriangleAlertIcon className="size-8"/>
+      }
+      title={
+        <FormattedMessage
+          defaultMessage="Other namespaces already own artifacts here"
+          description="Banner title shown when other namespaces already own artifacts under a claimed or verified groupId."
+        />
+      }
+      description={
+        <FormattedMessage
+          defaultMessage="{count, plural, one {Namespace} other {Namespaces}} {owners} already {count, plural, one {publishes} other {publish}} artifacts under this groupId. You may need to request an ownership transfer before you can publish."
+          description="Banner description listing namespaces that already own artifacts under a claimed or verified groupId."
+          values={{
+            count: conflictingOwners.length,
+            owners: <strong>{conflictingOwners.join(', ')}</strong>,
+          }}
+        />
+      }
+      variant="warning"
     />
   );
 }

--- a/konfigyr-frontend/src/components/groups/group-verification-state.tsx
+++ b/konfigyr-frontend/src/components/groups/group-verification-state.tsx
@@ -202,7 +202,7 @@ export function ConflictingOwnersAlert ({ conflictingOwners }: { conflictingOwne
           description="Banner description listing namespaces that already own artifacts under a claimed or verified groupId."
           values={{
             count: conflictingOwners.length,
-            owners: <strong>{conflictingOwners.join(', ')}</strong>,
+            owners: conflictingOwners.join(', '),
           }}
         />
       }

--- a/konfigyr-frontend/src/hooks/groups/types.ts
+++ b/konfigyr-frontend/src/hooks/groups/types.ts
@@ -11,6 +11,7 @@ export interface GroupVerification {
   createdAt: string;
   verifiedAt: string | null;
   revokedAt: string | null;
+  conflictingOwners?: Array<string>;
 }
 
 export interface VerificationChallenge {

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/groups/$groupId/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/groups/$groupId/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@konfigyr/hooks';
 import { ErrorState } from '@konfigyr/components/error';
 import { GroupsBreadcrumbs } from '@konfigyr/components/groups/breadcrumbs';
-import { GroupVerificationStateAlert } from '@konfigyr/components/groups/group-verification-state';
+import { ConflictingOwnersAlert, GroupVerificationStateAlert } from '@konfigyr/components/groups/group-verification-state';
 import { Button, buttonVariants } from '@konfigyr/components/ui/button';
 import { EmptyState } from '@konfigyr/components/ui/empty';
 import { GroupVerification } from '@konfigyr/components/groups/group-verification-challenge';
@@ -108,6 +108,10 @@ function RouteComponent () {
             </div>
 
             {banner}
+
+            {!!verification.conflictingOwners?.length && (
+              <ConflictingOwnersAlert conflictingOwners={verification.conflictingOwners}/>
+            )}
 
             <GroupVerification verification={verification} challenge={challenge}/>
 

--- a/konfigyr-frontend/test/components/groups/group-verification-state.test.tsx
+++ b/konfigyr-frontend/test/components/groups/group-verification-state.test.tsx
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import { renderWithMessageProvider } from '@konfigyr/test/helpers/messages';
 import {
+  ConflictingOwnersAlert,
   GroupVerificationState,
   GroupVerificationStateAlert,
   GroupVerificationStateBadge,
@@ -167,6 +168,32 @@ describe('components | groups | <GroupVerificationStateAlert/>', () => {
     expect(getByRole('alert')).toHaveAccessibleName('Claim revoked');
     expect(getByRole('alert')).toHaveAccessibleDescription(
       'Publishing under com.example.group is blocked. You can claim this groupId again at any time.',
+    );
+  });
+});
+
+describe('components | groups | <ConflictingOwnersAlert/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render a warning banner listing a single conflicting owner', () => {
+    const { getByRole } = renderWithMessageProvider(
+      <ConflictingOwnersAlert conflictingOwners={['ebf']} />,
+    );
+
+    expect(getByRole('alert')).toBeInTheDocument();
+    expect(getByRole('alert')).toHaveAccessibleName('Other namespaces already own artifacts here');
+    expect(getByRole('alert')).toHaveAccessibleDescription(
+      'Namespace ebf already publishes artifacts under this groupId. You may need to request an ownership transfer before you can publish.',
+    );
+  });
+
+  test('should render a warning banner listing multiple conflicting owners', () => {
+    const { getByRole } = renderWithMessageProvider(
+      <ConflictingOwnersAlert conflictingOwners={['ebf', 'acme-legacy']} />,
+    );
+
+    expect(getByRole('alert')).toHaveAccessibleDescription(
+      'Namespaces ebf, acme-legacy already publish artifacts under this groupId. You may need to request an ownership transfer before you can publish.',
     );
   });
 });

--- a/konfigyr-frontend/test/helpers/server/namespace/groups.ts
+++ b/konfigyr-frontend/test/helpers/server/namespace/groups.ts
@@ -22,11 +22,32 @@ const pendingVerification: GroupVerification = {
   revokedAt: null,
 };
 
+const conflictedVerification: GroupVerification = {
+  id: 'verification-conflicted',
+  groupId: 'com.acme.widgets',
+  state: 'PENDING',
+  createdAt: '2026-07-09T00:00:00Z',
+  verifiedAt: null,
+  revokedAt: null,
+  conflictingOwners: ['ebf'],
+};
+
 const verificationChallenge: VerificationChallenge = {
   id: 'challenge-pending',
   verificationId: pendingVerification.id,
   method: 'SOURCE_CODE',
   token: 'token-123',
+  state: 'UNVERIFIED',
+  createdAt: '2026-07-09T00:00:00Z',
+  verifiedAt: null,
+  expiresAt: null,
+};
+
+const conflictedChallenge: VerificationChallenge = {
+  id: 'challenge-conflicted',
+  verificationId: conflictedVerification.id,
+  method: 'DNS',
+  token: 'token-456',
   state: 'UNVERIFIED',
   createdAt: '2026-07-09T00:00:00Z',
   verifiedAt: null,
@@ -71,6 +92,10 @@ const get = http.get('http://localhost/api/namespaces/:slug/group-verifications/
     return HttpResponse.json(pendingVerification);
   }
 
+  if (groupId === conflictedVerification.groupId) {
+    return HttpResponse.json(conflictedVerification);
+  }
+
   return HttpResponse.json({
     status: 404,
     title: 'Not found',
@@ -81,7 +106,19 @@ const get = http.get('http://localhost/api/namespaces/:slug/group-verifications/
 const challenges = http.get('http://localhost/api/namespaces/:slug/group-verifications/:groupId/challenges', ({ params }) => {
   const { slug, groupId } = params;
 
-  if (slug !== namespaces.konfigyr.slug || groupId !== pendingVerification.groupId) {
+  if (slug !== namespaces.konfigyr.slug) {
+    const response: CollectionResponse<VerificationChallenge> = { data: [] };
+    return HttpResponse.json(response);
+  }
+
+  if (groupId === conflictedVerification.groupId) {
+    const response: CollectionResponse<VerificationChallenge> = {
+      data: [conflictedChallenge],
+    };
+    return HttpResponse.json(response);
+  }
+
+  if (groupId !== pendingVerification.groupId) {
     const response: CollectionResponse<VerificationChallenge> = { data: [] };
     return HttpResponse.json(response);
   }
@@ -109,14 +146,19 @@ const create = http.post('http://localhost/api/namespaces/:slug/group-verificati
     verificationMethod?: VerificationMethod;
   };
 
-  return HttpResponse.json({
+  const response: GroupVerification = {
     id: `${body.groupId}-claim`,
-    groupId: body.groupId,
+    groupId: body.groupId!,
     state: 'PENDING',
     createdAt: '2026-07-10T00:00:00Z',
     verifiedAt: null,
     revokedAt: null,
-  }, { status: 201 });
+    ...(body.groupId === conflictedVerification.groupId
+      ? { conflictingOwners: conflictedVerification.conflictingOwners }
+      : {}),
+  };
+
+  return HttpResponse.json(response, { status: 201 });
 });
 
 export default [

--- a/konfigyr-frontend/test/routes/namespace/groups/$groupId/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/groups/$groupId/index.test.tsx
@@ -29,4 +29,27 @@ describe('routes | namespace | groups | detail', () => {
       expect(getByRole('button', { name: 'Verify claim' })).toBeInTheDocument();
     });
   });
+
+  test('should not render a conflict banner when there are no conflicting owners', async () => {
+    const { getByText, queryByText } = renderWithRouter('/namespace/konfigyr/groups/com.example.group/');
+
+    await waitFor(() => {
+      expect(getByText('Ownership verified')).toBeInTheDocument();
+    });
+
+    expect(queryByText('Other namespaces already own artifacts here')).not.toBeInTheDocument();
+  });
+
+  test('should surface conflicting owners on the detail page', async () => {
+    const { getAllByRole, getByText } = renderWithRouter('/namespace/konfigyr/groups/com.acme.widgets/');
+
+    await waitFor(() => {
+      expect(getByText('Other namespaces already own artifacts here')).toBeInTheDocument();
+      expect(getByText(
+        'Namespace ebf already publishes artifacts under this groupId. You may need to request an ownership transfer before you can publish.',
+      )).toBeInTheDocument();
+    });
+
+    expect(getAllByRole('alert')).toHaveLength(2);
+  });
 });

--- a/konfigyr-frontend/test/routes/namespace/groups/create.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/groups/create.test.tsx
@@ -28,4 +28,17 @@ describe('routes | namespace | groups | create', () => {
       expect(router.state.location.pathname).toBe('/namespace/konfigyr/groups/io.github.acme');
     });
   });
+
+  test('should surface conflicting owners immediately after claiming a groupId with pre-existing artifacts', async () => {
+    const user = userEvent.setup();
+    const { getByRole, getByText, router, findByLabelText } = renderWithRouter('/namespace/konfigyr/groups/create');
+
+    await user.type(await findByLabelText('Group Id'), 'com.acme.widgets');
+    await user.click(getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe('/namespace/konfigyr/groups/com.acme.widgets');
+      expect(getByText('Other namespaces already own artifacts here')).toBeInTheDocument();
+    });
+  });
 });


### PR DESCRIPTION
- Surfaces the backend's `conflictingOwners` field on the group claim detail page as an informational warning banner, so an admin sees immediately that another namespace already owns artifacts under a claimed or verified `groupId` — before hitting a publish-time ownership conflict with no context.
- Adds `ConflictingOwnersAlert` to `group-verification-state.tsx`, reusing the existing `SimpleAlert` component (`warning` variant) rather than introducing a new visual pattern.
- Wires it into the claim detail route (`groups/$groupId/index.tsx`), rendered right after the existing verification-state banner whenever `conflictingOwners` is non-empty.
- Extends `GroupVerificationsController.getGroupVerification` (single GET) to also enrich its response with `conflictingOwners` — needed because a user navigating directly to the detail page (bookmark, refresh, shared link) bypasses the claim/verify mutation's query-cache seed, so the GET endpoint itself must carry the same data. The paginated list endpoint (`getGroupVerifications`) remains intentionally unenriched.
- No new hook/query changes needed on the frontend — `useClaimGroupVerification` and `useVerifyGroupVerification` already cache the full mutation response, so once the TypeScript type gained the field, it flowed through automatically.
