### PR TITLE
Artifact ownership transfer events

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryEvent.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryEvent.java
@@ -12,7 +12,7 @@ import org.jspecify.annotations.NonNull;
  * @since 1.0.0
  **/
 public abstract sealed class ArtifactoryEvent extends EntityEvent
-		permits ArtifactoryEvent.ArtifactEvent, ArtifactoryEvent.OwnershipTransferAccepted {
+		permits ArtifactoryEvent.ArtifactEvent, ArtifactoryEvent.OwnershipTransferEvent {
 
 	protected ArtifactoryEvent(EntityId id) {
 		super(id);
@@ -131,15 +131,68 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 	}
 
 	/**
-	 * Event that would be published when an artifact ownership transfer request is accepted by the
-	 * current owner and ownership of the affected artifacts has moved.
+	 * Abstract event type used for events related to the resolution of an
+	 * {@code com.konfigyr.artifactory.transfer.ArtifactOwnershipTransfer}.
 	 */
-	@DomainEvent(name = "ownership-transfer.accepted", namespace = "artifactory")
-	public static final class OwnershipTransferAccepted extends ArtifactoryEvent {
+	public static sealed abstract class OwnershipTransferEvent extends ArtifactoryEvent
+			permits OwnershipTransferAccepted, OwnershipTransferRejected, OwnershipTransferCancelled {
 
 		private final String groupId;
 		private final Owner from;
 		private final Owner to;
+
+		/**
+		 * Create a new {@link OwnershipTransferEvent} event for the given resolved transfer request.
+		 *
+		 * @param id the entity identifier of the resolved transfer request, can't be {@literal null}.
+		 * @param groupId the artifact groupId coordinate the transfer request pertains to, can't be {@literal null}.
+		 * @param from the namespace that owns the affected artifacts, can't be {@literal null}.
+		 * @param to the namespace that requested ownership of the affected artifacts, can't be {@literal null}.
+		 */
+		protected OwnershipTransferEvent(EntityId id, @NonNull String groupId, @NonNull Owner from, @NonNull Owner to) {
+			super(id);
+			this.groupId = groupId;
+			this.from = from;
+			this.to = to;
+		}
+
+		/**
+		 * Returns the Maven {@code groupId} coordinate the transfer request pertains to.
+		 *
+		 * @return artifact groupId coordinate, never {@literal null}.
+		 */
+		@NonNull
+		public String groupId() {
+			return groupId;
+		}
+
+		/**
+		 * Returns the namespace that owns the affected artifacts.
+		 *
+		 * @return current owner, never {@literal null}.
+		 */
+		@NonNull
+		public Owner from() {
+			return from;
+		}
+
+		/**
+		 * Returns the namespace that requested ownership of the affected artifacts.
+		 *
+		 * @return requesting namespace, never {@literal null}.
+		 */
+		@NonNull
+		public Owner to() {
+			return to;
+		}
+	}
+
+	/**
+	 * Event that would be published when an artifact ownership transfer request is accepted by the
+	 * current owner and ownership of the affected artifacts has moved.
+	 */
+	@DomainEvent(name = "ownership-transfer.accepted", namespace = "artifactory")
+	public static final class OwnershipTransferAccepted extends OwnershipTransferEvent {
 
 		/**
 		 * Create a new {@link OwnershipTransferAccepted} event for the given accepted transfer request.
@@ -150,40 +203,47 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * @param to the namespace that now owns the affected artifacts, can't be {@literal null}.
 		 */
 		public OwnershipTransferAccepted(EntityId id, @NonNull String groupId, @NonNull Owner from, @NonNull Owner to) {
-			super(id);
-			this.groupId = groupId;
-			this.from = from;
-			this.to = to;
+			super(id, groupId, from, to);
 		}
+	}
+
+	/**
+	 * Event that would be published when an artifact ownership transfer request is rejected by the
+	 * current owner. No artifact ownership is changed.
+	 */
+	@DomainEvent(name = "ownership-transfer.rejected", namespace = "artifactory")
+	public static final class OwnershipTransferRejected extends OwnershipTransferEvent {
 
 		/**
-		 * Returns the Maven {@code groupId} coordinate whose artifacts were transferred.
+		 * Create a new {@link OwnershipTransferRejected} event for the given rejected transfer request.
 		 *
-		 * @return artifact groupId coordinate, never {@literal null}.
+		 * @param id the entity identifier of the rejected transfer request, can't be {@literal null}.
+		 * @param groupId the artifact groupId coordinate whose transfer was rejected, can't be {@literal null}.
+		 * @param from the namespace that owns the affected artifacts and rejected the request, can't be {@literal null}.
+		 * @param to the namespace whose request to claim ownership was rejected, can't be {@literal null}.
 		 */
-		@NonNull
-		public String groupId() {
-			return groupId;
+		public OwnershipTransferRejected(EntityId id, @NonNull String groupId, @NonNull Owner from, @NonNull Owner to) {
+			super(id, groupId, from, to);
 		}
+	}
+
+	/**
+	 * Event that would be published when an artifact ownership transfer request is cancelled by the
+	 * requesting namespace. No artifact ownership is changed.
+	 */
+	@DomainEvent(name = "ownership-transfer.cancelled", namespace = "artifactory")
+	public static final class OwnershipTransferCancelled extends OwnershipTransferEvent {
 
 		/**
-		 * Returns the namespace that owned the affected artifacts before the transfer.
+		 * Create a new {@link OwnershipTransferCancelled} event for the given cancelled transfer request.
 		 *
-		 * @return previous owner, never {@literal null}.
+		 * @param id the entity identifier of the cancelled transfer request, can't be {@literal null}.
+		 * @param groupId the artifact groupId coordinate whose transfer was cancelled, can't be {@literal null}.
+		 * @param from the namespace that owns the affected artifacts, can't be {@literal null}.
+		 * @param to the namespace that cancelled its own request, can't be {@literal null}.
 		 */
-		@NonNull
-		public Owner from() {
-			return from;
-		}
-
-		/**
-		 * Returns the namespace that now owns the affected artifacts.
-		 *
-		 * @return new owner, never {@literal null}.
-		 */
-		@NonNull
-		public Owner to() {
-			return to;
+		public OwnershipTransferCancelled(EntityId id, @NonNull String groupId, @NonNull Owner from, @NonNull Owner to) {
+			super(id, groupId, from, to);
 		}
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/ArtifactOwnershipTransfers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/ArtifactOwnershipTransfers.java
@@ -107,6 +107,7 @@ public interface ArtifactOwnershipTransfers {
 	 * @return the rejected transfer with {@code resolvedAt} populated
 	 * @throws IllegalStateException when the transfer is not in a state that can transition to {@link TransferState#REJECTED}
 	 */
+	@DomainEventPublisher(publishes = "artifactory.ownership-transfer.rejected")
 	ArtifactOwnershipTransfer reject(ArtifactOwnershipTransfer transfer);
 
 	/**
@@ -116,6 +117,7 @@ public interface ArtifactOwnershipTransfers {
 	 * @return the cancelled transfer with {@code resolvedAt} populated
 	 * @throws IllegalStateException when the transfer is not in a state that can transition to {@link TransferState#CANCELLED}
 	 */
+	@DomainEventPublisher(publishes = "artifactory.ownership-transfer.cancelled")
 	ArtifactOwnershipTransfer cancel(ArtifactOwnershipTransfer transfer);
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfers.java
@@ -168,6 +168,10 @@ class DefaultArtifactOwnershipTransfers implements ArtifactOwnershipTransfers {
 	public ArtifactOwnershipTransfer reject(ArtifactOwnershipTransfer transfer) {
 		final ArtifactOwnershipTransfer rejected = resolve(transfer, TransferState.REJECTED);
 
+		eventPublisher.publishEvent(new ArtifactoryEvent.OwnershipTransferRejected(
+				rejected.id(), rejected.groupId(), rejected.from(), rejected.to()
+		));
+
 		log.info("Successfully rejected artifact ownership transfer {} for groupId '{}'", rejected.id(), rejected.groupId());
 
 		return rejected;
@@ -177,6 +181,10 @@ class DefaultArtifactOwnershipTransfers implements ArtifactOwnershipTransfers {
 	@Transactional(label = "artifact-ownership-transfers.cancel")
 	public ArtifactOwnershipTransfer cancel(ArtifactOwnershipTransfer transfer) {
 		final ArtifactOwnershipTransfer cancelled = resolve(transfer, TransferState.CANCELLED);
+
+		eventPublisher.publishEvent(new ArtifactoryEvent.OwnershipTransferCancelled(
+				cancelled.id(), cancelled.groupId(), cancelled.from(), cancelled.to()
+		));
 
 		log.info("Successfully cancelled artifact ownership transfer {} for groupId '{}'", cancelled.id(), cancelled.groupId());
 

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -498,9 +498,63 @@ class AuditEventListener {
 	@TransactionalEventListener(id = "audit.ownership-transfer-accepted", classes = ArtifactoryEvent.OwnershipTransferAccepted.class)
 	void on(ArtifactoryEvent.OwnershipTransferAccepted event) {
 		insert(event, builder -> builder
+				.namespace(event.to().id())
 				.entityType("artifact-ownership-transfer")
 				.entityId(event.id())
-				.eventType("artifactory.ownership-transfer.accepted")
+				.eventType("artifact-ownership-transfer.received")
+				.details("groupId", event.groupId())
+				.details("from", event.from().slug())
+				.details("to", event.to().slug())
+		);
+		insert(event, builder -> builder
+				.namespace(event.from().id())
+				.entityType("artifact-ownership-transfer")
+				.entityId(event.id())
+				.eventType("artifact-ownership-transfer.transferred")
+				.details("groupId", event.groupId())
+				.details("from", event.from().slug())
+				.details("to", event.to().slug())
+		);
+	}
+
+	@TransactionalEventListener(id = "audit.ownership-transfer-rejected", classes = ArtifactoryEvent.OwnershipTransferRejected.class)
+	void on(ArtifactoryEvent.OwnershipTransferRejected event) {
+		insert(event, builder -> builder
+				.namespace(event.to().id())
+				.entityType("artifact-ownership-transfer")
+				.entityId(event.id())
+				.eventType("artifact-ownership-transfer.request-rejected")
+				.details("groupId", event.groupId())
+				.details("from", event.from().slug())
+				.details("to", event.to().slug())
+		);
+		insert(event, builder -> builder
+				.namespace(event.from().id())
+				.entityType("artifact-ownership-transfer")
+				.entityId(event.id())
+				.eventType("artifact-ownership-transfer.rejected")
+				.details("groupId", event.groupId())
+				.details("from", event.from().slug())
+				.details("to", event.to().slug())
+		);
+	}
+
+	@TransactionalEventListener(id = "audit.ownership-transfer-cancelled", classes = ArtifactoryEvent.OwnershipTransferCancelled.class)
+	void on(ArtifactoryEvent.OwnershipTransferCancelled event) {
+		insert(event, builder -> builder
+				.namespace(event.to().id())
+				.entityType("artifact-ownership-transfer")
+				.entityId(event.id())
+				.eventType("artifact-ownership-transfer.cancelled")
+				.details("groupId", event.groupId())
+				.details("from", event.from().slug())
+				.details("to", event.to().slug())
+		);
+		insert(event, builder -> builder
+				.namespace(event.from().id())
+				.entityType("artifact-ownership-transfer")
+				.entityId(event.id())
+				.eventType("artifact-ownership-transfer.request-cancelled")
 				.details("groupId", event.groupId())
 				.details("from", event.from().slug())
 				.details("to", event.to().slug())

--- a/konfigyr-api/src/main/resources/messages/audit.properties
+++ b/konfigyr-api/src/main/resources/messages/audit.properties
@@ -57,3 +57,12 @@ audit.event.keyset.destroyed=Key ''{0}'' within a keyset was scheduled for destr
 audit.event.artifact-version.publication-created=Artifact publication started for {0}
 audit.event.artifact-version.publication-completed=Artifact {0} has been successfully published
 audit.event.artifact-version.publication-failed=Failed to publish {0} Artifact
+
+## Artifact ownership transfer events ##
+
+audit.event.artifact-ownership-transfer.received=You are now the owner of ''{1}''
+audit.event.artifact-ownership-transfer.transferred=You have transferred ''{1}'' to ''{2}''
+audit.event.artifact-ownership-transfer.request-rejected=Your request to transfer ''{1}'' was rejected by ''{0}''
+audit.event.artifact-ownership-transfer.rejected=You rejected the transfer request for ''{1}'' from ''{2}''
+audit.event.artifact-ownership-transfer.cancelled=You cancelled your request to transfer ''{1}''
+audit.event.artifact-ownership-transfer.request-cancelled=The transfer request for ''{1}'' from ''{2}'' was cancelled

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfersTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfersTest.java
@@ -123,25 +123,37 @@ class DefaultArtifactOwnershipTransfersTest extends AbstractIntegrationTest {
 	@Test
 	@Transactional
 	@DisplayName("should reject a pending transfer")
-	void shouldRejectPendingTransfer() {
+	void shouldRejectPendingTransfer(AssertablePublishedEvents events) {
 		final var pending = transferFor(Owners.ebf(), 1);
 
 		assertThat(transfers.reject(pending))
 				.returns(pending.id(), ArtifactOwnershipTransfer::id)
 				.returns(TransferState.REJECTED, ArtifactOwnershipTransfer::state)
 				.satisfies(it -> assertThat(it.resolvedAt()).isNotNull());
+
+		events.assertThat()
+				.contains(ArtifactoryEvent.OwnershipTransferRejected.class)
+				.matching(ArtifactoryEvent.OwnershipTransferRejected::groupId, pending.groupId())
+				.matching(ArtifactoryEvent.OwnershipTransferRejected::from, pending.from())
+				.matching(ArtifactoryEvent.OwnershipTransferRejected::to, pending.to());
 	}
 
 	@Test
 	@Transactional
 	@DisplayName("should cancel a pending transfer")
-	void shouldCancelPendingTransfer() {
+	void shouldCancelPendingTransfer(AssertablePublishedEvents events) {
 		final var pending = transferFor(Owners.ebf(), 1);
 
 		assertThat(transfers.cancel(pending))
 				.returns(pending.id(), ArtifactOwnershipTransfer::id)
 				.returns(TransferState.CANCELLED, ArtifactOwnershipTransfer::state)
 				.satisfies(it -> assertThat(it.resolvedAt()).isNotNull());
+
+		events.assertThat()
+				.contains(ArtifactoryEvent.OwnershipTransferCancelled.class)
+				.matching(ArtifactoryEvent.OwnershipTransferCancelled::groupId, pending.groupId())
+				.matching(ArtifactoryEvent.OwnershipTransferCancelled::from, pending.from())
+				.matching(ArtifactoryEvent.OwnershipTransferCancelled::to, pending.to());
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
@@ -938,6 +938,62 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("should persist two audit records for an accepted ownership transfer, one per namespace")
+	void shouldAuditOwnershipTransferAccepted() {
+		final var from = new Owner(EntityId.from(1210), "from-namespace");
+		final var to = new Owner(EntityId.from(1211), "to-namespace");
+
+		listener.on(new ArtifactoryEvent.OwnershipTransferAccepted(EntityId.from(1212), "com.konfigyr", from, to));
+
+		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1212), "artifact-ownership-transfer.received")
+				.returns(to.id(), AuditRecord::namespaceId)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("groupId", "com.konfigyr")
+						.containsEntry("from", from.slug())
+						.containsEntry("to", to.slug())
+				)
+				.satisfies(assertAuditRecordMessage("You are now the owner of '%s'", "com.konfigyr"));
+
+		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1212), "artifact-ownership-transfer.transferred")
+				.returns(from.id(), AuditRecord::namespaceId)
+				.satisfies(assertAuditRecordMessage("You have transferred '%s' to '%s'", "com.konfigyr", to.slug()));
+	}
+
+	@Test
+	@DisplayName("should persist two audit records for a rejected ownership transfer, one per namespace")
+	void shouldAuditOwnershipTransferRejected() {
+		final var from = new Owner(EntityId.from(1220), "from-namespace");
+		final var to = new Owner(EntityId.from(1221), "to-namespace");
+
+		listener.on(new ArtifactoryEvent.OwnershipTransferRejected(EntityId.from(1222), "com.konfigyr", from, to));
+
+		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1222), "artifact-ownership-transfer.request-rejected")
+				.returns(to.id(), AuditRecord::namespaceId)
+				.satisfies(assertAuditRecordMessage("Your request to transfer '%s' was rejected by '%s'", "com.konfigyr", from.slug()));
+
+		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1222), "artifact-ownership-transfer.rejected")
+				.returns(from.id(), AuditRecord::namespaceId)
+				.satisfies(assertAuditRecordMessage("You rejected the transfer request for '%s' from '%s'", "com.konfigyr", to.slug()));
+	}
+
+	@Test
+	@DisplayName("should persist two audit records for a cancelled ownership transfer, one per namespace")
+	void shouldAuditOwnershipTransferCancelled() {
+		final var from = new Owner(EntityId.from(1230), "from-namespace");
+		final var to = new Owner(EntityId.from(1231), "to-namespace");
+
+		listener.on(new ArtifactoryEvent.OwnershipTransferCancelled(EntityId.from(1232), "com.konfigyr", from, to));
+
+		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1232), "artifact-ownership-transfer.cancelled")
+				.returns(to.id(), AuditRecord::namespaceId)
+				.satisfies(assertAuditRecordMessage("You cancelled your request to transfer '%s'", "com.konfigyr"));
+
+		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1232), "artifact-ownership-transfer.request-cancelled")
+				.returns(from.id(), AuditRecord::namespaceId)
+				.satisfies(assertAuditRecordMessage("The transfer request for '%s' from '%s' was cancelled", "com.konfigyr", to.slug()));
+	}
+
+	@Test
 	@DisplayName("should not propagate persistence failures from the audit event listener")
 	void shouldNotPropagatePersistenceFailures() {
 		final var repository = mock(AuditEventRepository.class);

--- a/konfigyr-frontend/src/components/audit/audit-entity-type.tsx
+++ b/konfigyr-frontend/src/components/audit/audit-entity-type.tsx
@@ -1,22 +1,33 @@
 import { useIntl } from 'react-intl';
 import {
   AppWindowMacIcon,
+  ArrowLeftRightIcon,
   FolderKanbanIcon,
   FolderKeyIcon,
   GitBranchIcon,
   Grid2x2XIcon,
+  MailPlusIcon,
   MonitorCloudIcon,
+  ShieldCheckIcon,
+  TagIcon,
+  UserCircleIcon,
 } from 'lucide-react';
 
 import type { LucideProps } from 'lucide-react';
 
-export type AuditEntityType = string | ('namespace' | 'namespace-application' | 'keyset' | 'service' | 'profile');
+export type AuditEntityType = string | ('account' | 'namespace' | 'namespace-application' | 'namespace-trusted-issuer'
+  | 'invitation' | 'keyset' | 'service' | 'profile' | 'artifact-version' | 'artifact-ownership-transfer');
 
 export function useAuditEntityTypeLabel(): (value: AuditEntityType) => string {
   const intl = useIntl();
 
   return (value: AuditEntityType) => {
     switch (value) {
+      case 'account':
+        return intl.formatMessage({
+          defaultMessage: 'Account',
+          description: 'Label for the account audit entity type',
+        });
       case 'namespace':
         return intl.formatMessage({
           defaultMessage: 'Namespace',
@@ -26,6 +37,16 @@ export function useAuditEntityTypeLabel(): (value: AuditEntityType) => string {
         return intl.formatMessage({
           defaultMessage: 'Application',
           description: 'Label for the namespace application audit entity type',
+        });
+      case 'namespace-trusted-issuer':
+        return intl.formatMessage({
+          defaultMessage: 'Trusted issuer',
+          description: 'Label for the namespace trusted issuer audit entity type',
+        });
+      case 'invitation':
+        return intl.formatMessage({
+          defaultMessage: 'Invitation',
+          description: 'Label for the invitation audit entity type',
         });
       case 'keyset':
         return intl.formatMessage({
@@ -42,6 +63,16 @@ export function useAuditEntityTypeLabel(): (value: AuditEntityType) => string {
           defaultMessage: 'Service profile',
           description: 'Label for the profile audit entity type',
         });
+      case 'artifact-version':
+        return intl.formatMessage({
+          defaultMessage: 'Artifact version',
+          description: 'Label for the artifact version audit entity type',
+        });
+      case 'artifact-ownership-transfer':
+        return intl.formatMessage({
+          defaultMessage: 'Ownership transfer',
+          description: 'Label for the artifact ownership transfer audit entity type',
+        });
       default:
         return value;
     }
@@ -53,6 +84,10 @@ export function AuditEntityTypeIcon({ value, ...props }: { value: AuditEntityTyp
   const label = entityTypeLabelFor(value);
 
   switch (value) {
+    case 'account':
+      return (
+        <UserCircleIcon {...props} aria-label={label} />
+      );
     case 'namespace':
       return (
         <FolderKanbanIcon {...props} aria-label={label} />
@@ -60,6 +95,14 @@ export function AuditEntityTypeIcon({ value, ...props }: { value: AuditEntityTyp
     case 'namespace-application':
       return (
         <MonitorCloudIcon {...props} aria-label={label} />
+      );
+    case 'namespace-trusted-issuer':
+      return (
+        <ShieldCheckIcon {...props} aria-label={label} />
+      );
+    case 'invitation':
+      return (
+        <MailPlusIcon {...props} aria-label={label} />
       );
     case 'keyset':
       return (
@@ -72,6 +115,14 @@ export function AuditEntityTypeIcon({ value, ...props }: { value: AuditEntityTyp
     case 'profile':
       return (
         <GitBranchIcon {...props} aria-label={label} />
+      );
+    case 'artifact-version':
+      return (
+        <TagIcon {...props} aria-label={label} />
+      );
+    case 'artifact-ownership-transfer':
+      return (
+        <ArrowLeftRightIcon {...props} aria-label={label} />
       );
     default:
       return (

--- a/konfigyr-frontend/src/components/audit/audit-record-filters.tsx
+++ b/konfigyr-frontend/src/components/audit/audit-record-filters.tsx
@@ -26,6 +26,10 @@ import type { DateRange } from '@konfigyr/components/ui/calendar';
 const ENTITY_TYPES = [
   'namespace',
   'namespace-application',
+  'namespace-trusted-issuer',
+  'invitation',
+  'artifact-version',
+  'artifact-ownership-transfer',
   'keyset',
   'service',
   'profile',

--- a/konfigyr-frontend/test/components/audit/audit-entity-type.test.tsx
+++ b/konfigyr-frontend/test/components/audit/audit-entity-type.test.tsx
@@ -6,6 +6,16 @@ import { AuditEntityTypeIcon } from '@konfigyr/components/audit/audit-entity-typ
 describe('components | audit | <AuditEntityTypeIcon/>', () => {
   afterEach(() => cleanup());
 
+  test('should render <AuditEntityTypeIcon/> component with a label for account entity type', () => {
+    const { getByTestId } = renderWithMessageProvider(
+      <AuditEntityTypeIcon value="account" data-testid="icon"/>,
+    );
+
+    expect(getByTestId('icon')).toBeInTheDocument();
+    expect(getByTestId('icon')).toHaveAccessibleName('Account');
+    expect(getByTestId('icon')).toHaveClass('lucide-circle-user');
+  });
+
   test('should render <AuditEntityTypeIcon/> component with a label for namespace entity type', () => {
     const { getByTestId } = renderWithMessageProvider(
       <AuditEntityTypeIcon value="namespace" data-testid="icon"/>,
@@ -24,6 +34,26 @@ describe('components | audit | <AuditEntityTypeIcon/>', () => {
     expect(getByTestId('icon')).toBeInTheDocument();
     expect(getByTestId('icon')).toHaveAccessibleName('Application');
     expect(getByTestId('icon')).toHaveClass('lucide-monitor-cloud');
+  });
+
+  test('should render <AuditEntityTypeIcon/> component with a label for namespace trusted issuer entity type', () => {
+    const { getByTestId } = renderWithMessageProvider(
+      <AuditEntityTypeIcon value="namespace-trusted-issuer" data-testid="icon"/>,
+    );
+
+    expect(getByTestId('icon')).toBeInTheDocument();
+    expect(getByTestId('icon')).toHaveAccessibleName('Trusted issuer');
+    expect(getByTestId('icon')).toHaveClass('lucide-shield-check');
+  });
+
+  test('should render <AuditEntityTypeIcon/> component with a label for invitation entity type', () => {
+    const { getByTestId } = renderWithMessageProvider(
+      <AuditEntityTypeIcon value="invitation" data-testid="icon"/>,
+    );
+
+    expect(getByTestId('icon')).toBeInTheDocument();
+    expect(getByTestId('icon')).toHaveAccessibleName('Invitation');
+    expect(getByTestId('icon')).toHaveClass('lucide-mail-plus');
   });
 
   test('should render <AuditEntityTypeIcon/> component with a label for service entity type', () => {
@@ -54,6 +84,26 @@ describe('components | audit | <AuditEntityTypeIcon/>', () => {
     expect(getByTestId('icon')).toBeInTheDocument();
     expect(getByTestId('icon')).toHaveAccessibleName('Service profile');
     expect(getByTestId('icon')).toHaveClass('lucide-git-branch');
+  });
+
+  test('should render <AuditEntityTypeIcon/> component with a label for artifact version entity type', () => {
+    const { getByTestId } = renderWithMessageProvider(
+      <AuditEntityTypeIcon value="artifact-version" data-testid="icon"/>,
+    );
+
+    expect(getByTestId('icon')).toBeInTheDocument();
+    expect(getByTestId('icon')).toHaveAccessibleName('Artifact version');
+    expect(getByTestId('icon')).toHaveClass('lucide-tag');
+  });
+
+  test('should render <AuditEntityTypeIcon/> component with a label for artifact ownership transfer entity type', () => {
+    const { getByTestId } = renderWithMessageProvider(
+      <AuditEntityTypeIcon value="artifact-ownership-transfer" data-testid="icon"/>,
+    );
+
+    expect(getByTestId('icon')).toBeInTheDocument();
+    expect(getByTestId('icon')).toHaveAccessibleName('Ownership transfer');
+    expect(getByTestId('icon')).toHaveClass('lucide-arrow-left-right');
   });
 
   test('should render <AuditEntityTypeIcon/> component with a label for unknown entity type', () => {

--- a/konfigyr-frontend/test/components/audit/audit-record-filters.test.tsx
+++ b/konfigyr-frontend/test/components/audit/audit-record-filters.test.tsx
@@ -62,7 +62,7 @@ describe('components | audit | <AuditRecordFilters/>', () => {
     const onChange = vi.fn();
     const user = userEvent.setup();
 
-    const { getAllByRole, getByRole, findByRole } = renderWithMessageProvider(
+    const { getByRole, findByRole } = renderWithMessageProvider(
       <AuditRecordFilters debounceMs={0} query={{ entityType: 'namespace', size: 20 }} onQueryChange={onChange} />,
     );
 
@@ -71,9 +71,13 @@ describe('components | audit | <AuditRecordFilters/>', () => {
     const listbox = await findByRole('listbox');
     const options = within(listbox).getAllByRole('option');
 
-    expect(options).toHaveLength(5);
+    expect(options).toHaveLength(9);
     expect(within(listbox).getByRole('option', { name: 'Namespace' })).toBeInTheDocument();
     expect(within(listbox).getByRole('option', { name: 'Application' })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: 'Trusted issuer' })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: 'Invitation' })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: 'Artifact version' })).toBeInTheDocument();
+    expect(within(listbox).getByRole('option', { name: 'Ownership transfer' })).toBeInTheDocument();
     expect(within(listbox).getByRole('option', { name: 'KMS Keyset' })).toBeInTheDocument();
     expect(within(listbox).getByRole('option', { name: 'Service' })).toBeInTheDocument();
     expect(within(listbox).getByRole('option', { name: 'Service profile' })).toBeInTheDocument();


### PR DESCRIPTION
- Audit every resolved artifact ownership transfer (accepted, rejected, cancelled) with two rows, one per namespace, each carrying wording specific to that side of the transaction. This survives deletion of either namespace, since `audit_events.namespace_id` carries no foreign key while `artifact_ownership_transfers` cascade-deletes with its owning namespace.
- Extend `reject()`/`cancel()` on `ArtifactOwnershipTransfers` with their own domain events and `@DomainEventPublisher` annotations — previously only `accept()` published an event and was audited.
- Introduce a shared `OwnershipTransferEvent` base class in `ArtifactoryEvent` for the `groupId`/`from`/`to` fields common to the accepted/rejected/cancelled events.
- Fill in the audit UI's missing entity type labels and icons (`account`, `invitation`, `namespace-trusted-issuer`, `artifact-version`, plus an icon for `artifact-ownership-transfer`), which previously fell back to the raw event type string and a generic icon.