### PR TITLE
Introduction of an `ArtifactKey` as the version-less `groupId/artifactId` identity pair

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactCoordinates.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactCoordinates.java
@@ -1,11 +1,10 @@
 package com.konfigyr.artifactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.konfigyr.support.SearchQuery;
 import com.konfigyr.version.Version;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
-
-import java.io.Serializable;
 
 /**
  * Interface that describes the Maven Coordinates that artifacts use.
@@ -13,12 +12,23 @@ import java.io.Serializable;
  * Coordinates consists out of the three integral fields: {@code groupId:artifactId:version}.
  * These three fields act much like an address and timestamp in one. This marks a specific place in
  * a repository, acting like a coordinate system for Maven projects.
+ * <p>
+ * The {@code groupId:artifactId} pair, without the version, is described by the parent {@link ArtifactKey}
+ * interface.
  *
  * @author Vladimir Spasic
  * @since 1.0.0
+ * @see ArtifactKey
  */
 @NullMarked
-public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Serializable {
+public interface ArtifactCoordinates extends ArtifactKey, Comparable<ArtifactCoordinates> {
+
+	/**
+	 * The {@link SearchQuery.Criteria} descriptor used to narrow down the search of artifacts
+	 * or property descriptors by their {@link ArtifactCoordinates groupId:artifactId:version} coordinates.
+	 */
+	SearchQuery.Criteria<ArtifactCoordinates> CRITERIA =
+			SearchQuery.criteria("artifact.coordinates", ArtifactCoordinates.class);
 
 	/**
 	 * Parses the given textual representation of Maven coordinates and creates an
@@ -43,6 +53,17 @@ public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Se
 	 */
 	static ArtifactCoordinates of(Artifact artifact) {
 		return new SimpleArtifactCoordinates(artifact.groupId(), artifact.artifactId(), artifact.version());
+	}
+
+	/**
+	 * Creates an {@link ArtifactCoordinates} instance from the given {@link ArtifactKey} and {@code version}.
+	 *
+	 * @param key the artifact key used to build the coordinates, can't be {@literal null}
+	 * @param version the version of the artifact, can't be {@literal null}
+	 * @return the artifact coordinates, never {@literal null}
+	 */
+	static ArtifactCoordinates of(ArtifactKey key, String version) {
+		return new SimpleArtifactCoordinates(key.groupId(), key.artifactId(), version);
 	}
 
 	/**
@@ -114,20 +135,6 @@ public interface ArtifactCoordinates extends Comparable<ArtifactCoordinates>, Se
 	static int compare(ArtifactCoordinates a, ArtifactCoordinates b) {
 		return SimpleArtifactCoordinates.COMPARATOR.compare(a, b);
 	}
-
-	/**
-	 * Returns the {@code groupId} Maven coordinate of the artifact.
-	 *
-	 * @return the {@code groupId} Maven coordinate, can't be {@literal null}
-	 */
-	String groupId();
-
-	/**
-	 * Returns the {@code artifactId} Maven coordinate of the artifact.
-	 *
-	 * @return the {@code artifactId} Maven coordinate, can't be {@literal null}
-	 */
-	String artifactId();
 
 	/**
 	 * Returns the {@code version} Maven coordinate of the artifact.

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactDefinition.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactDefinition.java
@@ -50,7 +50,7 @@ public record ArtifactDefinition(
 	@Nullable URI repository,
 	@Nullable OffsetDateTime createdAt,
 	@Nullable OffsetDateTime updatedAt
-) implements ArtifactDescriptor, Comparable<ArtifactDefinition> {
+) implements ArtifactKey, ArtifactDescriptor, Comparable<ArtifactDefinition> {
 
 	@Serial
 	private static final long serialVersionUID = 8664247652890518668L;

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactDefinitionNotFoundException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactDefinitionNotFoundException.java
@@ -18,31 +18,35 @@ public class ArtifactDefinitionNotFoundException extends ArtifactoryException {
 	private static final long serialVersionUID = 6236774637610101542L;
 
 	/**
-	 * Maven {@code groupId} coordinate of the artifact that could not be found.
+	 * The {@code groupId}/{@code artifactId} identity of the artifact that could not be found.
 	 */
-	private final String groupId;
+	private final ArtifactKey key;
 
 	/**
-	 * Maven {@code artifactId} coordinate of the artifact that could not be found.
-	 */
-	private final String artifactId;
-
-	/**
-	 * Create a new instance when no artifact exists for the given {@code groupId} and
-	 * {@code artifactId} coordinates.
+	 * Create a new instance when no artifact exists for the given {@link ArtifactKey}.
 	 *
-	 * @param groupId the artifact {@code groupId} coordinate that could not be found, can't be {@literal null}
-	 * @param artifactId the artifact {@code artifactId} coordinate that could not be found, can't be {@literal null}
+	 * @param key the {@code groupId}/{@code artifactId} identity of the artifact that could not be found,
+	 *        can't be {@literal null}
 	 */
-	public ArtifactDefinitionNotFoundException(@NonNull String groupId, @NonNull String artifactId) {
-		super(HttpStatus.NOT_FOUND, "Can not find artifact with following coordinates: %s:%s".formatted(groupId, artifactId));
-		this.groupId = groupId;
-		this.artifactId = artifactId;
+	public ArtifactDefinitionNotFoundException(@NonNull ArtifactKey key) {
+		super(HttpStatus.NOT_FOUND, "Can not find artifact with following coordinates: %s".formatted(
+				ArtifactKey.format(key.groupId(), key.artifactId())));
+		this.key = key;
 	}
 
 	@Override
 	public Object[] getDetailMessageArguments() {
-		return new Object[] { groupId, artifactId };
+		return new Object[] { ArtifactKey.format(key.groupId(), key.artifactId()) };
+	}
+
+	/**
+	 * Returns the {@link ArtifactKey} of the artifact that could not be found.
+	 *
+	 * @return the {@link ArtifactKey}, never {@literal null}
+	 */
+	@NonNull
+	public ArtifactKey getKey() {
+		return key;
 	}
 
 	/**
@@ -52,7 +56,7 @@ public class ArtifactDefinitionNotFoundException extends ArtifactoryException {
 	 */
 	@NonNull
 	public String getGroupId() {
-		return groupId;
+		return key.groupId();
 	}
 
 	/**
@@ -62,7 +66,7 @@ public class ArtifactDefinitionNotFoundException extends ArtifactoryException {
 	 */
 	@NonNull
 	public String getArtifactId() {
-		return artifactId;
+		return key.artifactId();
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactKey.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactKey.java
@@ -1,0 +1,90 @@
+package com.konfigyr.artifactory;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.konfigyr.support.SearchQuery;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.io.Serializable;
+
+/**
+ * Interface that describes the versionless Maven coordinate pair, {@code groupId:artifactId}, that
+ * uniquely identifies an artifact across all of its published versions.
+ * <p>
+ * This is the "GA" half of the full "GAV" ({@code groupId:artifactId:version}) coordinate system used by
+ * {@link ArtifactCoordinates}.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see ArtifactCoordinates
+ */
+@NullMarked
+public interface ArtifactKey extends Serializable {
+
+	/**
+	 * The {@link SearchQuery.Criteria} descriptor used to narrow down the search of artifacts
+	 * or property descriptors by their {@link ArtifactKey groupId:artifactId pair}.
+	 */
+	SearchQuery.Criteria<ArtifactKey> CRITERIA = SearchQuery.criteria("artifact.key", ArtifactKey.class);
+
+	/**
+	 * Parses the given textual representation of a Maven {@code groupId:artifactId} pair and creates an
+	 * {@link ArtifactKey} instance.
+	 * <p>
+	 * The expected format is {@code groupId:artifactId}.
+	 *
+	 * @param key the textual representation of the key to parse, can be {@literal null}
+	 * @return the parsed artifact key, never {@literal null}
+	 * @throws IllegalArgumentException if the key string is invalid or cannot be parsed
+	 */
+	@JsonCreator
+	static ArtifactKey parse(@Nullable String key) {
+		return SimpleArtifactKey.parse(key);
+	}
+
+	/**
+	 * Creates an {@link ArtifactKey} instance from the given Maven coordinate components.
+	 *
+	 * @param groupId    the group identifier, can't be {@literal null}
+	 * @param artifactId the artifact identifier, can't be {@literal null}
+	 * @return the artifact key, never {@literal null}
+	 */
+	static ArtifactKey of(String groupId, String artifactId) {
+		return new SimpleArtifactKey(groupId, artifactId);
+	}
+
+	/**
+	 * Returns the {@code groupId} Maven coordinate of the artifact.
+	 *
+	 * @return the {@code groupId} Maven coordinate, can't be {@literal null}
+	 */
+	String groupId();
+
+	/**
+	 * Returns the {@code artifactId} Maven coordinate of the artifact.
+	 *
+	 * @return the {@code artifactId} Maven coordinate, can't be {@literal null}
+	 */
+	String artifactId();
+
+	/**
+	 * Formats the {@code groupId}/{@code artifactId} pair into a textual representation.
+	 *
+	 * @return the formatted key in the format {@code groupId:artifactId}, never {@literal null}
+	 */
+	default String format() {
+		return format(groupId(), artifactId());
+	}
+
+	/**
+	 * Formats the given Maven coordinate components into a textual representation.
+	 *
+	 * @param groupId    the group identifier, can't be {@literal null}
+	 * @param artifactId the artifact identifier, can't be {@literal null}
+	 * @return the formatted key in the format {@code groupId:artifactId}, never {@literal null}
+	 */
+	static String format(String groupId, String artifactId) {
+		return "%s:%s".formatted(groupId, artifactId);
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactOwnershipMismatchException.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactOwnershipMismatchException.java
@@ -10,7 +10,7 @@ import java.io.Serial;
  * {@link ArtifactVisibility} of, an artifact that is owned by a different namespace.
  * <p>
  * Ownership is a {@code groupId}/{@code artifactId} level concern, not a version level one, so
- * this exception carries the artifact coordinates without a version.
+ * this exception carries the artifact key without a version.
  *
  * @author Vladimir Spasic
  * @since 1.0.0
@@ -21,14 +21,9 @@ public class ArtifactOwnershipMismatchException extends ArtifactoryException {
 	private static final long serialVersionUID = -1523069864217405721L;
 
 	/**
-	 * Maven {@code groupId} coordinate of the artifact owned by a different namespace.
+	 * The {@code groupId}/{@code artifactId} identity of the artifact owned by a different namespace.
 	 */
-	private final String groupId;
-
-	/**
-	 * Maven {@code artifactId} coordinate of the artifact owned by a different namespace.
-	 */
-	private final String artifactId;
+	private final ArtifactKey key;
 
 	/**
 	 * The namespace that attempted to publish or change the visibility of the artifact.
@@ -36,29 +31,33 @@ public class ArtifactOwnershipMismatchException extends ArtifactoryException {
 	private final Owner owner;
 
 	/**
-	 * Create a new instance when the given {@link Owner} does not match the namespace that
-	 * already owns the artifact identified by the supplied {@code groupId} and {@code artifactId}.
+	 * Create a new instance when the given {@link Owner} does not match the namespace that already owns
+	 * the artifact identified by the supplied {@link ArtifactKey}.
+	 * <p>
+	 * Accepts any {@link ArtifactKey}, including an {@link ArtifactCoordinates} instance.
 	 *
-	 * @param groupId the {@code groupId} coordinate of the artifact owned by a different namespace, can't be {@literal null}
-	 * @param artifactId the {@code artifactId} coordinate of the artifact owned by a different namespace, can't be {@literal null}
-	 * @param owner the namespace that attempted to publish or change the visibility of the artifact, can't be {@literal null}
+	 * @param key the {@code groupId}/{@code artifactId} identity of the artifact owned by a different
+	 *        namespace, can't be {@literal null}
+	 * @param owner the namespace that attempted to publish or change the visibility of the artifact,
+	 *        can't be {@literal null}
 	 */
-	public ArtifactOwnershipMismatchException(@NonNull String groupId, @NonNull String artifactId, @NonNull Owner owner) {
-		super(HttpStatus.CONFLICT, "Artifact '%s:%s' is owned by a '%s' namespace".formatted(groupId, artifactId, owner.slug()));
-		this.groupId = groupId;
-		this.artifactId = artifactId;
+	public ArtifactOwnershipMismatchException(@NonNull ArtifactKey key, @NonNull Owner owner) {
+		// uses the static ArtifactKey.format(groupId, artifactId) rather than key.format(): if key is an
+		// ArtifactCoordinates, its overridden format() renders the version too, which this message must not leak
+		super(HttpStatus.CONFLICT, "Artifact '%s' is owned by a '%s' namespace"
+				.formatted(ArtifactKey.format(key.groupId(), key.artifactId()), owner.slug()));
+		this.key = key;
 		this.owner = owner;
 	}
 
 	/**
-	 * Create a new instance when the given {@link Owner} does not match the namespace that
-	 * already owns the artifact identified by the supplied {@link ArtifactCoordinates}.
+	 * Returns the {@link ArtifactKey} of the artifact owned by a different namespace.
 	 *
-	 * @param coordinates the coordinates of the artifact owned by a different namespace, can't be {@literal null}
-	 * @param owner the namespace that attempted to publish or change the visibility of the artifact, can't be {@literal null}
+	 * @return the {@link ArtifactKey}, never {@literal null}
 	 */
-	public ArtifactOwnershipMismatchException(@NonNull ArtifactCoordinates coordinates, @NonNull Owner owner) {
-		this(coordinates.groupId(), coordinates.artifactId(), owner);
+	@NonNull
+	public ArtifactKey getKey() {
+		return key;
 	}
 
 	/**
@@ -68,7 +67,7 @@ public class ArtifactOwnershipMismatchException extends ArtifactoryException {
 	 */
 	@NonNull
 	public String getGroupId() {
-		return groupId;
+		return key.groupId();
 	}
 
 	/**
@@ -78,7 +77,7 @@ public class ArtifactOwnershipMismatchException extends ArtifactoryException {
 	 */
 	@NonNull
 	public String getArtifactId() {
-		return artifactId;
+		return key.artifactId();
 	}
 
 	/**
@@ -93,7 +92,7 @@ public class ArtifactOwnershipMismatchException extends ArtifactoryException {
 
 	@Override
 	public Object[] getDetailMessageArguments() {
-		return new Object[] { groupId, artifactId, owner.slug() };
+		return new Object[] { ArtifactKey.format(key.groupId(), key.artifactId()), owner.slug() };
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
@@ -157,8 +157,7 @@ public interface Artifactory {
 	VersionedArtifact publish(@NonNull Owner owner, @NonNull ArtifactMetadata metadata);
 
 	/**
-	 * Changes the {@link ArtifactVisibility} of the artifact identified by the given {@code groupId}
-	 * and {@code artifactId}.
+	 * Changes the {@link ArtifactVisibility} of the artifact identified by the given {@link ArtifactKey}.
 	 * <p>
 	 * Visibility is a {@code groupId}/{@code artifactId} level concern, not a version level one: it
 	 * applies to every {@link VersionedArtifact} published under those coordinates. Only the
@@ -166,12 +165,11 @@ public interface Artifactory {
 	 * already resolved the requesting namespace to its {@link Owner}.
 	 *
 	 * @param owner the namespace requesting the change, can't be {@literal null}
-	 * @param groupId the artifact {@code groupId} coordinate, can't be {@literal null}
-	 * @param artifactId the artifact {@code artifactId} coordinate, can't be {@literal null}
+	 * @param key the {@code groupId}/{@code artifactId} identity of the artifact, can't be {@literal null}
 	 * @param visibility the visibility to apply, can't be {@literal null}
 	 * @throws ArtifactDefinitionNotFoundException when no artifact exists for the given coordinates
 	 * @throws ArtifactOwnershipMismatchException when the given owner does not own the artifact
 	 */
-	void changeVisibility(@NonNull Owner owner, @NonNull String groupId, @NonNull String artifactId, @NonNull ArtifactVisibility visibility);
+	void changeVisibility(@NonNull Owner owner, @NonNull ArtifactKey key, @NonNull ArtifactVisibility visibility);
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
@@ -225,9 +225,8 @@ class DefaultArtifactory implements Artifactory {
 				.fetchOptional(ARTIFACT_VERSIONS.ID)
 				.orElseThrow(() -> new ArtifactVersionNotFoundException(coordinates));
 
-		return context.select(PROPERTY_DEFINITIONS.fields())
-				.from(ARTIFACT_VERSION_PROPERTIES)
-				.innerJoin(PROPERTY_DEFINITIONS)
+		return createPropertySearchQuery()
+				.innerJoin(ARTIFACT_VERSION_PROPERTIES)
 				.on(PROPERTY_DEFINITIONS.ID.eq(ARTIFACT_VERSION_PROPERTIES.PROPERTY_DEFINITION_ID))
 				.where(ARTIFACT_VERSION_PROPERTIES.ARTIFACT_VERSION_ID.eq(artifactVersionId))
 				.fetch(record -> toPropertyDefinition(record, converters));
@@ -237,24 +236,23 @@ class DefaultArtifactory implements Artifactory {
 	@Transactional(label = "artifactory.change-visibility")
 	public void changeVisibility(
 			@NonNull Owner owner,
-			@NonNull String groupId,
-			@NonNull String artifactId,
+			@NonNull ArtifactKey key,
 			@NonNull ArtifactVisibility visibility
 	) {
 		final Long existingOwnerId = context.select(ARTIFACTS.NAMESPACE_ID)
 				.from(ARTIFACTS)
-				.where(ARTIFACTS.GROUP_ID.eq(groupId), ARTIFACTS.ARTIFACT_ID.eq(artifactId))
+				.where(toCondition(key))
 				.fetchOptional(ARTIFACTS.NAMESPACE_ID)
-				.orElseThrow(() -> new ArtifactDefinitionNotFoundException(groupId, artifactId));
+				.orElseThrow(() -> new ArtifactDefinitionNotFoundException(key));
 
 		if (!existingOwnerId.equals(owner.id().get())) {
-			throw new ArtifactOwnershipMismatchException(groupId, artifactId, owner);
+			throw new ArtifactOwnershipMismatchException(key, owner);
 		}
 
 		context.update(ARTIFACTS)
 				.set(ARTIFACTS.VISIBILITY, visibility.name())
 				.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
-				.where(ARTIFACTS.GROUP_ID.eq(groupId), ARTIFACTS.ARTIFACT_ID.eq(artifactId))
+				.where(toCondition(key))
 				.execute();
 	}
 
@@ -280,6 +278,17 @@ class DefaultArtifactory implements Artifactory {
 				.from(ARTIFACT_VERSIONS)
 				.innerJoin(ARTIFACTS)
 				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
+				.innerJoin(NAMESPACES)
+				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
+	}
+
+	@NonNull
+	private SelectJoinStep<? extends Record> createPropertySearchQuery() {
+		return context.select(PROPERTY_DEFINITIONS.fields())
+				.select(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, NAMESPACES.ID, NAMESPACES.SLUG)
+				.from(PROPERTY_DEFINITIONS)
+				.innerJoin(ARTIFACTS)
+				.on(ARTIFACTS.ID.eq(PROPERTY_DEFINITIONS.ARTIFACT_ID))
 				.innerJoin(NAMESPACES)
 				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
 	}
@@ -318,6 +327,14 @@ class DefaultArtifactory implements Artifactory {
 	}
 
 	@NonNull
+	static Condition toCondition(@NonNull ArtifactKey key) {
+		return DSL.and(
+				ARTIFACTS.GROUP_ID.eq(key.groupId()),
+				ARTIFACTS.ARTIFACT_ID.eq(key.artifactId())
+		);
+	}
+
+	@NonNull
 	static Condition toCondition(@NonNull ArtifactCoordinates coordinates) {
 		return DSL.and(
 				ARTIFACTS.GROUP_ID.eq(coordinates.groupId()),
@@ -326,8 +343,12 @@ class DefaultArtifactory implements Artifactory {
 		);
 	}
 
+	static Owner toOwner(Record record) {
+		return new Owner(record.get(NAMESPACES.ID, EntityId.class), record.get(NAMESPACES.SLUG));
+	}
+
 	static VersionedArtifact toVersionedArtifact(Record record) {
-		return toVersionedArtifact(record, new Owner(EntityId.from(record.get(NAMESPACES.ID)), record.get(NAMESPACES.SLUG)));
+		return toVersionedArtifact(record, toOwner(record));
 	}
 
 	static VersionedArtifact toVersionedArtifact(Record record, Owner owner) {
@@ -353,6 +374,9 @@ class DefaultArtifactory implements Artifactory {
 		return PropertyDefinition.builder()
 				.id(record.get(PROPERTY_DEFINITIONS.ID))
 				.artifact(record.get(PROPERTY_DEFINITIONS.ARTIFACT_ID))
+				.groupId(record.get(ARTIFACTS.GROUP_ID))
+				.artifactId(record.get(ARTIFACTS.ARTIFACT_ID))
+				.owner(toOwner(record))
 				.checksum(record.get(PROPERTY_DEFINITIONS.CHECKSUM))
 				.name(record.get(PROPERTY_DEFINITIONS.NAME))
 				.typeName(record.get(PROPERTY_DEFINITIONS.TYPE_NAME))

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/PropertyDefinition.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/PropertyDefinition.java
@@ -25,6 +25,8 @@ import java.io.Serial;
  *
  * @param id entity identifier for the property definition, can't be {@literal null}.
  * @param artifact entity identifier of the artifact that owns the property, can't be {@literal null}.
+ * @param key the {@code groupId}/{@code artifactId} identity of the artifact that owns the property, can't be {@literal null}.
+ * @param owner the namespace that owns the artifact that owns the property, can't be {@literal null}.
  * @param checksum unique checksum identifying this specific configuration definition, can't be {@literal null}.
  * @param name name of the configuration property, for example {@code spring.datasource.url}. Can't be {@literal null}.
  * @param typeName fully qualified Java type name, for example {@code java.lang.String}. Can't be {@literal null}.
@@ -42,6 +44,8 @@ import java.io.Serial;
 public record PropertyDefinition(
 		@NonNull @Identity EntityId id,
 		@NonNull @Association(aggregateType = ArtifactDefinition.class) EntityId artifact,
+		@NonNull ArtifactKey key,
+		@NonNull Owner owner,
 		@NonNull ByteArray checksum,
 		@NonNull String name,
 		@NonNull String typeName,
@@ -81,6 +85,9 @@ public record PropertyDefinition(
 
 		private EntityId id;
 		private EntityId artifact;
+		private String groupId;
+		private String artifactId;
+		private Owner owner;
 		private ByteArray checksum;
 		private int occurrences = 1;
 		private Version firstSeen;
@@ -151,6 +158,56 @@ public record PropertyDefinition(
 		@NonNull
 		public Builder artifact(EntityId artifact) {
 			this.artifact = artifact;
+			return this;
+		}
+
+		/**
+		 * Sets the {@code groupId} coordinate of the artifact that owns this property.
+		 *
+		 * @param groupId {@code groupId} coordinate of the owning artifact.
+		 * @return property definition builder
+		 */
+		@NonNull
+		public Builder groupId(String groupId) {
+			this.groupId = groupId;
+			return this;
+		}
+
+		/**
+		 * Sets the {@code artifactId} coordinate of the artifact that owns this property.
+		 *
+		 * @param artifactId {@code artifactId} coordinate of the owning artifact.
+		 * @return property definition builder
+		 */
+		@NonNull
+		public Builder artifactId(String artifactId) {
+			this.artifactId = artifactId;
+			return this;
+		}
+
+		/**
+		 * Sets the {@code groupId}/{@code artifactId} identity of the artifact that owns this property,
+		 * deconstructing it into its two coordinate fields.
+		 *
+		 * @param key the {@link ArtifactKey} of the owning artifact.
+		 * @return property definition builder
+		 */
+		@NonNull
+		public Builder key(ArtifactKey key) {
+			this.groupId = key.groupId();
+			this.artifactId = key.artifactId();
+			return this;
+		}
+
+		/**
+		 * Sets the namespace that owns the artifact that owns this property.
+		 *
+		 * @param owner the owning namespace.
+		 * @return property definition builder
+		 */
+		@NonNull
+		public Builder owner(Owner owner) {
+			this.owner = owner;
 			return this;
 		}
 
@@ -234,6 +291,9 @@ public record PropertyDefinition(
 		protected PropertyDefinition instantiate() {
 			Assert.notNull(id, "Property definition entity identifier must not be null");
 			Assert.notNull(artifact, "Artifact entity identifier must not be null");
+			Assert.hasText(groupId, "Artifact groupId must not be blank");
+			Assert.hasText(artifactId, "Artifact artifactId must not be blank");
+			Assert.notNull(owner, "Artifact owner must not be null");
 			Assert.notNull(checksum, "Property checksum must not be null");
 			Assert.notNull(name, "Property name must not be null");
 			Assert.notNull(typeName, "Property type name must not be null");
@@ -241,8 +301,8 @@ public record PropertyDefinition(
 			Assert.notNull(firstSeen, "First seen version must not be null");
 			Assert.notNull(lastSeen, "Last seen version must not be null");
 
-			return new PropertyDefinition(id, artifact, checksum, name, typeName, schema, defaultValue,
-					description, deprecation, occurrences, firstSeen, lastSeen);
+			return new PropertyDefinition(id, artifact, ArtifactKey.of(groupId, artifactId), owner, checksum, name, typeName,
+					schema, defaultValue, description, deprecation, occurrences, firstSeen, lastSeen);
 		}
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/SimpleArtifactCoordinates.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/SimpleArtifactCoordinates.java
@@ -2,7 +2,8 @@ package com.konfigyr.artifactory;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.konfigyr.version.Version;
-import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 import org.springframework.util.Assert;
 
 import java.io.Serial;
@@ -10,11 +11,8 @@ import java.util.Comparator;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-record SimpleArtifactCoordinates(
-		@NonNull String groupId,
-		@NonNull String artifactId,
-		@NonNull Version version
-) implements ArtifactCoordinates {
+@NullMarked
+record SimpleArtifactCoordinates(String groupId, String artifactId, Version version) implements ArtifactCoordinates {
 
 	@Serial
 	private static final long serialVersionUID = 1L;
@@ -26,7 +24,7 @@ record SimpleArtifactCoordinates(
 			.thenComparing(ArtifactCoordinates::artifactId)
 			.thenComparing(ArtifactCoordinates::version);
 
-	static SimpleArtifactCoordinates parse(String coordinates) {
+	static SimpleArtifactCoordinates parse(@Nullable String coordinates) {
 		Assert.hasText(coordinates, "Artifact coordinates must not be null or blank");
 
 		final Matcher matcher = PATTERN.matcher(coordinates);
@@ -43,19 +41,15 @@ record SimpleArtifactCoordinates(
 	}
 
 	SimpleArtifactCoordinates(String groupId, String artifactId, String version) {
-		this(groupId, artifactId, version == null ? null : Version.of(version));
+		this(groupId, artifactId, Version.of(version));
 	}
 
-	SimpleArtifactCoordinates(String groupId, String artifactId, Version version) {
+	SimpleArtifactCoordinates {
 		Assert.hasText(groupId, "Group ID cannot be empty");
 		Assert.hasText(artifactId, "Artifact ID cannot be empty");
 		Assert.notNull(version, "Version cannot be null");
-		this.groupId = groupId;
-		this.artifactId = artifactId;
-		this.version = version;
 	}
 
-	@NonNull
 	@Override
 	@JsonValue
 	public String toString() {

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/SimpleArtifactKey.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/SimpleArtifactKey.java
@@ -1,0 +1,42 @@
+package com.konfigyr.artifactory;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.util.Assert;
+
+import java.io.Serial;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+@NullMarked
+record SimpleArtifactKey(String groupId, String artifactId) implements ArtifactKey {
+
+	@Serial
+	private static final long serialVersionUID = 1L;
+
+	static final Pattern PATTERN = Pattern.compile("^(?<groupId>[^:]+):(?<artifactId>[^:]+)$");
+
+	static SimpleArtifactKey parse(@Nullable String key) {
+		Assert.hasText(key, "Artifact key must not be null or blank");
+
+		final Matcher matcher = PATTERN.matcher(key);
+
+		if (!matcher.matches()) {
+			throw new IllegalArgumentException("Invalid Artifact key: " + key);
+		}
+
+		return new SimpleArtifactKey(matcher.group("groupId"), matcher.group("artifactId"));
+	}
+
+	SimpleArtifactKey {
+		Assert.hasText(groupId, "Group ID cannot be empty");
+		Assert.hasText(artifactId, "Artifact ID cannot be empty");
+	}
+
+	@Override
+	@JsonValue
+	public String toString() {
+		return format();
+	}
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/VersionedArtifact.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/VersionedArtifact.java
@@ -55,7 +55,7 @@ public record VersionedArtifact(
 		@Nullable URI website,
 		@Nullable URI repository,
 		@NonNull Instant publishedAt
-) implements ArtifactDescriptor, Publication {
+) implements ArtifactKey, ArtifactDescriptor, Publication {
 
 	@Serial
 	private static final long serialVersionUID = 2501993329087351789L;

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
@@ -107,7 +107,7 @@ class ArtifactoryController {
 				"Could not extract namespace identifier from the current authenticated principal"
 		));
 
-		artifactory.changeVisibility(owner, groupId, artifactId, request.visibility());
+		artifactory.changeVisibility(owner, ArtifactKey.of(groupId, artifactId), request.visibility());
 	}
 
 	private Optional<Owner> resolveOwner() {

--- a/konfigyr-api/src/main/resources/messages/problem-detail.properties
+++ b/konfigyr-api/src/main/resources/messages/problem-detail.properties
@@ -304,8 +304,8 @@ problemDetail.com.konfigyr.artifactory.ArtifactVersionExistsException=You attemp
   coordinates ''{0}'' that already exists. Please use a different release version and try again.
 
 problemDetail.title.com.konfigyr.artifactory.ArtifactOwnershipMismatchException=Artifact ownership conflict
-problemDetail.com.konfigyr.artifactory.ArtifactOwnershipMismatchException=The artifact ''{0}:{1}'' is owned by a different \
-  namespace and cannot be published to or modified by ''{2}''.
+problemDetail.com.konfigyr.artifactory.ArtifactOwnershipMismatchException=The artifact ''{0}'' is owned by a different \
+  namespace and cannot be published to or modified by ''{1}''.
 
 problemDetail.title.com.konfigyr.artifactory.OwnerNotFoundException=Organization not found
 problemDetail.com.konfigyr.artifactory.OwnerNotFoundException=The namespace you're trying to access doesn't exist \
@@ -338,7 +338,7 @@ problemDetail.com.konfigyr.artifactory.transfer.ArtifactOwnershipTransferAlready
 
 problemDetail.title.com.konfigyr.artifactory.ArtifactDefinitionNotFoundException=Artifact not found
 problemDetail.com.konfigyr.artifactory.ArtifactDefinitionNotFoundException=Could not find an artifact with the following \
-  coordinates: ''{0}:{1}''.
+  coordinates: ''{0}''.
 
 ## Service manifest module exceptions ##
 

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactKeyTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactKeyTest.java
@@ -1,0 +1,104 @@
+package com.konfigyr.artifactory;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class ArtifactKeyTest {
+
+	final JsonMapper mapper = JsonMapper.builder().build();
+
+	@ValueSource(strings = {
+			"com.konfigyr:konfigyr-api",
+			"org.eclipse.aether:aether-impl",
+			"com.google.code.findbugs:annotations",
+			"org.sonatype.sisu:sisu-guice"
+	})
+	@ParameterizedTest(name = "should parse key: {0}")
+	@DisplayName("should create ArtifactKey from Maven groupId:artifactId string")
+	void shouldParseKey(String key) {
+		assertThat(ArtifactKey.parse(key))
+				.isNotNull()
+				.isInstanceOf(SimpleArtifactKey.class)
+				.hasToString(key);
+	}
+
+	@Test
+	@DisplayName("should fail to parse ArtifactKey from null, empty, blank or invalid key")
+	void shouldFailToParseKey() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> ArtifactKey.parse(null))
+				.withMessageContaining("Artifact key must not be null or blank")
+				.withNoCause();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> ArtifactKey.parse(""))
+				.withMessageContaining("Artifact key must not be null or blank")
+				.withNoCause();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> ArtifactKey.parse("   "))
+				.withMessageContaining("Artifact key must not be null or blank")
+				.withNoCause();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> ArtifactKey.parse("invalid key"))
+				.withMessageContaining("Invalid Artifact key: invalid key")
+				.withNoCause();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> ArtifactKey.parse("com.konfigyr:konfigyr-api:1.0.0"))
+				.withMessageContaining("Invalid Artifact key: com.konfigyr:konfigyr-api:1.0.0")
+				.withNoCause();
+	}
+
+	@Test
+	@DisplayName("should create Artifact key from fields")
+	void createKey() {
+		assertThat(ArtifactKey.of("com.konfigyr", "konfigyr-api"))
+				.returns("com.konfigyr", ArtifactKey::groupId)
+				.returns("konfigyr-api", ArtifactKey::artifactId)
+				.hasToString("com.konfigyr:konfigyr-api")
+				.isEqualTo(ArtifactKey.parse("com.konfigyr:konfigyr-api"))
+				.isNotEqualTo(ArtifactKey.parse("com.konfigyr:konfigyr-identity"));
+	}
+
+	@Test
+	@DisplayName("should fail to create Artifact key from blank fields")
+	void shouldFailToCreateKeyFromBlankFields() {
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> ArtifactKey.of("", "konfigyr-api"))
+				.withMessageContaining("Group ID cannot be empty")
+				.withNoCause();
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> ArtifactKey.of("com.konfigyr", ""))
+				.withMessageContaining("Artifact ID cannot be empty")
+				.withNoCause();
+	}
+
+	@Test
+	@DisplayName("should serialize Artifact key to JSON string")
+	void serializeKey() throws IOException {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-api");
+
+		assertThat(mapper.writeValueAsString(key))
+				.isEqualTo("\"com.konfigyr:konfigyr-api\"");
+	}
+
+	@Test
+	@DisplayName("should deserialize Artifact key from JSON string")
+	void deserializeKey() throws IOException {
+		assertThat(mapper.readValue("\"com.konfigyr:konfigyr-api\"", ArtifactKey.class))
+				.isEqualTo(ArtifactKey.of("com.konfigyr", "konfigyr-api"))
+				.isInstanceOf(SimpleArtifactKey.class);
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
@@ -335,7 +335,7 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 				.as("should not yet be visible to a different namespace while still private")
 				.isEmpty();
 
-		artifactory.changeVisibility(Owners.konfigyr(), "com.konfigyr", "konfigyr-internal-secrets", ArtifactVisibility.PUBLIC);
+		artifactory.changeVisibility(Owners.konfigyr(), coordinates, ArtifactVisibility.PUBLIC);
 
 		assertThat(artifactory.get(Owners.johnDoe(), coordinates))
 				.as("should now be visible to a different namespace after becoming public")
@@ -348,13 +348,16 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 	@Transactional
 	@DisplayName("should reject changing visibility when the caller does not own the artifact")
 	void shouldRejectChangeVisibilityForDifferentOwner() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-internal-secrets");
+
 		assertThatExceptionOfType(ArtifactOwnershipMismatchException.class)
-				.isThrownBy(() -> artifactory.changeVisibility(Owners.johnDoe(), "com.konfigyr", "konfigyr-internal-secrets", ArtifactVisibility.PUBLIC))
-				.returns("com.konfigyr", ArtifactOwnershipMismatchException::getGroupId)
-				.returns("konfigyr-internal-secrets", ArtifactOwnershipMismatchException::getArtifactId)
+				.isThrownBy(() -> artifactory.changeVisibility(Owners.johnDoe(), key, ArtifactVisibility.PUBLIC))
+				.returns(key, ArtifactOwnershipMismatchException::getKey)
+				.returns(key.groupId(), ArtifactOwnershipMismatchException::getGroupId)
+				.returns(key.artifactId(), ArtifactOwnershipMismatchException::getArtifactId)
 				.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode);
 
-		assertThat(artifactory.get(Owners.konfigyr(), ArtifactCoordinates.parse("com.konfigyr:konfigyr-internal-secrets:1.0.0")))
+		assertThat(artifactory.get(Owners.konfigyr(), ArtifactCoordinates.of(key, "1.0.0")))
 				.as("visibility must remain unchanged after a rejected attempt")
 				.isPresent()
 				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
@@ -364,10 +367,13 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 	@Test
 	@DisplayName("should reject changing visibility for an unknown artifact")
 	void shouldRejectChangeVisibilityForUnknownArtifact() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-does-not-exist");
+
 		assertThatExceptionOfType(ArtifactDefinitionNotFoundException.class)
-				.isThrownBy(() -> artifactory.changeVisibility(Owners.konfigyr(), "com.konfigyr", "konfigyr-does-not-exist", ArtifactVisibility.PUBLIC))
-				.returns("com.konfigyr", ArtifactDefinitionNotFoundException::getGroupId)
-				.returns("konfigyr-does-not-exist", ArtifactDefinitionNotFoundException::getArtifactId)
+				.isThrownBy(() -> artifactory.changeVisibility(Owners.konfigyr(), key, ArtifactVisibility.PUBLIC))
+				.returns(key, ArtifactDefinitionNotFoundException::getKey)
+				.returns(key.groupId(), ArtifactDefinitionNotFoundException::getGroupId)
+				.returns(key.artifactId(), ArtifactDefinitionNotFoundException::getArtifactId)
 				.returns(HttpStatus.NOT_FOUND, ArtifactDefinitionNotFoundException::getStatusCode);
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/PropertyDefinitionTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/PropertyDefinitionTest.java
@@ -19,6 +19,9 @@ class PropertyDefinitionTest {
 		final var property = PropertyDefinition.builder()
 				.id(1236L)
 				.artifact(1453L)
+				.groupId("com.konfigyr")
+				.artifactId("konfigyr-api")
+				.owner(Owners.konfigyr())
 				.typeName("java.lang.String")
 				.schema(StringSchema.builder()
 						.example("super-app")
@@ -39,6 +42,8 @@ class PropertyDefinitionTest {
 				.isNotNull()
 				.returns(EntityId.from(1236L), PropertyDefinition::id)
 				.returns(EntityId.from(1453L), PropertyDefinition::artifact)
+				.returns(ArtifactKey.of("com.konfigyr", "konfigyr-api"), PropertyDefinition::key)
+				.returns(Owners.konfigyr(), PropertyDefinition::owner)
 				.returns("java.lang.String", PropertyDefinition::typeName)
 				.returns("spring.application.name", PropertyDefinition::name)
 				.returns("The name of the Spring application", PropertyDefinition::description)
@@ -58,11 +63,34 @@ class PropertyDefinitionTest {
 	}
 
 	@Test
+	@DisplayName("should set the artifact key by deconstructing it into groupId and artifactId")
+	void createPropertyFromKey() {
+		final var property = PropertyDefinition.builder()
+				.id(1236L)
+				.artifact(1453L)
+				.key(ArtifactKey.of("com.konfigyr", "konfigyr-api"))
+				.owner(Owners.konfigyr())
+				.typeName("java.lang.String")
+				.schema(StringSchema.instance())
+				.name("spring.application.name")
+				.checksum(ByteArray.fromString("checksum"))
+				.firstSeen("1.0.0")
+				.lastSeen("1.1.0")
+				.build();
+
+		assertThat(property)
+				.returns(ArtifactKey.of("com.konfigyr", "konfigyr-api"), PropertyDefinition::key);
+	}
+
+	@Test
 	@DisplayName("should sort property definition by name")
 	void sortProperties() {
 		final var builder = PropertyDefinition.builder()
 				.id("000013229FPVS")
 				.artifact("000005KK96ZZP")
+				.groupId("com.konfigyr")
+				.artifactId("konfigyr-api")
+				.owner(Owners.konfigyr())
 				.typeName("java.lang.String")
 				.schema(StringSchema.instance())
 				.checksum(ByteArray.fromString("checksum"))


### PR DESCRIPTION
`ArtifactCoordinates` bundles `groupId`, `artifactId` and `version` together, so any code that only cares about an artifact's identity, not a specific release, had to work with two loose `String` parameters instead of a real type. This extracts that versionless `groupId:artifactId` pair into a new `ArtifactKey` interface, which `ArtifactCoordinates` now extends, and retrofits the handful of call sites that were already passing `groupId`/`artifactId` around as separate strings.

- New `ArtifactKey` interface (`groupId()`, `artifactId()`, `format()`, static `parse`/`of`/`format`, a `SearchQuery.Criteria<ArtifactKey>` constant) plus its `SimpleArtifactKey` record implementation, mirroring `ArtifactCoordinates`/`SimpleArtifactCoordinates`.
- `ArtifactCoordinates extends ArtifactKey`, `groupId()`/`artifactId()` are now inherited rather than redeclared; `SimpleArtifactCoordinates` needed no changes since its record accessors already satisfy the interface.
- `Artifactory.changeVisibility(...)` now takes an `ArtifactKey` instead of two `String` parameters.
- `ArtifactDefinitionNotFoundException` and `ArtifactOwnershipMismatchException` now take an `ArtifactKey` (the mismatch exception's separate `ArtifactCoordinates` overload was removed, since `ArtifactCoordinates` already satisfies `ArtifactKey`). Both build their message via the *static* `ArtifactKey.format(groupId, artifactId)` rather than the instance `key.format()`, if `key` happens to be an `ArtifactCoordinates`, its overridden `format()` renders the version too, which these version-agnostic messages must not leak.
- `PropertyDefinition` now carries an `ArtifactKey key` (plus `Owner owner`) describing the artifact it belongs to, alongside its existing `artifact: EntityId` association, a natural-key/business-key complement to that surrogate reference, the same shape `VersionedArtifact` already has for its own artifact reference. Its builder deconstructs a supplied `.key(ArtifactKey)` into two internal fields and reconstructs the `ArtifactKey` on `build()`, so callers can populate it either as a whole key or field-by-field (useful when mapping straight off individual jOOQ columns).
- `ArtifactDefinition` and `VersionedArtifact` now also `implements ArtifactKey`, a free addition, since both already expose matching `groupId()`/`artifactId()` accessors via `ArtifactDescriptor`.
- `problem-detail.properties` message templates updated for the reduced placeholder count on the two retrofitted exceptions.
