### PR TITLE
Artifactory Publications API

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactCoordinates.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactCoordinates.java
@@ -25,10 +25,9 @@ public interface ArtifactCoordinates extends ArtifactKey, Comparable<ArtifactCoo
 
 	/**
 	 * The {@link SearchQuery.Criteria} descriptor used to narrow down the search of artifacts
-	 * or property descriptors by their {@link ArtifactCoordinates groupId:artifactId:version} coordinates.
+	 * or property descriptors by their {@code version} Maven coordinates.
 	 */
-	SearchQuery.Criteria<ArtifactCoordinates> CRITERIA =
-			SearchQuery.criteria("artifact.coordinates", ArtifactCoordinates.class);
+	SearchQuery.Criteria<String> VERSION_CRITERIA = SearchQuery.criteria("artifact.coordinates.version", String.class);
 
 	/**
 	 * Parses the given textual representation of Maven coordinates and creates an

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactKey.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactKey.java
@@ -23,9 +23,15 @@ public interface ArtifactKey extends Serializable {
 
 	/**
 	 * The {@link SearchQuery.Criteria} descriptor used to narrow down the search of artifacts
-	 * or property descriptors by their {@link ArtifactKey groupId:artifactId pair}.
+	 * or property descriptors by their {@code groupId} Maven coordinate.
 	 */
-	SearchQuery.Criteria<ArtifactKey> CRITERIA = SearchQuery.criteria("artifact.key", ArtifactKey.class);
+	SearchQuery.Criteria<String> GROUP_ID_CRITERIA = SearchQuery.criteria("artifact.coordinates.group_id", String.class);
+
+	/**
+	 * The {@link SearchQuery.Criteria} descriptor used to narrow down the search of artifacts
+	 * or property descriptors by their {@code artifactId} Maven coordinate.
+	 */
+	SearchQuery.Criteria<String> ARTIFACT_ID_CRITERIA = SearchQuery.criteria("artifact.coordinates.artifact_id", String.class);
 
 	/**
 	 * Parses the given textual representation of a Maven {@code groupId:artifactId} pair and creates an

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
@@ -1,6 +1,5 @@
 package com.konfigyr.artifactory;
 
-import org.jmolecules.event.annotation.DomainEventPublisher;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
 
@@ -10,21 +9,18 @@ import java.util.Optional;
 import java.util.Set;
 
 /**
- * Interface that represents the primary entry point to the {@code Artifactory} domain.
+ * Interface that represents a visibility-based, read-only view onto the {@code Artifactory} domain.
  * <p>
- * The {@code Artifactory} service provides operations for resolving, inspecting, and publishing
- * versioned artifacts managed by the platform. Artifacts represent reusable configuration libraries
- * whose metadata and property definitions are versioned and published through this service.
+ * The {@code Artifactory} service resolves and inspects versioned artifacts managed by the platform,
+ * answering "what can this caller see": {@link ArtifactVisibility#PUBLIC PUBLIC} artifacts are visible
+ * to everyone, {@link ArtifactVisibility#PRIVATE PRIVATE} artifacts only to their owner.
  * <p>
- * Implementations are responsible for enforcing domain invariants such as coordinate uniqueness,
- * release immutability, and metadata validation. Published artifacts are expected to be immutable
- * representations of a configuration schema at a specific point in time.
- * <p>
- * The {@code Artifactory} interface represents the main boundary between the application layer and
- * the artifact repository domain.
+ * Managing a namespace's own registry — publishing new versions, changing visibility, or removing what
+ * it has published — is handled by {@link Publications} instead.
  *
  * @author Vladimir Spasic
  * @since 1.0.0
+ * @see Publications
  */
 public interface Artifactory {
 
@@ -176,54 +172,5 @@ public interface Artifactory {
 	 */
 	@NonNull
 	Set<Publication> existing(@NonNull Owner owner, @NonNull Collection<ArtifactCoordinates> coordinates);
-
-	/**
-	 * Publishes a new artifact version based on the provided metadata.
-	 * <p>
-	 * This operation performs the release process for an artifact, which includes:
-	 * <ul>
-	 *   <li>Validating artifact coordinates and metadata</li>
-	 *   <li>Persisting the artifact version</li>
-	 *   <li>Registering associated property definitions</li>
-	 *   <li>Emitting a domain event indicating that a new artifact version has been released</li>
-	 * </ul>
-	 * <p>
-	 * Implementations should treat published artifact versions as immutable. Once a version has been
-	 * successfully published, its metadata and property definitions must not be modified.
-	 * <p>
-	 * The {@code artifactory.artifact-version.publication-created} domain event will be emitted after
-	 * a successful publication.
-	 * <p>
-	 * Publishing is restricted to owners that hold an active verification claim covering the artifact
-	 * {@code groupId}. The caller is expected to have already resolved the publishing namespace to
-	 * its {@link Owner}.
-	 *
-	 * @param owner the namespace publishing the artifact, can't {@literal null}
-	 * @param metadata the metadata describing the artifact version to publish, can't {@literal null}
-	 * @return the resulting {@link VersionedArtifact} representing the published artifact
-	 * @throws ArtifactVersionExistsException when an artifact with the same coordinates already exists
-	 * @throws ArtifactOwnershipMismatchException when the artifact already exists and is owned by a
-	 *         different namespace
-	 * @throws com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException when the owner does not hold
-	 *         an active verification claim covering the artifact {@code groupId}
-	 */
-	@DomainEventPublisher(publishes = "artifactory.artifact-version.publication-created")
-	VersionedArtifact publish(@NonNull Owner owner, @NonNull ArtifactMetadata metadata);
-
-	/**
-	 * Changes the {@link ArtifactVisibility} of the artifact identified by the given {@link ArtifactKey}.
-	 * <p>
-	 * Visibility is a {@code groupId}/{@code artifactId} level concern, not a version level one: it
-	 * applies to every {@link VersionedArtifact} published under those coordinates. Only the
-	 * namespace that owns the artifact may change its visibility. The caller is expected to have
-	 * already resolved the requesting namespace to its {@link Owner}.
-	 *
-	 * @param owner the namespace requesting the change, can't be {@literal null}
-	 * @param key the {@code groupId}/{@code artifactId} identity of the artifact, can't be {@literal null}
-	 * @param visibility the visibility to apply, can't be {@literal null}
-	 * @throws ArtifactDefinitionNotFoundException when no artifact exists for the given coordinates
-	 * @throws ArtifactOwnershipMismatchException when the given owner does not own the artifact
-	 */
-	void changeVisibility(@NonNull Owner owner, @NonNull ArtifactKey key, @NonNull ArtifactVisibility visibility);
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryAutoConfiguration.java
@@ -46,19 +46,29 @@ public class ArtifactoryAutoConfiguration implements WebMvcConfigurer {
 	}
 
 	@Bean
+	ArtifactoryQueries artifactoryQueries(DSLContext context, ArtifactoryConverters artifactoryConverters) {
+		return new ArtifactoryQueries(context, artifactoryConverters);
+	}
+
+	@Bean
 	MetadataStore metadataStore(@Value("${konfigyr.artifactory.metadata-store.root}") URI root) {
 		return new FileSystemMetadataStore(Path.of(root));
 	}
 
 	@Bean
 	@ConditionalOnMissingBean(Artifactory.class)
-	Artifactory defaultArtifactory(
-			DSLContext context,
+	Artifactory defaultArtifactory(ArtifactoryQueries queries) {
+		return new DefaultArtifactory(queries);
+	}
+
+	@Bean
+	@ConditionalOnMissingBean(Publications.class)
+	Publications defaultPublications(
 			MetadataStore store,
-			ArtifactoryConverters converters,
+			ArtifactoryQueries queries,
 			ApplicationEventPublisher eventPublisher,
 			GroupVerifications groupVerifications
 	) {
-		return new DefaultArtifactory(context, store, converters, eventPublisher, groupVerifications);
+		return new DefaultPublications(store, queries, groupVerifications, eventPublisher);
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryEvent.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryEvent.java
@@ -12,17 +12,30 @@ import org.jspecify.annotations.NonNull;
  * @since 1.0.0
  **/
 public abstract sealed class ArtifactoryEvent extends EntityEvent
-		permits ArtifactoryEvent.ArtifactEvent, ArtifactoryEvent.OwnershipTransferEvent {
+		permits ArtifactoryEvent.ArtifactEvent, ArtifactoryEvent.DefinitionEvent, ArtifactoryEvent.OwnershipTransferEvent {
 
-	protected ArtifactoryEvent(EntityId id) {
+	private final Owner owner;
+
+	protected ArtifactoryEvent(EntityId id, @NonNull Owner owner) {
 		super(id);
+		this.owner = owner;
+	}
+
+	/**
+	 * The owner of the {@code Artifact} that was the subject of the event.
+	 *
+	 * @return the artifact owner, never {@literal null}.
+	 */
+	@NonNull
+	public Owner owner() {
+		return this.owner;
 	}
 
 	/**
 	 * Abstract event type used for events related to a {@link VersionedArtifact}.
 	 */
 	public static sealed abstract class ArtifactEvent extends ArtifactoryEvent
-			permits PublicationCreated, PublicationCompleted, PublicationFailed {
+			permits PublicationCreated, PublicationCompleted, PublicationFailed, PublicationRetracted {
 
 		private final ArtifactCoordinates coordinates;
 
@@ -32,7 +45,7 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * @param artifact artifact version to create the event for, can't be {@literal null}.
 		 */
 		protected ArtifactEvent(@NonNull VersionedArtifact artifact) {
-			this(artifact.id(), artifact.coordinates());
+			this(artifact.id(), artifact.owner(), artifact.coordinates());
 		}
 
 		/**
@@ -40,10 +53,11 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * of the {@link VersionedArtifact} and it's coordinates.
 		 *
 		 * @param id entity identifier of the created artifact version, can't be {@literal null}.
+		 * @param owner the owner of the created artifact version, can't be {@literal null}.
 		 * @param coordinates the artifact coordinates of the created artifact version, can't be {@literal null}.
 		 */
-		protected ArtifactEvent(EntityId id, @NonNull ArtifactCoordinates coordinates) {
-			super(id);
+		protected ArtifactEvent(EntityId id, @NonNull Owner owner, @NonNull ArtifactCoordinates coordinates) {
+			super(id, owner);
 			this.coordinates = coordinates;
 		}
 
@@ -69,10 +83,11 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * {@link VersionedArtifact} that was just created by the {@link Artifactory}.
 		 *
 		 * @param id entity identifier of the created artifact version
+		 * @param owner the owner of the created artifact version that was just published
 		 * @param coordinates the artifact coordinates of the created artifact version
 		 */
-		public PublicationCreated(EntityId id, ArtifactCoordinates coordinates) {
-			super(id, coordinates);
+		public PublicationCreated(EntityId id, Owner owner, ArtifactCoordinates coordinates) {
+			super(id, owner, coordinates);
 		}
 	}
 
@@ -88,7 +103,7 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * @param artifact affected artifact version, can't be {@literal null}.
 		 */
 		public PublicationCompleted(VersionedArtifact artifact) {
-			this(artifact.id(), artifact.coordinates());
+			super(artifact);
 		}
 
 		/**
@@ -96,10 +111,11 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * {@link VersionedArtifact} that was successfully published by the {@link Artifactory}.
 		 *
 		 * @param id entity identifier of the artifact version
+		 * @param owner the owner of the artifact version
 		 * @param coordinates the artifact coordinates of the artifact version
 		 */
-		public PublicationCompleted(EntityId id, ArtifactCoordinates coordinates) {
-			super(id, coordinates);
+		public PublicationCompleted(EntityId id, Owner owner, ArtifactCoordinates coordinates) {
+			super(id, owner, coordinates);
 		}
 	}
 
@@ -115,7 +131,7 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * @param artifact affected artifact version, can't be {@literal null}.
 		 */
 		public PublicationFailed(VersionedArtifact artifact) {
-			this(artifact.id(), artifact.coordinates());
+			super(artifact);
 		}
 
 		/**
@@ -123,10 +139,111 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * {@link VersionedArtifact} that was could not be published by the {@link Artifactory}.
 		 *
 		 * @param id entity identifier of the artifact version
+		 * @param owner the owner of the artifact version
 		 * @param coordinates the artifact coordinates of the artifact version
 		 */
-		public PublicationFailed(EntityId id, ArtifactCoordinates coordinates) {
-			super(id, coordinates);
+		public PublicationFailed(EntityId id, Owner owner, ArtifactCoordinates coordinates) {
+			super(id, owner, coordinates);
+		}
+	}
+
+	/**
+	 * Event that would be published when a previously published {@link VersionedArtifact} is retracted.
+	 */
+	@DomainEvent(name = "artifact-version.publication-retracted", namespace = "artifactory")
+	public static final class PublicationRetracted extends ArtifactEvent {
+
+		/**
+		 * Create a new {@link PublicationRetracted} event for the {@link VersionedArtifact} that was retracted.
+		 *
+		 * @param id entity identifier of the retracted artifact version, can't be {@literal null}.
+		 * @param owner the owner of the retracted artifact version
+		 * @param coordinates the artifact coordinates of the retracted artifact version, can't be {@literal null}.
+		 */
+		public PublicationRetracted(EntityId id, @NonNull Owner owner, @NonNull ArtifactCoordinates coordinates) {
+			super(id, owner, coordinates);
+		}
+	}
+
+	/**
+	 * Abstract event type used for events related to an {@link ArtifactDefinition}.
+	 */
+	public static sealed abstract class DefinitionEvent extends ArtifactoryEvent
+			permits Deregistered, VisibilityChanged {
+
+		private final ArtifactKey key;
+
+		/**
+		 * Create a new {@link DefinitionEvent} event for the {@link ArtifactDefinition}.
+		 *
+		 * @param id entity identifier of the affected artifact definition, can't be {@literal null}.
+		 * @param owner the owner of the affected artifact definition
+		 * @param key the {@code groupId}/{@code artifactId} identity of the affected artifact, can't be {@literal null}.
+		 */
+		protected DefinitionEvent(EntityId id, @NonNull Owner owner, @NonNull ArtifactKey key) {
+			super(id, owner);
+			this.key = key;
+		}
+
+		/**
+		 * Returns the {@link ArtifactKey} of the affected {@link ArtifactDefinition}.
+		 *
+		 * @return artifact key, never {@literal null}.
+		 */
+		@NonNull
+		public ArtifactKey key() {
+			return key;
+		}
+	}
+
+	/**
+	 * Event that would be published when an {@link ArtifactDefinition}, together with every
+	 * {@link VersionedArtifact} published under it, is deregistered from the registry.
+	 */
+	@DomainEvent(name = "artifact-definition.deregistered", namespace = "artifactory")
+	public static final class Deregistered extends DefinitionEvent {
+
+		/**
+		 * Create a new {@link Deregistered} event for the {@link ArtifactDefinition} that was removed.
+		 *
+		 * @param id entity identifier of the deregistered artifact definition, can't be {@literal null}.
+		 * @param owner the owner of the deregistered artifact definition
+		 * @param key the {@code groupId}/{@code artifactId} identity of the deregistered artifact, can't be {@literal null}.
+		 */
+		public Deregistered(EntityId id, @NonNull Owner owner, @NonNull ArtifactKey key) {
+			super(id, owner, key);
+		}
+	}
+
+	/**
+	 * Event that would be published when the {@link ArtifactVisibility} of an {@link ArtifactDefinition} changes.
+	 */
+	@DomainEvent(name = "artifact-definition.visibility-changed", namespace = "artifactory")
+	public static final class VisibilityChanged extends DefinitionEvent {
+
+		private final ArtifactVisibility visibility;
+
+		/**
+		 * Create a new {@link VisibilityChanged} event for the {@link ArtifactDefinition} whose visibility changed.
+		 *
+		 * @param id entity identifier of the affected artifact definition, can't be {@literal null}.
+		 * @param owner the owner of the affected artifact definition
+		 * @param key the {@code groupId}/{@code artifactId} identity of the affected artifact, can't be {@literal null}.
+		 * @param visibility the {@link ArtifactVisibility} that was applied, can't be {@literal null}.
+		 */
+		public VisibilityChanged(EntityId id, @NonNull Owner owner, @NonNull ArtifactKey key, @NonNull ArtifactVisibility visibility) {
+			super(id, owner, key);
+			this.visibility = visibility;
+		}
+
+		/**
+		 * Returns the {@link ArtifactVisibility} that was applied to the affected {@link ArtifactDefinition}.
+		 *
+		 * @return the new visibility, never {@literal null}.
+		 */
+		@NonNull
+		public ArtifactVisibility visibility() {
+			return visibility;
 		}
 	}
 
@@ -150,7 +267,7 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		 * @param to the namespace that requested ownership of the affected artifacts, can't be {@literal null}.
 		 */
 		protected OwnershipTransferEvent(EntityId id, @NonNull String groupId, @NonNull Owner from, @NonNull Owner to) {
-			super(id);
+			super(id, from);
 			this.groupId = groupId;
 			this.from = from;
 			this.to = to;

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryQueries.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryQueries.java
@@ -1,0 +1,197 @@
+package com.konfigyr.artifactory;
+
+import com.konfigyr.data.PageableExecutor;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.io.ByteArray;
+import lombok.RequiredArgsConstructor;
+import org.jooq.*;
+import org.jooq.Record;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
+import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
+import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
+import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
+import static com.konfigyr.data.tables.PropertyDefinitions.PROPERTY_DEFINITIONS;
+
+@NullMarked
+@RequiredArgsConstructor
+final class ArtifactoryQueries {
+
+	private static final PageableExecutor artifactDefinitionPageableExecutor = PageableExecutor.builder()
+			.defaultSortField(ARTIFACTS.CREATED_AT.desc())
+			.sortField("name", ARTIFACTS.NAME)
+			.sortField("groupId", ARTIFACTS.GROUP_ID)
+			.sortField("artifactId", ARTIFACTS.ARTIFACT_ID)
+			.build();
+
+	private static final PageableExecutor versionedArtifactPageableExecutor = PageableExecutor.builder()
+			.defaultSortField(ARTIFACT_VERSIONS.RELEASED_AT.desc())
+			.sortField("date", ARTIFACT_VERSIONS.RELEASED_AT)
+			.sortField("name", ARTIFACTS.NAME)
+			.sortField("groupId", ARTIFACTS.GROUP_ID)
+			.sortField("artifactId", ARTIFACTS.ARTIFACT_ID)
+			.sortField("version", ARTIFACT_VERSIONS.VERSION)
+			.build();
+
+	private static final PageableExecutor propertySearchPageableExecutor = PageableExecutor.builder()
+			.defaultSortField(PROPERTY_DEFINITIONS.NAME.asc())
+			.sortField("name", PROPERTY_DEFINITIONS.NAME)
+			.build();
+
+	private final DSLContext context;
+	private final ArtifactoryConverters converters;
+
+	DSLContext context() {
+		return context;
+	}
+
+	ArtifactoryConverters converters() {
+		return converters;
+	}
+
+	Page<ArtifactDefinition> definitions(Condition condition, Pageable pageable) {
+		return artifactDefinitionPageableExecutor.execute(
+				createArtifactDefinitionQuery().where(condition),
+				ArtifactoryQueries::toArtifactDefinition,
+				pageable,
+				() -> context.fetchCount(createArtifactDefinitionQuery().where(condition))
+		);
+	}
+
+	Optional<ArtifactDefinition> definition(Condition condition) {
+		return createArtifactDefinitionQuery()
+				.where(condition)
+				.fetchOptional(ArtifactoryQueries::toArtifactDefinition);
+	}
+
+	Page<VersionedArtifact> versions(Condition condition, Pageable pageable) {
+		return versionedArtifactPageableExecutor.execute(
+				createVersionedArtifactQuery().where(condition),
+				ArtifactoryQueries::toVersionedArtifact,
+				pageable,
+				() -> context.fetchCount(createVersionedArtifactQuery().where(condition))
+		);
+	}
+
+	Optional<VersionedArtifact> version(Condition condition) {
+		return createVersionedArtifactQuery()
+				.where(condition)
+				.fetchOptional(ArtifactoryQueries::toVersionedArtifact);
+	}
+
+	Page<PropertyDefinition> properties(Condition condition, Pageable pageable) {
+		return propertySearchPageableExecutor.execute(
+				createPropertySearchQuery().where(condition),
+				record -> toPropertyDefinition(record, converters),
+				pageable,
+				() -> context.fetchCount(createPropertySearchQuery().where(condition))
+		);
+	}
+
+	Optional<PropertyDefinition> property(Condition condition) {
+		return createPropertySearchQuery()
+				.where(condition)
+				.fetchOptional(record -> toPropertyDefinition(record, converters));
+	}
+
+	SelectJoinStep<? extends Record> createArtifactDefinitionQuery() {
+		return context.select(ARTIFACTS.fields())
+				.select(NAMESPACES.ID, NAMESPACES.SLUG)
+				.from(ARTIFACTS)
+				.innerJoin(NAMESPACES)
+				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
+	}
+
+	SelectJoinStep<? extends Record> createVersionedArtifactQuery() {
+		return context.select(ARTIFACT_VERSIONS.fields())
+				.select(ARTIFACTS.ID, ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, ARTIFACTS.VISIBILITY,
+						ARTIFACTS.NAME, ARTIFACTS.DESCRIPTION, ARTIFACTS.WEBSITE, ARTIFACTS.REPOSITORY)
+				.select(NAMESPACES.ID, NAMESPACES.SLUG)
+				.from(ARTIFACT_VERSIONS)
+				.innerJoin(ARTIFACTS)
+				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
+				.innerJoin(NAMESPACES)
+				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
+	}
+
+	SelectJoinStep<? extends Record> createPropertySearchQuery() {
+		return context.select(PROPERTY_DEFINITIONS.fields())
+				.select(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, NAMESPACES.ID, NAMESPACES.SLUG)
+				.from(PROPERTY_DEFINITIONS)
+				.innerJoin(ARTIFACTS)
+				.on(ARTIFACTS.ID.eq(PROPERTY_DEFINITIONS.ARTIFACT_ID))
+				.innerJoin(NAMESPACES)
+				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
+	}
+
+	static Owner toOwner(Record record) {
+		return new Owner(
+				record.get(NAMESPACES.ID, EntityId.class),
+				record.get(NAMESPACES.SLUG)
+		);
+	}
+
+	static ArtifactDefinition toArtifactDefinition(Record record) {
+		return ArtifactDefinition.builder()
+				.id(record.get(ARTIFACTS.ID))
+				.owner(toOwner(record))
+				.groupId(record.get(ARTIFACTS.GROUP_ID))
+				.artifactId(record.get(ARTIFACTS.ARTIFACT_ID))
+				.visibility(record.get(ARTIFACTS.VISIBILITY, ArtifactVisibility.class))
+				.name(record.get(ARTIFACTS.NAME))
+				.description(record.get(ARTIFACTS.DESCRIPTION))
+				.website(record.get(ARTIFACTS.WEBSITE))
+				.repository(record.get(ARTIFACTS.REPOSITORY))
+				.createdAt(record.get(ARTIFACTS.CREATED_AT))
+				.updatedAt(record.get(ARTIFACTS.UPDATED_AT))
+				.build();
+	}
+
+	static VersionedArtifact toVersionedArtifact(Record record) {
+		return toVersionedArtifact(record, toOwner(record));
+	}
+
+	static VersionedArtifact toVersionedArtifact(Record record, Owner owner) {
+		return VersionedArtifact.builder()
+				.id(record.get(ARTIFACT_VERSIONS.ID))
+				.artifact(record.get(ARTIFACT_VERSIONS.ARTIFACT_ID))
+				.owner(owner)
+				.groupId(record.get(ARTIFACTS.GROUP_ID))
+				.artifactId(record.get(ARTIFACTS.ARTIFACT_ID))
+				.visibility(record.get(ARTIFACTS.VISIBILITY, ArtifactVisibility.class))
+				.version(record.get(ARTIFACT_VERSIONS.VERSION))
+				.state(record.get(ARTIFACT_VERSIONS.STATE, PublicationState.class))
+				.checksum(record.get(ARTIFACT_VERSIONS.CHECKSUM, Converter.from(ByteArray.class, String.class, ByteArray::encodeHex)))
+				.name(record.get(ARTIFACTS.NAME))
+				.description(record.get(ARTIFACTS.DESCRIPTION))
+				.website(record.get(ARTIFACTS.WEBSITE))
+				.repository(record.get(ARTIFACTS.REPOSITORY))
+				.publishedAt(record.get(ARTIFACT_VERSIONS.RELEASED_AT))
+				.build();
+	}
+
+	static PropertyDefinition toPropertyDefinition(Record record, ArtifactoryConverters converters) {
+		return PropertyDefinition.builder()
+				.id(record.get(PROPERTY_DEFINITIONS.ID))
+				.artifact(record.get(PROPERTY_DEFINITIONS.ARTIFACT_ID))
+				.groupId(record.get(ARTIFACTS.GROUP_ID))
+				.artifactId(record.get(ARTIFACTS.ARTIFACT_ID))
+				.owner(toOwner(record))
+				.checksum(record.get(PROPERTY_DEFINITIONS.CHECKSUM))
+				.name(record.get(PROPERTY_DEFINITIONS.NAME))
+				.typeName(record.get(PROPERTY_DEFINITIONS.TYPE_NAME))
+				.defaultValue(record.get(PROPERTY_DEFINITIONS.DEFAULT_VALUE))
+				.description(record.get(PROPERTY_DEFINITIONS.DESCRIPTION))
+				.schema(record.get(PROPERTY_DEFINITIONS.SCHEMA, converters.schema()))
+				.deprecation(record.get(PROPERTY_DEFINITIONS.DEPRECATION, converters.deprecation()))
+				.occurrences(record.get(PROPERTY_DEFINITIONS.OCCURRENCES))
+				.firstSeen(record.get(PROPERTY_DEFINITIONS.FIRST_SEEN))
+				.lastSeen(record.get(PROPERTY_DEFINITIONS.LAST_SEEN))
+				.build();
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
@@ -1,35 +1,13 @@
 package com.konfigyr.artifactory;
 
-import com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException;
-import com.konfigyr.artifactory.ownership.GroupVerifications;
-import com.konfigyr.artifactory.store.MetadataStore;
-import com.konfigyr.data.Keys;
-import com.konfigyr.data.SettableRecord;
-import com.konfigyr.entity.EntityId;
-import com.konfigyr.io.ByteArray;
-import io.micrometer.observation.annotation.ObservationKeyValue;
-import io.micrometer.observation.annotation.Observed;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.jooq.Condition;
-import org.jooq.Converter;
-import org.jooq.DSLContext;
-import org.jooq.Record;
-import org.jooq.SelectJoinStep;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.Resource;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.Assert;
 
-import java.security.DigestOutputStream;
-import java.security.MessageDigest;
-import java.time.Instant;
-import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -38,71 +16,58 @@ import java.util.Set;
 import static com.konfigyr.data.tables.ArtifactVersionProperties.ARTIFACT_VERSION_PROPERTIES;
 import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
 import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
-import static com.konfigyr.data.tables.Namespaces.NAMESPACES;
 import static com.konfigyr.data.tables.PropertyDefinitions.PROPERTY_DEFINITIONS;
 
 @Slf4j
 @RequiredArgsConstructor
 class DefaultArtifactory implements Artifactory {
 
-	private final DSLContext context;
-	private final MetadataStore store;
-	private final ArtifactoryConverters converters;
-	private final ApplicationEventPublisher eventPublisher;
-	private final GroupVerifications groupVerifications;
+	private final ArtifactoryQueries queries;
 
 	@NonNull
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.get-artifact-definition")
 	public Optional<ArtifactDefinition> get(@NonNull ArtifactKey key) {
-		return createArtifactDefinitionQuery()
-				.where(toCondition(key))
-				.fetchOptional(DefaultArtifactory::toArtifactDefinition);
+		return queries.definition(toCondition(key));
 	}
 
 	@NonNull
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.get-visible-artifact-definition")
 	public Optional<ArtifactDefinition> get(@Nullable Owner owner, @NonNull ArtifactKey key) {
-		return createArtifactDefinitionQuery()
-				.where(DSL.and(visibilityCondition(owner), toCondition(key)))
-				.fetchOptional(DefaultArtifactory::toArtifactDefinition);
+		return queries.definition(DSL.and(visibilityCondition(owner), toCondition(key)));
 	}
 
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.artifact-key-exists")
 	public boolean exists(@NonNull ArtifactKey key) {
-		return context.fetchExists(ARTIFACTS, toCondition(key));
+		return queries.context().fetchExists(ARTIFACTS, toCondition(key));
 	}
 
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.visible-artifact-key-exists")
 	public boolean exists(@Nullable Owner owner, @NonNull ArtifactKey key) {
-		return context.fetchExists(ARTIFACTS, DSL.and(toCondition(key), visibilityCondition(owner)));
+		return queries.context().fetchExists(ARTIFACTS, DSL.and(toCondition(key), visibilityCondition(owner)));
 	}
 
 	@NonNull
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.get-versioned-artifact")
 	public Optional<VersionedArtifact> get(@NonNull ArtifactCoordinates coordinates) {
-		return createVersionedArtifactQuery()
-				.where(toCondition(coordinates))
-				.fetchOptional(DefaultArtifactory::toVersionedArtifact);
+		return queries.version(toCondition(coordinates));
 	}
 
 	@NonNull
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.get-visible-versioned-artifact")
 	public Optional<VersionedArtifact> get(@Nullable Owner owner, @NonNull ArtifactCoordinates coordinates) {
-		return createVersionedArtifactQuery()
-				.where(DSL.and(toCondition(coordinates), visibilityCondition(owner)))
-				.fetchOptional(DefaultArtifactory::toVersionedArtifact);
+		return queries.version(DSL.and(toCondition(coordinates), visibilityCondition(owner)));
 	}
 
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.coordinates-exists")
 	public boolean exists(@NonNull ArtifactCoordinates coordinates) {
-		return context.fetchExists(
+		return queries.context().fetchExists(
 				DSL.select(ARTIFACT_VERSIONS.ID)
 						.from(ARTIFACT_VERSIONS)
 						.innerJoin(ARTIFACTS)
@@ -114,7 +79,7 @@ class DefaultArtifactory implements Artifactory {
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.visible-coordinates-exists")
 	public boolean exists(@Nullable Owner owner, @NonNull ArtifactCoordinates coordinates) {
-		return context.fetchExists(
+		return queries.context().fetchExists(
 				DSL.select(ARTIFACT_VERSIONS.ID)
 						.from(ARTIFACT_VERSIONS)
 						.innerJoin(ARTIFACTS)
@@ -135,7 +100,7 @@ class DefaultArtifactory implements Artifactory {
 		final String[] artifactIds = coordinates.stream().map(ArtifactCoordinates::artifactId).toArray(String[]::new);
 		final String[] versions = coordinates.stream().map(coordinate -> coordinate.version().get()).toArray(String[]::new);
 
-		return createVersionedArtifactQuery()
+		return queries.createVersionedArtifactQuery()
 				.where(DSL.and(
 						DSL.row(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, ARTIFACT_VERSIONS.VERSION)
 								.in(DSL.select(DSL.field("g", String.class), DSL.field("a", String.class), DSL.field("v", String.class))
@@ -143,111 +108,14 @@ class DefaultArtifactory implements Artifactory {
 												groupIds, artifactIds, versions)),
 						visibilityCondition(owner)
 				))
-				.fetchSet(DefaultArtifactory::toVersionedArtifact);
-	}
-
-	@Override
-	@Observed(name = "konfigyr.artifactory.release")
-	@Transactional(label = "artifactory.release-artifact-component")
-	public VersionedArtifact publish(
-			@NonNull Owner owner,
-			@NonNull
-			@ObservationKeyValue(key = "konfigyr.artifactory.artifact", expression = "#this")
-			ArtifactMetadata metadata
-	) {
-		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(metadata);
-
-		if (exists(coordinates)) {
-			throw new ArtifactVersionExistsException(coordinates);
-		}
-
-		assertCanRelease(owner, metadata.groupId());
-		assertSameOwner(owner, coordinates);
-
-		final ByteArray checksum;
-		final Resource resource;
-
-		try (ByteArrayOutputStream os = new ByteArrayOutputStream(metadata.properties().size() * 128)) {
-			final DigestOutputStream dos = new DigestOutputStream(os, MessageDigest.getInstance("SHA-256"));
-			converters.mapper().writeValue(dos, metadata.properties());
-
-			resource = new ByteArrayResource(os.toByteArray(), coordinates.format() + ".json");
-			checksum = new ByteArray(dos.getMessageDigest().digest());
-		} catch (Exception ex) {
-			throw new ArtifactoryException("Unexpected error occurred while calculating metadata checksum for artifact: " + coordinates.format(), ex);
-		}
-
-		final Record artifactRecord = context.insertInto(ARTIFACTS)
-				.set(
-						SettableRecord.of(context, ARTIFACTS)
-								.set(ARTIFACTS.ID, EntityId.generate().map(EntityId::get))
-								.set(ARTIFACTS.NAMESPACE_ID, owner.id().get())
-								.set(ARTIFACTS.GROUP_ID, coordinates.groupId())
-								.set(ARTIFACTS.ARTIFACT_ID, coordinates.artifactId())
-								.set(ARTIFACTS.VISIBILITY, ArtifactVisibility.PRIVATE.name())
-								.set(ARTIFACTS.NAME, metadata.name())
-								.set(ARTIFACTS.DESCRIPTION, metadata.description())
-								.set(ARTIFACTS.WEBSITE, metadata.website(), converters.uri())
-								.set(ARTIFACTS.REPOSITORY, metadata.repository(), converters.uri())
-								.set(ARTIFACTS.CREATED_AT, OffsetDateTime.now())
-								.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
-								.get()
-				)
-				.onConflictOnConstraint(Keys.UNIQUE_ARTIFACT)
-				.doUpdate()
-				.set(ARTIFACTS.NAME, metadata.name())
-				.set(ARTIFACTS.DESCRIPTION, metadata.description())
-				.set(ARTIFACTS.WEBSITE, converters.uri().to(metadata.website()))
-				.set(ARTIFACTS.REPOSITORY, converters.uri().to(metadata.repository()))
-				.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
-				.returning(ARTIFACTS.ID, ARTIFACTS.VISIBILITY)
-				.fetchOne();
-
-		Assert.state(artifactRecord != null, "Failed to insert new artifact record");
-
-		final Long artifactId = artifactRecord.get(ARTIFACTS.ID);
-		final ArtifactVisibility visibility = artifactRecord.get(ARTIFACTS.VISIBILITY, ArtifactVisibility.class);
-
-		final Long artifactVersionId = context.insertInto(ARTIFACT_VERSIONS)
-				.set(
-						SettableRecord.of(context, ARTIFACT_VERSIONS)
-								.set(ARTIFACT_VERSIONS.ID, EntityId.generate().map(EntityId::get))
-								.set(ARTIFACT_VERSIONS.ARTIFACT_ID, artifactId)
-								.set(ARTIFACT_VERSIONS.VERSION, coordinates.version().get())
-								.set(ARTIFACT_VERSIONS.STATE, ReleaseState.PENDING.name())
-								.set(ARTIFACT_VERSIONS.CHECKSUM, checksum)
-								.set(ARTIFACT_VERSIONS.RELEASED_AT, OffsetDateTime.now())
-								.get()
-				)
-				.returning(ARTIFACT_VERSIONS.ID)
-				.fetchOne(ARTIFACT_VERSIONS.ID);
-
-		Assert.state(artifactVersionId != null, "Failed to insert new artifact version record");
-
-		try {
-			store.save(coordinates, resource);
-		} catch (Exception ex) {
-			throw new ArtifactoryException("Unexpected error occurred while storing metadata for artifact: " + coordinates.format(), ex);
-		}
-
-		eventPublisher.publishEvent(new ArtifactoryEvent.PublicationCreated(EntityId.from(artifactVersionId), coordinates));
-
-		return VersionedArtifact.from(metadata)
-				.id(artifactVersionId)
-				.artifact(artifactId)
-				.owner(owner)
-				.visibility(visibility)
-				.state(PublicationState.PENDING)
-				.checksum(checksum.encodeHex())
-				.publishedAt(Instant.now())
-				.build();
+				.fetchSet(ArtifactoryQueries::toVersionedArtifact);
 	}
 
 	@NonNull
 	@Override
 	@Transactional(readOnly = true, label = "artifactory.version-properties")
 	public List<PropertyDefinition> properties(@NonNull ArtifactCoordinates coordinates) {
-		final Long artifactVersionId = context.select(ARTIFACT_VERSIONS.ID)
+		final Long artifactVersionId = queries.context().select(ARTIFACT_VERSIONS.ID)
 				.from(ARTIFACT_VERSIONS)
 				.innerJoin(ARTIFACTS)
 				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
@@ -255,102 +123,11 @@ class DefaultArtifactory implements Artifactory {
 				.fetchOptional(ARTIFACT_VERSIONS.ID)
 				.orElseThrow(() -> new ArtifactVersionNotFoundException(coordinates));
 
-		return createPropertySearchQuery()
+		return queries.createPropertySearchQuery()
 				.innerJoin(ARTIFACT_VERSION_PROPERTIES)
 				.on(PROPERTY_DEFINITIONS.ID.eq(ARTIFACT_VERSION_PROPERTIES.PROPERTY_DEFINITION_ID))
 				.where(ARTIFACT_VERSION_PROPERTIES.ARTIFACT_VERSION_ID.eq(artifactVersionId))
-				.fetch(record -> toPropertyDefinition(record, converters));
-	}
-
-	@Override
-	@Transactional(label = "artifactory.change-visibility")
-	public void changeVisibility(
-			@NonNull Owner owner,
-			@NonNull ArtifactKey key,
-			@NonNull ArtifactVisibility visibility
-	) {
-		final Long existingOwnerId = context.select(ARTIFACTS.NAMESPACE_ID)
-				.from(ARTIFACTS)
-				.where(toCondition(key))
-				.fetchOptional(ARTIFACTS.NAMESPACE_ID)
-				.orElseThrow(() -> new ArtifactDefinitionNotFoundException(key));
-
-		if (!existingOwnerId.equals(owner.id().get())) {
-			throw new ArtifactOwnershipMismatchException(key, owner);
-		}
-
-		context.update(ARTIFACTS)
-				.set(ARTIFACTS.VISIBILITY, visibility.name())
-				.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
-				.where(toCondition(key))
-				.execute();
-	}
-
-	@NonNull
-	private SelectJoinStep<? extends Record> createArtifactDefinitionQuery() {
-		return context.select(ARTIFACTS.fields())
-				.select(NAMESPACES.ID, NAMESPACES.SLUG)
-				.from(ARTIFACTS)
-				.innerJoin(NAMESPACES)
-				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
-	}
-
-	@NonNull
-	private SelectJoinStep<? extends Record> createVersionedArtifactQuery() {
-		return context.select(
-						ARTIFACT_VERSIONS.ID,
-						ARTIFACT_VERSIONS.STATE,
-						ARTIFACT_VERSIONS.CHECKSUM,
-						ARTIFACTS.ID,
-						ARTIFACTS.GROUP_ID,
-						ARTIFACTS.ARTIFACT_ID,
-						ARTIFACTS.VISIBILITY,
-						NAMESPACES.ID,
-						NAMESPACES.SLUG,
-						ARTIFACT_VERSIONS.VERSION,
-						ARTIFACTS.NAME,
-						ARTIFACTS.DESCRIPTION,
-						ARTIFACTS.WEBSITE,
-						ARTIFACTS.REPOSITORY,
-						ARTIFACT_VERSIONS.RELEASED_AT
-				)
-				.from(ARTIFACT_VERSIONS)
-				.innerJoin(ARTIFACTS)
-				.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
-				.innerJoin(NAMESPACES)
-				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
-	}
-
-	@NonNull
-	private SelectJoinStep<? extends Record> createPropertySearchQuery() {
-		return context.select(PROPERTY_DEFINITIONS.fields())
-				.select(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, NAMESPACES.ID, NAMESPACES.SLUG)
-				.from(PROPERTY_DEFINITIONS)
-				.innerJoin(ARTIFACTS)
-				.on(ARTIFACTS.ID.eq(PROPERTY_DEFINITIONS.ARTIFACT_ID))
-				.innerJoin(NAMESPACES)
-				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
-	}
-
-	private void assertCanRelease(Owner owner, String groupId) {
-		groupVerifications.findActiveCovering(owner, groupId)
-				.orElseThrow(() -> new GroupIdNotVerifiedException(groupId, owner));
-	}
-
-	private void assertSameOwner(Owner owner, ArtifactCoordinates coordinates) {
-		final boolean ownedByAnotherNamespace = context.fetchExists(
-				DSL.select(ARTIFACTS.ID)
-						.from(ARTIFACTS)
-						.where(
-								ARTIFACTS.GROUP_ID.eq(coordinates.groupId()),
-								ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()),
-								ARTIFACTS.NAMESPACE_ID.ne(owner.id().get())
-						)
-		);
-
-		if (ownedByAnotherNamespace) {
-			throw new ArtifactOwnershipMismatchException(coordinates, owner);
-		}
+				.fetch(record -> ArtifactoryQueries.toPropertyDefinition(record, queries.converters()));
 	}
 
 	@NonNull
@@ -380,68 +157,5 @@ class DefaultArtifactory implements Artifactory {
 				ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()),
 				ARTIFACT_VERSIONS.VERSION.eq(coordinates.version().get())
 		);
-	}
-
-	static Owner toOwner(Record record) {
-		return new Owner(record.get(NAMESPACES.ID, EntityId.class), record.get(NAMESPACES.SLUG));
-	}
-
-	static ArtifactDefinition toArtifactDefinition(Record record) {
-		return ArtifactDefinition.builder()
-				.id(record.get(ARTIFACTS.ID))
-				.owner(toOwner(record))
-				.groupId(record.get(ARTIFACTS.GROUP_ID))
-				.artifactId(record.get(ARTIFACTS.ARTIFACT_ID))
-				.visibility(record.get(ARTIFACTS.VISIBILITY, ArtifactVisibility.class))
-				.name(record.get(ARTIFACTS.NAME))
-				.description(record.get(ARTIFACTS.DESCRIPTION))
-				.website(record.get(ARTIFACTS.WEBSITE))
-				.repository(record.get(ARTIFACTS.REPOSITORY))
-				.createdAt(record.get(ARTIFACTS.CREATED_AT))
-				.updatedAt(record.get(ARTIFACTS.UPDATED_AT))
-				.build();
-	}
-
-	static VersionedArtifact toVersionedArtifact(Record record) {
-		return toVersionedArtifact(record, toOwner(record));
-	}
-
-	static VersionedArtifact toVersionedArtifact(Record record, Owner owner) {
-		return VersionedArtifact.builder()
-				.id(record.get(ARTIFACT_VERSIONS.ID))
-				.artifact(record.get(ARTIFACTS.ID))
-				.owner(owner)
-				.groupId(record.get(ARTIFACTS.GROUP_ID))
-				.artifactId(record.get(ARTIFACTS.ARTIFACT_ID))
-				.visibility(record.get(ARTIFACTS.VISIBILITY, ArtifactVisibility.class))
-				.version(record.get(ARTIFACT_VERSIONS.VERSION))
-				.state(record.get(ARTIFACT_VERSIONS.STATE, PublicationState.class))
-				.checksum(record.get(ARTIFACT_VERSIONS.CHECKSUM, Converter.from(ByteArray.class, String.class, ByteArray::encodeHex)))
-				.name(record.get(ARTIFACTS.NAME))
-				.description(record.get(ARTIFACTS.DESCRIPTION))
-				.website(record.get(ARTIFACTS.WEBSITE))
-				.repository(record.get(ARTIFACTS.REPOSITORY))
-				.publishedAt(record.get(ARTIFACT_VERSIONS.RELEASED_AT))
-				.build();
-	}
-
-	static PropertyDefinition toPropertyDefinition(Record record, ArtifactoryConverters converters) {
-		return PropertyDefinition.builder()
-				.id(record.get(PROPERTY_DEFINITIONS.ID))
-				.artifact(record.get(PROPERTY_DEFINITIONS.ARTIFACT_ID))
-				.groupId(record.get(ARTIFACTS.GROUP_ID))
-				.artifactId(record.get(ARTIFACTS.ARTIFACT_ID))
-				.owner(toOwner(record))
-				.checksum(record.get(PROPERTY_DEFINITIONS.CHECKSUM))
-				.name(record.get(PROPERTY_DEFINITIONS.NAME))
-				.typeName(record.get(PROPERTY_DEFINITIONS.TYPE_NAME))
-				.defaultValue(record.get(PROPERTY_DEFINITIONS.DEFAULT_VALUE))
-				.description(record.get(PROPERTY_DEFINITIONS.DESCRIPTION))
-				.schema(record.get(PROPERTY_DEFINITIONS.SCHEMA, converters.schema()))
-				.deprecation(record.get(PROPERTY_DEFINITIONS.DEPRECATION, converters.deprecation()))
-				.occurrences(record.get(PROPERTY_DEFINITIONS.OCCURRENCES))
-				.firstSeen(record.get(PROPERTY_DEFINITIONS.FIRST_SEEN))
-				.lastSeen(record.get(PROPERTY_DEFINITIONS.LAST_SEEN))
-				.build();
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultPublications.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultPublications.java
@@ -1,0 +1,321 @@
+package com.konfigyr.artifactory;
+
+import com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException;
+import com.konfigyr.artifactory.ownership.GroupVerifications;
+import com.konfigyr.artifactory.store.MetadataStore;
+import com.konfigyr.data.Keys;
+import com.konfigyr.data.SettableRecord;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.io.ByteArray;
+import com.konfigyr.support.SearchQuery;
+import io.micrometer.observation.annotation.ObservationKeyValue;
+import io.micrometer.observation.annotation.Observed;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.jooq.Condition;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.Resource;
+import org.springframework.data.domain.Page;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.Assert;
+
+import java.security.DigestOutputStream;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
+import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
+
+@Slf4j
+@NullMarked
+@RequiredArgsConstructor
+public class DefaultPublications implements Publications {
+
+	private final MetadataStore store;
+	private final ArtifactoryQueries queries;
+	private final GroupVerifications verifications;
+	private final ApplicationEventPublisher eventPublisher;
+
+	@Override
+	@Transactional(readOnly = true, label = "artifactory.publications.search-artifact-definition")
+	public Page<ArtifactDefinition> artifacts(Owner owner, SearchQuery query) {
+		final List<Condition> conditions = new ArrayList<>();
+		conditions.add(toCondition(owner));
+
+		query.criteria(ArtifactKey.GROUP_ID_CRITERIA)
+				.map(ARTIFACTS.GROUP_ID::equalIgnoreCase)
+				.ifPresent(conditions::add);
+
+		query.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA)
+				.map(ARTIFACTS.ARTIFACT_ID::equalIgnoreCase)
+				.ifPresent(conditions::add);
+
+		query.term().ifPresent(term -> conditions.add(DSL.or(
+				ARTIFACTS.GROUP_ID.containsIgnoreCase(term),
+				ARTIFACTS.ARTIFACT_ID.containsIgnoreCase(term),
+				ARTIFACTS.NAME.containsIgnoreCase(term),
+				ARTIFACTS.DESCRIPTION.containsIgnoreCase(term)
+		)));
+
+		return queries.definitions(DSL.and(conditions), query.pageable());
+	}
+
+	@Override
+	@Transactional(readOnly = true, label = "artifactory.publications.get-artifact-definition")
+	public Optional<ArtifactDefinition> get(Owner owner, ArtifactKey key) {
+		return queries.definition(toCondition(owner, key));
+	}
+
+	@Override
+	@Transactional(readOnly = true, label = "artifactory.publications.artifact-definition-exists")
+	public boolean exists(Owner owner, ArtifactKey key) {
+		return queries.context().fetchExists(ARTIFACTS, toCondition(owner, key));
+	}
+
+	@Override
+	@Transactional(label = "artifactory.publications.deregister-artifact-definition")
+	public void deregister(Owner owner, ArtifactKey key) {
+		if (!exists(owner, key)) {
+			throw new ArtifactDefinitionNotFoundException(key);
+		}
+
+		final EntityId artifactId = queries.context().delete(ARTIFACTS)
+					.where(toCondition(owner, key))
+					.returning(ARTIFACTS.ID)
+					.fetchOne(ARTIFACTS.ID, EntityId.class);
+
+		Assert.state(artifactId != null, () -> "Failed to deregister artifact: %s".formatted(key.format()));
+		eventPublisher.publishEvent(new ArtifactoryEvent.Deregistered(artifactId, owner, key));
+	}
+
+	@Override
+	@Transactional(readOnly = true, label = "artifactory.publications.search-artifact-versions")
+	public Page<VersionedArtifact> versions(Owner owner, SearchQuery query) {
+		final List<Condition> conditions = new ArrayList<>();
+		conditions.add(toCondition(owner));
+
+		query.criteria(ArtifactKey.GROUP_ID_CRITERIA)
+				.map(ARTIFACTS.GROUP_ID::equalIgnoreCase)
+				.ifPresent(conditions::add);
+
+		query.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA)
+				.map(ARTIFACTS.ARTIFACT_ID::equalIgnoreCase)
+				.ifPresent(conditions::add);
+
+		query.criteria(ArtifactCoordinates.VERSION_CRITERIA)
+				.map(ARTIFACT_VERSIONS.VERSION::equalIgnoreCase)
+				.ifPresent(conditions::add);
+
+		query.term().ifPresent(term -> conditions.add(DSL.or(
+				ARTIFACTS.GROUP_ID.containsIgnoreCase(term),
+				ARTIFACTS.ARTIFACT_ID.containsIgnoreCase(term),
+				ARTIFACT_VERSIONS.VERSION.containsIgnoreCase(term),
+				ARTIFACTS.NAME.containsIgnoreCase(term),
+				ARTIFACTS.DESCRIPTION.containsIgnoreCase(term)
+		)));
+
+		return queries.versions(DSL.and(conditions), query.pageable());
+	}
+
+	@Override
+	@Transactional(readOnly = true, label = "artifactory.publications.get-artifact-version")
+	public Optional<VersionedArtifact> get(Owner owner, ArtifactCoordinates coordinates) {
+		return queries.version(toCondition(owner, coordinates));
+	}
+
+	@Override
+	@Transactional(readOnly = true, label = "artifactory.publications.artifact-version-exists")
+	public boolean exists(Owner owner, ArtifactCoordinates coordinates) {
+		return queries.context().fetchExists(
+				DSL.select(ARTIFACT_VERSIONS.ID)
+						.from(ARTIFACT_VERSIONS)
+						.innerJoin(ARTIFACTS)
+						.on(ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID))
+						.where(toCondition(owner, coordinates))
+		);
+	}
+
+	@Override
+	@Observed(name = "konfigyr.artifactory.release")
+	@Transactional(label = "artifactory.publications.publish-artifact-metadata")
+	public VersionedArtifact publish(
+			Owner owner,
+			@ObservationKeyValue(key = "konfigyr.artifactory.artifact", expression = "#this")
+			ArtifactMetadata metadata
+	) {
+		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(metadata);
+		final ArtifactoryConverters converters = queries.converters();
+
+		if (exists(owner, coordinates)) {
+			throw new ArtifactVersionExistsException(coordinates);
+		}
+
+		if (verifications.findActiveCovering(owner, coordinates.groupId()).isEmpty()) {
+			throw new GroupIdNotVerifiedException(coordinates.groupId(), owner);
+		}
+
+		assertSameOwner(owner, coordinates);
+
+		final ByteArray checksum;
+		final Resource resource;
+
+		try (ByteArrayOutputStream os = new ByteArrayOutputStream(metadata.properties().size() * 128)) {
+			final DigestOutputStream dos = new DigestOutputStream(os, MessageDigest.getInstance("SHA-256"));
+			converters.mapper().writeValue(dos, metadata.properties());
+
+			resource = new ByteArrayResource(os.toByteArray(), coordinates.format() + ".json");
+			checksum = new ByteArray(dos.getMessageDigest().digest());
+		} catch (Exception ex) {
+			throw new ArtifactoryException("Unexpected error occurred while calculating metadata checksum for artifact: " + coordinates.format(), ex);
+		}
+
+		final Record artifactRecord = queries.context().insertInto(ARTIFACTS)
+				.set(
+						SettableRecord.of(queries.context(), ARTIFACTS)
+								.set(ARTIFACTS.ID, EntityId.generate().map(EntityId::get))
+								.set(ARTIFACTS.NAMESPACE_ID, owner.id().get())
+								.set(ARTIFACTS.GROUP_ID, coordinates.groupId())
+								.set(ARTIFACTS.ARTIFACT_ID, coordinates.artifactId())
+								.set(ARTIFACTS.VISIBILITY, ArtifactVisibility.PRIVATE.name())
+								.set(ARTIFACTS.NAME, metadata.name())
+								.set(ARTIFACTS.DESCRIPTION, metadata.description())
+								.set(ARTIFACTS.WEBSITE, metadata.website(), converters.uri())
+								.set(ARTIFACTS.REPOSITORY, metadata.repository(), converters.uri())
+								.set(ARTIFACTS.CREATED_AT, OffsetDateTime.now())
+								.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
+								.get()
+				)
+				.onConflictOnConstraint(Keys.UNIQUE_ARTIFACT)
+				.doUpdate()
+				.set(ARTIFACTS.NAME, metadata.name())
+				.set(ARTIFACTS.DESCRIPTION, metadata.description())
+				.set(ARTIFACTS.WEBSITE, converters.uri().to(metadata.website()))
+				.set(ARTIFACTS.REPOSITORY, converters.uri().to(metadata.repository()))
+				.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
+				.returning(ARTIFACTS.ID, ARTIFACTS.VISIBILITY)
+				.fetchOne();
+
+		Assert.state(artifactRecord != null, "Failed to insert new artifact record");
+
+		final Long artifactId = artifactRecord.get(ARTIFACTS.ID);
+		final ArtifactVisibility visibility = artifactRecord.get(ARTIFACTS.VISIBILITY, ArtifactVisibility.class);
+
+		final EntityId artifactVersionId = queries.context().insertInto(ARTIFACT_VERSIONS)
+				.set(
+						SettableRecord.of(queries.context(), ARTIFACT_VERSIONS)
+								.set(ARTIFACT_VERSIONS.ID, EntityId.generate().map(EntityId::get))
+								.set(ARTIFACT_VERSIONS.ARTIFACT_ID, artifactId)
+								.set(ARTIFACT_VERSIONS.VERSION, coordinates.version().get())
+								.set(ARTIFACT_VERSIONS.STATE, ReleaseState.PENDING.name())
+								.set(ARTIFACT_VERSIONS.CHECKSUM, checksum)
+								.set(ARTIFACT_VERSIONS.RELEASED_AT, OffsetDateTime.now())
+								.get()
+				)
+				.returning(ARTIFACT_VERSIONS.ID)
+				.fetchOne(ARTIFACT_VERSIONS.ID, EntityId.class);
+
+		Assert.state(artifactVersionId != null, () -> "Failed to insert new artifact version record for: %s"
+				.formatted(coordinates.format()));
+
+		try {
+			store.save(coordinates, resource);
+		} catch (Exception ex) {
+			throw new ArtifactoryException("Unexpected error occurred while storing metadata for artifact: " + coordinates.format(), ex);
+		}
+
+		eventPublisher.publishEvent(new ArtifactoryEvent.PublicationCreated(artifactVersionId, owner, coordinates));
+
+		return VersionedArtifact.from(metadata)
+				.id(artifactVersionId)
+				.artifact(artifactId)
+				.owner(owner)
+				.visibility(visibility)
+				.state(PublicationState.PENDING)
+				.checksum(checksum.encodeHex())
+				.publishedAt(Instant.now())
+				.build();
+	}
+
+	@Override
+	@Transactional(label = "artifactory.publications.retract-artifact-version")
+	public void retract(Owner owner, ArtifactCoordinates coordinates) {
+		if (!exists(owner, coordinates)) {
+			throw new ArtifactVersionNotFoundException(coordinates);
+		}
+
+		final EntityId artifactVersionId = queries.context().delete(ARTIFACT_VERSIONS)
+					.using(ARTIFACTS)
+					.where(DSL.and(
+							ARTIFACTS.ID.eq(ARTIFACT_VERSIONS.ARTIFACT_ID),
+							toCondition(owner, coordinates)
+					))
+					.returning(ARTIFACT_VERSIONS.ID)
+					.fetchOne(ARTIFACT_VERSIONS.ID, EntityId.class);
+
+		Assert.state(artifactVersionId != null, () -> "Failed to retract artifact version: %s".formatted(coordinates.format()));
+		eventPublisher.publishEvent(new ArtifactoryEvent.PublicationRetracted(artifactVersionId, owner, coordinates));
+	}
+
+	@Override
+	@Transactional(label = "artifactory.publications.update-artifact-visibility")
+	public void changeVisibility(Owner owner, ArtifactKey key, ArtifactVisibility visibility) {
+		if (!exists(owner, key)) {
+			throw new ArtifactDefinitionNotFoundException(key);
+		}
+
+		final EntityId artifactId = queries.context().update(ARTIFACTS)
+				.set(ARTIFACTS.VISIBILITY, visibility.name())
+				.set(ARTIFACTS.UPDATED_AT, OffsetDateTime.now())
+				.where(toCondition(owner, key))
+				.returning(ARTIFACTS.ID)
+				.fetchOne(ARTIFACTS.ID, EntityId.class);
+
+		Assert.state(artifactId != null, () -> "Failed to update visibility for artifact: %s".formatted(key.format()));
+		eventPublisher.publishEvent(new ArtifactoryEvent.VisibilityChanged(artifactId, owner, key, visibility));
+	}
+
+	private void assertSameOwner(Owner owner, ArtifactCoordinates coordinates) {
+		final boolean ownedByAnotherNamespace = queries.context().fetchExists(
+				DSL.select(ARTIFACTS.ID)
+						.from(ARTIFACTS)
+						.where(
+								ARTIFACTS.GROUP_ID.eq(coordinates.groupId()),
+								ARTIFACTS.ARTIFACT_ID.eq(coordinates.artifactId()),
+								ARTIFACTS.NAMESPACE_ID.ne(owner.id().get())
+						)
+		);
+
+		if (ownedByAnotherNamespace) {
+			throw new ArtifactOwnershipMismatchException(coordinates, owner);
+		}
+	}
+
+	static Condition toCondition(Owner owner) {
+		return ARTIFACTS.NAMESPACE_ID.eq(owner.id().get());
+	}
+
+	static Condition toCondition(ArtifactKey key) {
+		final List<Condition> conditions = new ArrayList<>();
+		conditions.add(ARTIFACTS.GROUP_ID.eq(key.groupId()));
+		conditions.add(ARTIFACTS.ARTIFACT_ID.eq(key.artifactId()));
+
+		if (key instanceof ArtifactCoordinates coordinates) {
+			conditions.add(ARTIFACT_VERSIONS.VERSION.eq(coordinates.version().get()));
+		}
+
+		return DSL.and(conditions);
+	}
+
+	static Condition toCondition(Owner owner, ArtifactKey key) {
+		return DSL.and(toCondition(owner), toCondition(key));
+	}
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/Publications.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/Publications.java
@@ -1,0 +1,188 @@
+package com.konfigyr.artifactory;
+
+import com.konfigyr.support.SearchQuery;
+import org.jmolecules.event.annotation.DomainEventPublisher;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.data.domain.Page;
+
+import java.util.Optional;
+
+/**
+ * Interface that represents a namespace's own view onto the artifacts it manages within the
+ * {@code Artifactory} domain.
+ * <p>
+ * Where {@link Artifactory} answers "what can this caller see", a visibility-based view in which
+ * {@link ArtifactVisibility#PUBLIC PUBLIC} artifacts are visible to everyone and
+ * {@link ArtifactVisibility#PRIVATE PRIVATE} artifacts are visible only to their owner, {@code Publications}
+ * answers "what does this namespace own". Every operation on this interface is strictly scoped to the
+ * given {@link Owner}: a {@code PUBLIC} artifact owned by a different namespace is never returned, listed,
+ * or matched here, even though it would be visible through {@link Artifactory}.
+ * <p>
+ * Use {@link Artifactory} when resolving or consuming artifacts published by any namespace. Use
+ * {@code Publications} when managing a namespace's own registry: listing its artifacts, publishing new
+ * versions, changing visibility, or removing what it has published.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@NullMarked
+public interface Publications {
+
+	/**
+	 * Searches the {@link ArtifactDefinition artifact definitions} owned by the given namespace.
+	 * <p>
+	 * Unlike {@link Artifactory}, this is not a visibility-based lookup, only artifacts owned by
+	 * {@code owner} are matched, regardless of their {@link ArtifactVisibility}.
+	 *
+	 * @param owner the namespace whose artifacts are being searched, can't be {@literal null}
+	 * @param query the search query used to filter and page through the results, can't be {@literal null}
+	 * @return a page of {@link ArtifactDefinition artifact definitions} owned by {@code owner}, never {@literal null}
+	 */
+	Page<ArtifactDefinition> artifacts(Owner owner, SearchQuery query);
+
+	/**
+	 * Resolves the overview of an artifact owned by the given namespace.
+	 * <p>
+	 * Unlike {@link Artifactory#get(Owner, ArtifactKey)}, this lookup is strict: it only resolves when
+	 * {@code owner} is the actual owner of the artifact. A {@code PUBLIC} artifact owned by a different
+	 * namespace behaves as if it did not exist.
+	 *
+	 * @param owner the namespace expected to own the artifact, can't be {@literal null}
+	 * @param key the artifact key identifying the artifact, can't be {@literal null}
+	 * @return the resolved {@link ArtifactDefinition}, or {@code empty} if no such artifact is owned by {@code owner}
+	 */
+	Optional<ArtifactDefinition> get(Owner owner, ArtifactKey key);
+
+	/**
+	 * Determines whether the given namespace owns an artifact for the given key, see
+	 * {@link #get(Owner, ArtifactKey)} for the ownership rule.
+	 *
+	 * @param owner the namespace expected to own the artifact, can't be {@literal null}
+	 * @param key the artifact key identifying the artifact, can't be {@literal null}
+	 * @return {@code true} if {@code owner} owns an artifact for the given key, otherwise {@code false}
+	 */
+	boolean exists(Owner owner, ArtifactKey key);
+
+	/**
+	 * Permanently removes the artifact identified by the given key, together with every
+	 * {@link VersionedArtifact} published under it, from the registry.
+	 * <p>
+	 * This is a destructive, non-reversible operation. Only the namespace that owns the artifact may
+	 * deregister it. The {@code artifactory.artifact-definition.deregistered} domain event is emitted
+	 * once the artifact and all of its versions have been removed.
+	 *
+	 * @param owner the namespace requesting the removal, can't be {@literal null}
+	 * @param key the {@code groupId}/{@code artifactId} identity of the artifact to remove, can't be {@literal null}
+	 * @throws ArtifactDefinitionNotFoundException when no artifact exists for the given key
+	 * @throws ArtifactOwnershipMismatchException when the given owner does not own the artifact
+	 */
+	@DomainEventPublisher(publishes = "artifactory.artifact-definition.deregistered")
+	void deregister(Owner owner, ArtifactKey key);
+
+	/**
+	 * Searches the {@link VersionedArtifact versions} published under artifacts owned by the given namespace.
+	 * <p>
+	 * Scope this search to a single artifact by supplying {@link ArtifactKey#GROUP_ID_CRITERIA},
+	 * {@link ArtifactKey#ARTIFACT_ID_CRITERIA} or {@link ArtifactCoordinates#VERSION_CRITERIA} in the {@code query}.
+	 * <p>
+	 * As with every other method on this interface, only versions of artifacts owned by {@code owner} are matched.
+	 *
+	 * @param owner the namespace whose artifact versions are being searched, can't be {@literal null}
+	 * @param query the search query used to filter and page through the results, can't be {@literal null}
+	 * @return a page of {@link VersionedArtifact versions} owned by {@code owner}, never {@literal null}
+	 */
+	Page<VersionedArtifact> versions(Owner owner, SearchQuery query);
+
+	/**
+	 * Resolves a specific artifact version owned by the given namespace.
+	 * <p>
+	 * Unlike {@link Artifactory#get(Owner, ArtifactCoordinates)}, this lookup is strict: it only resolves
+	 * when {@code owner} is the actual owner of the artifact version. A {@code PUBLIC} version owned by a
+	 * different namespace behaves as if it did not exist.
+	 *
+	 * @param owner the namespace expected to own the artifact version, can't be {@literal null}
+	 * @param coordinates the artifact coordinates identifying the artifact version, can't be {@literal null}
+	 * @return the resolved {@link VersionedArtifact}, or {@code empty} if no such version is owned by {@code owner}
+	 */
+	Optional<VersionedArtifact> get(Owner owner, ArtifactCoordinates coordinates);
+
+	/**
+	 * Determines whether the given namespace owns an artifact version for the given coordinates, see
+	 * {@link #get(Owner, ArtifactCoordinates)} for the ownership rule.
+	 *
+	 * @param owner the namespace expected to own the artifact version, can't be {@literal null}
+	 * @param coordinates the artifact coordinates identifying the artifact version, can't be {@literal null}
+	 * @return {@code true} if {@code owner} owns an artifact version for the given coordinates, otherwise
+	 *         {@code false}
+	 */
+	boolean exists(Owner owner, ArtifactCoordinates coordinates);
+
+	/**
+	 * Publishes a new artifact version based on the provided metadata.
+	 * <p>
+	 * This operation performs the release process for an artifact, which includes:
+	 * <ul>
+	 *   <li>Validating artifact coordinates and metadata</li>
+	 *   <li>Persisting the artifact version</li>
+	 *   <li>Registering associated property definitions</li>
+	 *   <li>Emitting a domain event indicating that a new artifact version has been released</li>
+	 * </ul>
+	 * <p>
+	 * Implementations should treat published artifact versions as immutable. Once a version has been
+	 * successfully published, its metadata and property definitions must not be modified.
+	 * <p>
+	 * The {@code artifactory.artifact-version.publication-created} domain event will be emitted after
+	 * a successful publication.
+	 * <p>
+	 * Publishing is restricted to owners that hold an active verification claim covering the artifact
+	 * {@code groupId}. The caller is expected to have already resolved the publishing namespace to
+	 * its {@link Owner}.
+	 *
+	 * @param owner the namespace publishing the artifact, can't be {@literal null}
+	 * @param metadata the metadata describing the artifact version to publish, can't be {@literal null}
+	 * @return the resulting {@link VersionedArtifact} representing the published artifact
+	 * @throws ArtifactVersionExistsException when an artifact with the same coordinates already exists
+	 * @throws ArtifactOwnershipMismatchException when the artifact already exists and is owned by a
+	 *         different namespace
+	 * @throws com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException when the owner does not hold
+	 *         an active verification claim covering the artifact {@code groupId}
+	 */
+	@DomainEventPublisher(publishes = "artifactory.artifact-version.publication-created")
+	VersionedArtifact publish(Owner owner, ArtifactMetadata metadata);
+
+	/**
+	 * Retracts a single previously published artifact version, removing it from the registry.
+	 * <p>
+	 * Unlike {@link #deregister(Owner, ArtifactKey)}, this only removes the one version identified by
+	 * {@code coordinates} — the artifact definition and any other published versions are unaffected.
+	 * This is a destructive, non-reversible operation. Only the namespace that owns the artifact may
+	 * retract one of its versions. The {@code artifactory.artifact-version.publication-retracted} domain
+	 * event is emitted once the version has been removed.
+	 *
+	 * @param owner the namespace requesting the removal, can't be {@literal null}
+	 * @param coordinates the artifact coordinates identifying the version to remove, can't be {@literal null}
+	 * @throws ArtifactVersionNotFoundException when no artifact version exists for the given coordinates
+	 * @throws ArtifactOwnershipMismatchException when the given owner does not own the artifact
+	 */
+	@DomainEventPublisher(publishes = "artifactory.artifact-version.publication-retracted")
+	void retract(Owner owner, ArtifactCoordinates coordinates);
+
+	/**
+	 * Changes the {@link ArtifactVisibility} of the artifact identified by the given {@link ArtifactKey}.
+	 * <p>
+	 * Visibility is a {@code groupId}/{@code artifactId} level concern, not a version level one: it
+	 * applies to every {@link VersionedArtifact} published under those coordinates. Only the
+	 * namespace that owns the artifact may change its visibility. The
+	 * {@code artifactory.artifact-definition.visibility-changed} domain event is emitted after a
+	 * successful change.
+	 *
+	 * @param owner the namespace requesting the change, can't be {@literal null}
+	 * @param key the {@code groupId}/{@code artifactId} identity of the artifact, can't be {@literal null}
+	 * @param visibility the visibility to apply, can't be {@literal null}
+	 * @throws ArtifactDefinitionNotFoundException when no artifact exists for the given coordinates
+	 * @throws ArtifactOwnershipMismatchException when the given owner does not own the artifact
+	 */
+	@DomainEventPublisher(publishes = "artifactory.artifact-definition.visibility-changed")
+	void changeVisibility(Owner owner, ArtifactKey key, ArtifactVisibility visibility);
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
@@ -37,8 +37,9 @@ import java.util.Optional;
 @RequiresScope(OAuthScope.READ_ARTIFACTS)
 class ArtifactoryController {
 
-	private final Artifactory artifactory;
 	private final OwnerResolver resolver;
+	private final Artifactory artifactory;
+	private final Publications publications;
 
 	@GetMapping("/{groupId}/{artifactId}")
 	EntityModel<ArtifactDefinition> definition(
@@ -106,7 +107,7 @@ class ArtifactoryController {
 		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(groupId, artifactId, version);
 		publication.validate(coordinates, errors);
 
-		return EntityModel.of(artifactory.publish(owner, publication.toArtifactMetadata()));
+		return EntityModel.of(publications.publish(owner, publication.toArtifactMetadata()));
 	}
 
 	@GetMapping("/{groupId}/{artifactId}/{version}/properties")
@@ -131,7 +132,7 @@ class ArtifactoryController {
 				"Could not extract namespace identifier from the current authenticated principal"
 		));
 
-		artifactory.changeVisibility(owner, ArtifactKey.of(groupId, artifactId), request.visibility());
+		publications.changeVisibility(owner, ArtifactKey.of(groupId, artifactId), request.visibility());
 	}
 
 	private Optional<Owner> resolveOwner() {

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
@@ -21,10 +21,22 @@ interface Assemblers {
 		return definition -> EntityModel.of(definition, linkBuilder(definition).selfRel());
 	}
 
+	static RepresentationModelAssembler<ArtifactDefinition, EntityModel<ArtifactDefinition>> definition(Owner owner) {
+		return definition -> EntityModel.of(definition, linkBuilder(owner, definition).selfRel())
+				.add(linkBuilder(owner, definition).path("versions").rel("List artifact versions"))
+				.add(linkBuilder(owner, definition).path("visibility").method(HttpMethod.PUT).rel("Update artifact visibility"))
+				.add(linkBuilder(owner, definition).method(HttpMethod.DELETE).rel("Deregister artifact"));
+	}
+
 	static RepresentationModelAssembler<VersionedArtifact, EntityModel<VersionedArtifact>> artifact(ArtifactCoordinates coordinates) {
 		return artifact -> EntityModel.of(artifact, linkBuilder(coordinates).selfRel())
 				.add(linkBuilder(coordinates).method(HttpMethod.POST).rel("publish"))
 				.add(linkBuilder(coordinates).method(HttpMethod.GET).rel("properties"));
+	}
+
+	static RepresentationModelAssembler<VersionedArtifact, EntityModel<VersionedArtifact>> artifact(Owner owner) {
+		return artifact -> EntityModel.of(artifact, linkBuilder(owner, (Artifact) artifact).selfRel())
+				.add(linkBuilder(owner, (Artifact) artifact).method(HttpMethod.DELETE).rel("Retract artifact version"));
 	}
 
 	static RepresentationModelAssembler<PropertyDefinition, EntityModel<PropertyDefinition>> property(ArtifactCoordinates coordinates) {
@@ -71,6 +83,25 @@ interface Assemblers {
 	static LinkBuilder linkBuilder(ArtifactCoordinates coordinates) {
 		return linkBuilder((ArtifactKey) coordinates)
 				.path(coordinates.version().get());
+	}
+
+	static LinkBuilder linkBuilder(Owner owner, ArtifactKey key) {
+		return Link.builder()
+				.path("namespaces")
+				.path(owner.slug())
+				.path("artifacts")
+				.path(key.groupId())
+				.path(key.artifactId());
+	}
+
+	static LinkBuilder linkBuilder(Owner owner, Artifact artifact) {
+		return Link.builder()
+				.path("namespaces")
+				.path(owner.slug())
+				.path("artifacts")
+				.path(artifact.groupId())
+				.path(artifact.artifactId())
+				.path(artifact.version());
 	}
 
 	static LinkBuilder linkBuilder(Owner owner, GroupVerification verification) {

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/PublicationsController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/PublicationsController.java
@@ -1,0 +1,192 @@
+package com.konfigyr.artifactory.controller;
+
+import com.konfigyr.artifactory.*;
+import com.konfigyr.hateoas.EntityModel;
+import com.konfigyr.hateoas.PagedModel;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.security.oauth.RequiresScope;
+import com.konfigyr.support.SearchQuery;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+@NullMarked
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/namespaces/{namespace}")
+@RequiresScope(OAuthScope.READ_ARTIFACTS)
+class PublicationsController {
+
+	private final Publications publications;
+	private final OwnerResolver ownerResolver;
+
+	@GetMapping("/artifacts")
+	@PreAuthorize("isMember(#namespace)")
+	PagedModel<EntityModel<ArtifactDefinition>> list(
+			@PathVariable String namespace,
+			@Nullable @RequestParam(required = false) String groupId,
+			@Nullable @RequestParam(required = false) String artifactId,
+			@Nullable @RequestParam(required = false) String term,
+			Pageable pageable
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final SearchQuery query = SearchQuery.builder()
+				.criteria(ArtifactKey.GROUP_ID_CRITERIA, groupId)
+				.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA, artifactId)
+				.pageable(pageable)
+				.term(term)
+				.build();
+
+		return Assemblers.definition(owner).assemble(publications.artifacts(owner, query));
+	}
+
+	@GetMapping("/artifacts/{groupId}")
+	@PreAuthorize("isMember(#namespace)")
+	PagedModel<EntityModel<ArtifactDefinition>> list(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@Nullable @RequestParam(required = false) String term,
+			Pageable pageable
+	) {
+		return list(namespace, groupId, null, term, pageable);
+	}
+
+	@GetMapping("/artifacts/{groupId}/{artifactId}")
+	@PreAuthorize("isMember(#namespace)")
+	EntityModel<ArtifactDefinition> get(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@PathVariable String artifactId
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactKey key = ArtifactKey.of(groupId, artifactId);
+		final ArtifactDefinition artifact = publications.get(owner, key)
+				.orElseThrow(() -> new ArtifactDefinitionNotFoundException(key));
+
+		return Assemblers.definition(owner).assemble(artifact);
+	}
+
+	@RequestMapping(method = RequestMethod.HEAD, path = "/artifacts/{groupId}/{artifactId}")
+	@PreAuthorize("isMember(#namespace)")
+	ResponseEntity<Void> exists(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@PathVariable String artifactId
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactKey key = ArtifactKey.of(groupId, artifactId);
+		final HttpStatus status = publications.exists(owner, key) ? HttpStatus.OK : HttpStatus.NOT_FOUND;
+
+		return ResponseEntity.status(status).build();
+	}
+
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@PutMapping("/artifacts/{groupId}/{artifactId}/visibility")
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.PUBLISH_ARTIFACTS)
+	void changeVisibility(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@PathVariable String artifactId,
+			@RequestBody @Validated ChangeVisibilityRequest request
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		publications.changeVisibility(owner, ArtifactKey.of(groupId, artifactId), request.visibility());
+	}
+
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@DeleteMapping("/artifacts/{groupId}/{artifactId}")
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.PUBLISH_ARTIFACTS)
+	void deregister(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@PathVariable String artifactId
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		publications.deregister(owner, ArtifactKey.of(groupId, artifactId));
+	}
+
+	@GetMapping("/artifacts/{groupId}/{artifactId}/versions")
+	@PreAuthorize("isMember(#namespace)")
+	PagedModel<EntityModel<VersionedArtifact>> versions(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@PathVariable String artifactId,
+			@Nullable @RequestParam(required = false) String version,
+			@Nullable @RequestParam(required = false) String term,
+			Pageable pageable
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactKey key = ArtifactKey.of(groupId, artifactId);
+
+		if (!publications.exists(owner, key)) {
+			throw new ArtifactDefinitionNotFoundException(key);
+		}
+
+		final SearchQuery query = SearchQuery.builder()
+				.criteria(ArtifactKey.GROUP_ID_CRITERIA, groupId)
+				.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA, artifactId)
+				.criteria(ArtifactCoordinates.VERSION_CRITERIA, version)
+				.pageable(pageable)
+				.term(term)
+				.build();
+
+		return Assemblers.artifact(owner).assemble(publications.versions(owner, query));
+	}
+
+	@GetMapping("/artifacts/{groupId}/{artifactId}/{version}")
+	@PreAuthorize("isMember(#namespace)")
+	EntityModel<VersionedArtifact> getVersion(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@PathVariable String artifactId,
+			@PathVariable String version
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(groupId, artifactId, version);
+		final VersionedArtifact artifact = publications.get(owner, coordinates)
+				.orElseThrow(() -> new ArtifactVersionNotFoundException(coordinates));
+
+		return Assemblers.artifact(owner).assemble(artifact);
+	}
+
+	@RequestMapping(method = RequestMethod.HEAD, path = "/artifacts/{groupId}/{artifactId}/{version}")
+	@PreAuthorize("isMember(#namespace)")
+	ResponseEntity<Void> exists(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@PathVariable String artifactId,
+			@PathVariable String version
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		final ArtifactCoordinates coordinates = ArtifactCoordinates.of(groupId, artifactId, version);
+		final HttpStatus status = publications.exists(owner, coordinates) ? HttpStatus.OK : HttpStatus.NOT_FOUND;
+
+		return ResponseEntity.status(status).build();
+	}
+
+	@ResponseStatus(HttpStatus.NO_CONTENT)
+	@DeleteMapping("/artifacts/{groupId}/{artifactId}/{version}")
+	@PreAuthorize("isAdmin(#namespace)")
+	@RequiresScope(OAuthScope.PUBLISH_ARTIFACTS)
+	void retract(
+			@PathVariable String namespace,
+			@PathVariable String groupId,
+			@PathVariable String artifactId,
+			@PathVariable String version
+	) {
+		final Owner owner = ownerResolver.resolve(namespace);
+		publications.retract(owner, ArtifactCoordinates.of(groupId, artifactId, version));
+	}
+
+	record ChangeVisibilityRequest(@NotNull ArtifactVisibility visibility) { /* noop */ }
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -468,6 +468,7 @@ class AuditEventListener {
 	@TransactionalEventListener(id = "audit.publication-created", classes = ArtifactoryEvent.PublicationCreated.class)
 	void on(ArtifactoryEvent.PublicationCreated event) {
 		insert(event, builder -> builder
+				.namespace(event.owner().id())
 				.entityType("artifact-version")
 				.entityId(event.id())
 				.eventType("artifact-version.publication-created")
@@ -478,6 +479,7 @@ class AuditEventListener {
 	@TransactionalEventListener(id = "audit.publication-completed", classes = ArtifactoryEvent.PublicationCompleted.class)
 	void on(ArtifactoryEvent.PublicationCompleted event) {
 		insert(event, builder -> builder
+				.namespace(event.owner().id())
 				.entityType("artifact-version")
 				.entityId(event.id())
 				.eventType("artifact-version.publication-completed")
@@ -488,10 +490,45 @@ class AuditEventListener {
 	@TransactionalEventListener(id = "audit.publication-failed", classes = ArtifactoryEvent.PublicationFailed.class)
 	void on(ArtifactoryEvent.PublicationFailed event) {
 		insert(event, builder -> builder
+				.namespace(event.owner().id())
 				.entityType("artifact-version")
 				.entityId(event.id())
 				.eventType("artifact-version.publication-failed")
 				.details("coordinates", event.coordinates().format())
+		);
+	}
+
+	@TransactionalEventListener(id = "audit.publication-retracted", classes = ArtifactoryEvent.PublicationRetracted.class)
+	void on(ArtifactoryEvent.PublicationRetracted event) {
+		insert(event, builder -> builder
+				.namespace(event.owner().id())
+				.entityType("artifact-version")
+				.entityId(event.id())
+				.eventType("artifact-version.publication-retracted")
+				.details("coordinates", event.coordinates().format())
+		);
+	}
+
+	@TransactionalEventListener(id = "audit.artifact-deregistered", classes = ArtifactoryEvent.Deregistered.class)
+	void on(ArtifactoryEvent.Deregistered event) {
+		insert(event, builder -> builder
+				.namespace(event.owner().id())
+				.entityType("artifact-definition")
+				.entityId(event.id())
+				.eventType("artifact-definition.deregistered")
+				.details("key", event.key().format())
+		);
+	}
+
+	@TransactionalEventListener(id = "audit.artifact-visibility-changed", classes = ArtifactoryEvent.VisibilityChanged.class)
+	void on(ArtifactoryEvent.VisibilityChanged event) {
+		insert(event, builder -> builder
+				.namespace(event.owner().id())
+				.entityType("artifact-definition")
+				.entityId(event.id())
+				.eventType("artifact-definition.visibility-changed")
+				.details("key", event.key().format())
+				.details("visibility", event.visibility().name())
 		);
 	}
 

--- a/konfigyr-api/src/main/resources/messages/audit.properties
+++ b/konfigyr-api/src/main/resources/messages/audit.properties
@@ -57,6 +57,9 @@ audit.event.keyset.destroyed=Key ''{0}'' within a keyset was scheduled for destr
 audit.event.artifact-version.publication-created=Artifact publication started for {0}
 audit.event.artifact-version.publication-completed=Artifact {0} has been successfully published
 audit.event.artifact-version.publication-failed=Failed to publish {0} Artifact
+audit.event.artifact-version.publication-retracted=Artifact {0} was retracted
+audit.event.artifact-definition.deregistered=Artifact {0} was deregistered
+audit.event.artifact-definition.visibility-changed=Visibility of artifact {0} was changed to {1}
 
 ## Artifact ownership transfer events ##
 

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
@@ -1,7 +1,5 @@
 package com.konfigyr.artifactory;
 
-import com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException;
-import com.konfigyr.artifactory.store.MetadataStore;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.io.ByteArray;
 import com.konfigyr.test.AbstractIntegrationTest;
@@ -10,11 +8,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
-import org.springframework.modulith.test.AssertablePublishedEvents;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.net.URI;
-import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -25,9 +20,6 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 
 	@Autowired
 	Artifactory artifactory;
-
-	@Autowired
-	MetadataStore store;
 
 	@Test
 	@DisplayName("should retrieve the artifact overview strictly scoped to its owner")
@@ -197,80 +189,6 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 	}
 
 	@Test
-	@Transactional
-	@DisplayName("should create a new artifact release")
-	void shouldPublishArtifact(AssertablePublishedEvents events) {
-		final var artifact = TestArtifacts.artifact(builder -> builder.version("3.0.0"));
-		final var metadata = TestArtifacts.metadata(artifact);
-
-		assertThat(artifactory.publish(Owners.konfigyr(), metadata))
-				.isNotNull()
-				.returns(artifact.groupId(), VersionedArtifact::groupId)
-				.returns(artifact.artifactId(), VersionedArtifact::artifactId)
-				.returns(artifact.version(), VersionedArtifact::version)
-				.returns(artifact.name(), VersionedArtifact::name)
-				.returns(artifact.description(), VersionedArtifact::description)
-				.returns(artifact.website(), VersionedArtifact::website)
-				.returns(artifact.repository(), VersionedArtifact::repository)
-				.returns(PublicationState.PENDING, VersionedArtifact::state)
-				.returns("8d9d53cfd5d27febf82baf0f8d801545358c1cf21e3d54cf9c2e5c5ba1754b98", VersionedArtifact::checksum)
-				.satisfies(it -> assertThat(it.publishedAt())
-						.isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS))
-				);
-
-		assertThat(store.get(ArtifactCoordinates.of(artifact)))
-				.as("Should store property descriptor in the metadata store")
-				.isPresent();
-
-		events.assertThat()
-				.as("Should publish an event for the new artifact release")
-				.contains(ArtifactoryEvent.PublicationCreated.class)
-				.matching(ArtifactoryEvent.PublicationCreated::coordinates, ArtifactCoordinates.of(artifact));
-	}
-
-	@Test
-	@DisplayName("should fail to create a new artifact release when version already exists")
-	void shouldPublishExistingArtifact(AssertablePublishedEvents events) {
-		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-api:1.0.0");
-		final var metadata = TestArtifacts.metadata(coordinates);
-
-		assertThatExceptionOfType(ArtifactVersionExistsException.class)
-				.isThrownBy(() -> artifactory.publish(Owners.konfigyr(), metadata))
-				.withMessageContaining("Artifact version already exists for following coordinates: %s", coordinates)
-				.returns(coordinates, ArtifactVersionExistsException::getCoordinates)
-				.withNoCause();
-
-		assertThat(store.get(coordinates))
-				.as("Should not store property descriptor in the metadata store")
-				.isEmpty();
-
-		assertThat(events.ofType(ArtifactoryEvent.PublicationCreated.class))
-				.as("Should not publish any release event when artifact release fails")
-				.isEmpty();
-	}
-
-	@Test
-	@DisplayName("should fail to release an artifact when the owner has no active claim covering the groupId")
-	void shouldRejectPublishForUnverifiedGroupId(AssertablePublishedEvents events) {
-		final var coordinates = ArtifactCoordinates.parse("com.unverified:some-artifact:1.0.0");
-		final var metadata = TestArtifacts.metadata(coordinates);
-
-		assertThatExceptionOfType(GroupIdNotVerifiedException.class)
-				.isThrownBy(() -> artifactory.publish(Owners.konfigyr(), metadata))
-				.returns("com.unverified", GroupIdNotVerifiedException::getGroupId)
-				.returns("konfigyr", ex -> ex.getOwner().slug())
-				.returns(HttpStatus.BAD_REQUEST, GroupIdNotVerifiedException::getStatusCode);
-
-		assertThat(store.get(coordinates))
-				.as("Should not store property descriptor when the groupId is not verified")
-				.isEmpty();
-
-		assertThat(events.ofType(ArtifactoryEvent.PublicationCreated.class))
-				.as("Should not publish any release event when ownership is not verified")
-				.isEmpty();
-	}
-
-	@Test
 	@DisplayName("should retrieve properties for an artifact version")
 	void retrieveArtifactProperties() {
 		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.1");
@@ -425,75 +343,6 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 		assertThat(artifactory.exists(null, coordinates))
 				.as("a caller with no namespace context should not see a private artifact exists")
 				.isFalse();
-	}
-
-	@Test
-	@DisplayName("should reject publishing a new version when the existing artifact is owned by a different namespace")
-	void shouldRejectPublishWhenExistingArtifactOwnedByDifferentNamespace() {
-		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:reclaimed-artifact:1.0.0");
-		final var metadata = TestArtifacts.metadata(coordinates);
-
-		assertThatExceptionOfType(ArtifactOwnershipMismatchException.class)
-				.isThrownBy(() -> artifactory.publish(Owners.konfigyr(), metadata))
-				.returns("com.konfigyr", ArtifactOwnershipMismatchException::getGroupId)
-				.returns("reclaimed-artifact", ArtifactOwnershipMismatchException::getArtifactId)
-				.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode);
-
-		assertThat(artifactory.exists(coordinates))
-				.as("no new version should have been created for the rejected publish attempt")
-				.isFalse();
-	}
-
-	@Test
-	@Transactional
-	@DisplayName("should change visibility of an owned artifact")
-	void shouldChangeVisibilityForOwnedArtifact() {
-		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-internal-secrets:1.0.0");
-
-		assertThat(artifactory.get(Owners.johnDoe(), coordinates))
-				.as("should not yet be visible to a different namespace while still private")
-				.isEmpty();
-
-		artifactory.changeVisibility(Owners.konfigyr(), coordinates, ArtifactVisibility.PUBLIC);
-
-		assertThat(artifactory.get(Owners.johnDoe(), coordinates))
-				.as("should now be visible to a different namespace after becoming public")
-				.isPresent()
-				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
-				.returns(ArtifactVisibility.PUBLIC, VersionedArtifact::visibility);
-	}
-
-	@Test
-	@Transactional
-	@DisplayName("should reject changing visibility when the caller does not own the artifact")
-	void shouldRejectChangeVisibilityForDifferentOwner() {
-		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-internal-secrets");
-
-		assertThatExceptionOfType(ArtifactOwnershipMismatchException.class)
-				.isThrownBy(() -> artifactory.changeVisibility(Owners.johnDoe(), key, ArtifactVisibility.PUBLIC))
-				.returns(key, ArtifactOwnershipMismatchException::getKey)
-				.returns(key.groupId(), ArtifactOwnershipMismatchException::getGroupId)
-				.returns(key.artifactId(), ArtifactOwnershipMismatchException::getArtifactId)
-				.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode);
-
-		assertThat(artifactory.get(Owners.konfigyr(), ArtifactCoordinates.of(key, "1.0.0")))
-				.as("visibility must remain unchanged after a rejected attempt")
-				.isPresent()
-				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
-				.returns(ArtifactVisibility.PRIVATE, VersionedArtifact::visibility);
-	}
-
-	@Test
-	@DisplayName("should reject changing visibility for an unknown artifact")
-	void shouldRejectChangeVisibilityForUnknownArtifact() {
-		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-does-not-exist");
-
-		assertThatExceptionOfType(ArtifactDefinitionNotFoundException.class)
-				.isThrownBy(() -> artifactory.changeVisibility(Owners.konfigyr(), key, ArtifactVisibility.PUBLIC))
-				.returns(key, ArtifactDefinitionNotFoundException::getKey)
-				.returns(key.groupId(), ArtifactDefinitionNotFoundException::getGroupId)
-				.returns(key.artifactId(), ArtifactDefinitionNotFoundException::getArtifactId)
-				.returns(HttpStatus.NOT_FOUND, ArtifactDefinitionNotFoundException::getStatusCode);
 	}
 
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/PublicationsTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/PublicationsTest.java
@@ -1,0 +1,499 @@
+package com.konfigyr.artifactory;
+
+import com.konfigyr.artifactory.ownership.GroupIdNotVerifiedException;
+import com.konfigyr.artifactory.store.MetadataStore;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.support.SearchQuery;
+import com.konfigyr.test.AbstractIntegrationTest;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.modulith.test.AssertablePublishedEvents;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import static org.assertj.core.api.Assertions.*;
+
+class PublicationsTest extends AbstractIntegrationTest {
+
+	@Autowired
+	Publications publications;
+
+	@Autowired
+	MetadataStore store;
+
+	@Test
+	@DisplayName("should search artifacts owned by a namespace")
+	void shouldSearchArtifactsOwnedByNamespace() {
+		final var result = publications.artifacts(Owners.konfigyr(), SearchQuery.of(Pageable.ofSize(20)));
+
+		assertThat(result.stream())
+				.extracting(ArtifactDefinition::id)
+				.containsExactlyInAnyOrder(
+						EntityId.from(2), EntityId.from(3), EntityId.from(4), EntityId.from(5),
+						EntityId.from(6), EntityId.from(7), EntityId.from(8), EntityId.from(9),
+						EntityId.from(10), EntityId.from(11), EntityId.from(12), EntityId.from(14)
+				);
+	}
+
+	@Test
+	@DisplayName("should never include another namespace's artifacts in a search, even when public")
+	void shouldNeverIncludeArtifactsOwnedByDifferentNamespaceInSearch() {
+		final var result = publications.artifacts(Owners.johnDoe(), SearchQuery.of(Pageable.ofSize(20)));
+
+		assertThat(result.stream())
+				.as("john-doe owns only its own fixtures, never konfigyr's public artifacts")
+				.extracting(ArtifactDefinition::id)
+				.containsExactlyInAnyOrder(EntityId.from(1), EntityId.from(13), EntityId.from(15));
+	}
+
+	@Test
+	@DisplayName("should return an empty search result when no artifact matches the filter")
+	void shouldReturnEmptyResultForNamespaceWithNoArtifacts() {
+		final var result = publications.artifacts(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("does-not-match-anything")
+				.build());
+
+		assertThat(result).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should filter artifact search by groupId criteria")
+	void shouldFilterArtifactsByGroupIdCriteria() {
+		final var result = publications.artifacts(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.criteria(ArtifactKey.GROUP_ID_CRITERIA, "org.springframework.modulith")
+				.build());
+
+		assertThat(result.stream())
+				.extracting(ArtifactDefinition::id)
+				.containsExactlyInAnyOrder(EntityId.from(9), EntityId.from(10));
+	}
+
+	@Test
+	@DisplayName("should filter artifact search by artifactId criteria")
+	void shouldFilterArtifactsByArtifactIdCriteria() {
+		final var result = publications.artifacts(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA, "spring-boot-jooq")
+				.build());
+
+		assertThat(result.stream())
+				.extracting(ArtifactDefinition::id)
+				.containsExactly(EntityId.from(11));
+	}
+
+	@Test
+	@DisplayName("should filter artifact search by term")
+	void shouldFilterArtifactsByTerm() {
+		final var result = publications.artifacts(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("crypto")
+				.build());
+
+		assertThat(result.stream())
+				.extracting(ArtifactDefinition::id)
+				.containsExactlyInAnyOrder(EntityId.from(2), EntityId.from(3));
+	}
+
+	@Test
+	@DisplayName("should retrieve an artifact definition owned by the namespace")
+	void shouldGetOwnedArtifactDefinition() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-api");
+
+		assertThat(publications.get(Owners.konfigyr(), key))
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(ArtifactDefinition.class))
+				.returns(EntityId.from(5), ArtifactDefinition::id)
+				.returns(Owners.konfigyr(), ArtifactDefinition::owner)
+				.returns(ArtifactVisibility.PUBLIC, ArtifactDefinition::visibility);
+	}
+
+	@Test
+	@DisplayName("should retrieve a private artifact definition owned by the namespace")
+	void shouldGetOwnedPrivateArtifactDefinition() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-internal-secrets");
+
+		assertThat(publications.get(Owners.konfigyr(), key))
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(ArtifactDefinition.class))
+				.returns(ArtifactVisibility.PRIVATE, ArtifactDefinition::visibility);
+	}
+
+	@Test
+	@DisplayName("should never retrieve an artifact definition owned by a different namespace, even when public")
+	void shouldNotGetArtifactDefinitionOwnedByDifferentNamespace() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-crypto-api");
+
+		assertThat(publications.get(Owners.johnDoe(), key))
+				.as("konfigyr-crypto-api is PUBLIC but owned by konfigyr, not john-doe")
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve an unknown artifact definition")
+	void shouldNotGetUnknownArtifactDefinition() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-does-not-exist");
+
+		assertThat(publications.get(Owners.konfigyr(), key)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should determine existence of an artifact owned by the namespace")
+	void shouldDetermineExistenceOfOwnedArtifact() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-api");
+
+		assertThat(publications.exists(Owners.konfigyr(), key)).isTrue();
+	}
+
+	@Test
+	@DisplayName("should never determine existence of an artifact owned by a different namespace, even when public")
+	void shouldNotDetermineExistenceOfArtifactOwnedByDifferentNamespace() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-crypto-api");
+
+		assertThat(publications.exists(Owners.johnDoe(), key)).isFalse();
+	}
+
+	@Test
+	@DisplayName("should determine non-existence of an unknown artifact")
+	void shouldNotDetermineExistenceOfUnknownArtifact() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-does-not-exist");
+
+		assertThat(publications.exists(Owners.konfigyr(), key)).isFalse();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should deregister an owned artifact together with all of its versions")
+	void shouldDeregisterOwnedArtifact(AssertablePublishedEvents events) {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-crypto-tink");
+		final var coordinates = ArtifactCoordinates.of(key, "1.0.0");
+
+		publications.deregister(Owners.konfigyr(), key);
+
+		assertThat(publications.exists(Owners.konfigyr(), key))
+				.as("the artifact definition should be removed")
+				.isFalse();
+
+		assertThat(publications.exists(Owners.konfigyr(), coordinates))
+				.as("its versions should be cascade removed as well")
+				.isFalse();
+
+		events.assertThat()
+				.contains(ArtifactoryEvent.Deregistered.class)
+				.matching(ArtifactoryEvent.Deregistered::key, key)
+				.matching(ArtifactoryEvent.Deregistered::owner, Owners.konfigyr());
+	}
+
+	@Test
+	@DisplayName("should fail to deregister an unknown artifact")
+	void shouldFailToDeregisterUnknownArtifact() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-does-not-exist");
+
+		assertThatExceptionOfType(ArtifactDefinitionNotFoundException.class)
+				.isThrownBy(() -> publications.deregister(Owners.konfigyr(), key))
+				.returns(key, ArtifactDefinitionNotFoundException::getKey);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to deregister an artifact owned by a different namespace")
+	void shouldFailToDeregisterArtifactOwnedByDifferentNamespace() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-api");
+
+		assertThatExceptionOfType(ArtifactDefinitionNotFoundException.class)
+				.isThrownBy(() -> publications.deregister(Owners.johnDoe(), key))
+				.returns(key, ArtifactDefinitionNotFoundException::getKey);
+
+		assertThat(publications.exists(Owners.konfigyr(), key))
+				.as("the artifact must remain untouched after a rejected attempt")
+				.isTrue();
+	}
+
+	@Test
+	@DisplayName("should search artifact versions owned by a namespace")
+	void shouldSearchVersionsOwnedByNamespace() {
+		final var result = publications.versions(Owners.konfigyr(), SearchQuery.of(Pageable.ofSize(20)));
+
+		assertThat(result.stream())
+				.extracting(VersionedArtifact::id)
+				.containsExactlyInAnyOrder(
+						EntityId.from(2), EntityId.from(3), EntityId.from(4), EntityId.from(5),
+						EntityId.from(6), EntityId.from(7), EntityId.from(8), EntityId.from(9),
+						EntityId.from(10), EntityId.from(11), EntityId.from(12), EntityId.from(13),
+						EntityId.from(14), EntityId.from(15), EntityId.from(17), EntityId.from(18)
+				);
+	}
+
+	@Test
+	@DisplayName("should never include another namespace's artifact versions in a search, even when public")
+	void shouldNeverIncludeVersionsOwnedByDifferentNamespaceInSearch() {
+		final var result = publications.versions(Owners.johnDoe(), SearchQuery.of(Pageable.ofSize(20)));
+
+		assertThat(result.stream())
+				.extracting(VersionedArtifact::id)
+				.containsExactlyInAnyOrder(EntityId.from(1), EntityId.from(16));
+	}
+
+	@Test
+	@DisplayName("should filter artifact version search by artifactId criteria")
+	void shouldFilterVersionsByArtifactIdCriteria() {
+		final var result = publications.versions(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA, "spring-boot-jooq")
+				.build());
+
+		assertThat(result.stream())
+				.extracting(VersionedArtifact::id)
+				.containsExactly(EntityId.from(12));
+	}
+
+	@Test
+	@DisplayName("should filter artifact version search by version criteria")
+	void shouldFilterVersionsByVersionCriteria() {
+		final var result = publications.versions(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.criteria(ArtifactCoordinates.VERSION_CRITERIA, "1.0.1")
+				.build());
+
+		assertThat(result.stream())
+				.extracting(VersionedArtifact::id)
+				.containsExactly(EntityId.from(3));
+	}
+
+	@Test
+	@DisplayName("should filter artifact version search by term")
+	void shouldFilterVersionsByTerm() {
+		final var result = publications.versions(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("modulith")
+				.build());
+
+		assertThat(result.stream())
+				.extracting(VersionedArtifact::id)
+				.containsExactlyInAnyOrder(EntityId.from(10), EntityId.from(11), EntityId.from(14), EntityId.from(15));
+	}
+
+	@Test
+	@DisplayName("should retrieve an artifact version owned by the namespace")
+	void shouldGetOwnedArtifactVersion() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.0");
+
+		assertThat(publications.get(Owners.konfigyr(), coordinates))
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(VersionedArtifact.class))
+				.returns(EntityId.from(2), VersionedArtifact::id)
+				.returns(Owners.konfigyr(), VersionedArtifact::owner);
+	}
+
+	@Test
+	@DisplayName("should never retrieve an artifact version owned by a different namespace, even when public")
+	void shouldNotGetArtifactVersionOwnedByDifferentNamespace() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.0");
+
+		assertThat(publications.get(Owners.johnDoe(), coordinates)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve an unknown artifact version")
+	void shouldNotGetUnknownArtifactVersion() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:99.0.0");
+
+		assertThat(publications.get(Owners.konfigyr(), coordinates)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should determine existence of an artifact version owned by the namespace")
+	void shouldDetermineExistenceOfOwnedArtifactVersion() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.0");
+
+		assertThat(publications.exists(Owners.konfigyr(), coordinates)).isTrue();
+	}
+
+	@Test
+	@DisplayName("should never determine existence of an artifact version owned by a different namespace, even when public")
+	void shouldNotDetermineExistenceOfArtifactVersionOwnedByDifferentNamespace() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.0");
+
+		assertThat(publications.exists(Owners.johnDoe(), coordinates)).isFalse();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should create a new artifact release")
+	void shouldPublishArtifact(AssertablePublishedEvents events) {
+		final var artifact = TestArtifacts.artifact(builder -> builder.version("3.0.0"));
+		final var metadata = TestArtifacts.metadata(artifact);
+
+		assertThat(publications.publish(Owners.konfigyr(), metadata))
+				.isNotNull()
+				.returns(artifact.groupId(), VersionedArtifact::groupId)
+				.returns(artifact.artifactId(), VersionedArtifact::artifactId)
+				.returns(artifact.version(), VersionedArtifact::version)
+				.returns(artifact.name(), VersionedArtifact::name)
+				.returns(artifact.description(), VersionedArtifact::description)
+				.returns(artifact.website(), VersionedArtifact::website)
+				.returns(artifact.repository(), VersionedArtifact::repository)
+				.returns(PublicationState.PENDING, VersionedArtifact::state)
+				.returns("8d9d53cfd5d27febf82baf0f8d801545358c1cf21e3d54cf9c2e5c5ba1754b98", VersionedArtifact::checksum)
+				.satisfies(it -> assertThat(it.publishedAt())
+						.isCloseTo(Instant.now(), within(1, ChronoUnit.SECONDS))
+				);
+
+		assertThat(store.get(ArtifactCoordinates.of(artifact)))
+				.as("Should store property descriptor in the metadata store")
+				.isPresent();
+
+		events.assertThat()
+				.contains(ArtifactoryEvent.PublicationCreated.class)
+				.matching(ArtifactoryEvent.PublicationCreated::coordinates, ArtifactCoordinates.of(artifact))
+				.matching(ArtifactoryEvent.PublicationCreated::owner, Owners.konfigyr());
+	}
+
+	@Test
+	@DisplayName("should fail to create a new artifact release when version already exists")
+	void shouldFailToPublishExistingVersion(AssertablePublishedEvents events) {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-api:1.0.0");
+		final var metadata = TestArtifacts.metadata(coordinates);
+
+		assertThatExceptionOfType(ArtifactVersionExistsException.class)
+				.isThrownBy(() -> publications.publish(Owners.konfigyr(), metadata))
+				.returns(coordinates, ArtifactVersionExistsException::getCoordinates);
+
+		assertThat(events.ofType(ArtifactoryEvent.PublicationCreated.class)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should fail to release an artifact when the owner has no active claim covering the groupId")
+	void shouldFailToPublishForUnverifiedGroupId(AssertablePublishedEvents events) {
+		final var coordinates = ArtifactCoordinates.parse("com.unverified:some-artifact:1.0.0");
+		final var metadata = TestArtifacts.metadata(coordinates);
+
+		assertThatExceptionOfType(GroupIdNotVerifiedException.class)
+				.isThrownBy(() -> publications.publish(Owners.konfigyr(), metadata))
+				.returns("com.unverified", GroupIdNotVerifiedException::getGroupId);
+
+		assertThat(events.ofType(ArtifactoryEvent.PublicationCreated.class)).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should reject publishing a new version when the existing artifact is owned by a different namespace")
+	void shouldRejectPublishWhenExistingArtifactOwnedByDifferentNamespace(AssertablePublishedEvents events) {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:reclaimed-artifact:2.0.0");
+		final var metadata = TestArtifacts.metadata(coordinates);
+
+		assertThatExceptionOfType(ArtifactOwnershipMismatchException.class)
+				.isThrownBy(() -> publications.publish(Owners.konfigyr(), metadata))
+				.returns("com.konfigyr", ArtifactOwnershipMismatchException::getGroupId)
+				.returns("reclaimed-artifact", ArtifactOwnershipMismatchException::getArtifactId)
+				.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode);
+
+		assertThat(publications.exists(Owners.konfigyr(), coordinates))
+				.as("no new version should have been created for the rejected publish attempt")
+				.isFalse();
+
+		assertThat(events.ofType(ArtifactoryEvent.PublicationCreated.class)).isEmpty();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should retract a single owned artifact version, leaving the definition and other versions untouched")
+	void shouldRetractOwnedVersion(AssertablePublishedEvents events) {
+		final var key = ArtifactKey.of("org.springframework.boot", "spring-boot-jooq");
+		final var coordinates = ArtifactCoordinates.of(key, "4.0.4");
+
+		publications.retract(Owners.konfigyr(), coordinates);
+
+		assertThat(publications.exists(Owners.konfigyr(), coordinates))
+				.as("the retracted version should no longer exist")
+				.isFalse();
+
+		assertThat(publications.exists(Owners.konfigyr(), key))
+				.as("the artifact definition itself should remain")
+				.isTrue();
+
+		events.assertThat()
+				.contains(ArtifactoryEvent.PublicationRetracted.class)
+				.matching(ArtifactoryEvent.PublicationRetracted::coordinates, coordinates)
+				.matching(ArtifactoryEvent.PublicationRetracted::owner, Owners.konfigyr());
+	}
+
+	@Test
+	@DisplayName("should fail to retract an unknown artifact version")
+	void shouldFailToRetractUnknownVersion() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:99.0.0");
+
+		assertThatExceptionOfType(ArtifactVersionNotFoundException.class)
+				.isThrownBy(() -> publications.retract(Owners.konfigyr(), coordinates))
+				.returns(coordinates, ArtifactVersionNotFoundException::getCoordinates);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to retract an artifact version owned by a different namespace")
+	void shouldFailToRetractVersionOwnedByDifferentNamespace() {
+		final var coordinates = ArtifactCoordinates.parse("com.konfigyr:konfigyr-crypto-api:1.0.0");
+
+		assertThatExceptionOfType(ArtifactVersionNotFoundException.class)
+				.isThrownBy(() -> publications.retract(Owners.johnDoe(), coordinates))
+				.returns(coordinates, ArtifactVersionNotFoundException::getCoordinates);
+
+		assertThat(publications.exists(Owners.konfigyr(), coordinates))
+				.as("the version must remain untouched after a rejected attempt")
+				.isTrue();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should change visibility of an owned artifact")
+	void shouldChangeVisibilityOfOwnedArtifact(AssertablePublishedEvents events) {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-internal-secrets");
+
+		publications.changeVisibility(Owners.konfigyr(), key, ArtifactVisibility.PUBLIC);
+
+		assertThat(publications.get(Owners.konfigyr(), key))
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(ArtifactDefinition.class))
+				.returns(ArtifactVisibility.PUBLIC, ArtifactDefinition::visibility);
+
+		events.assertThat()
+				.contains(ArtifactoryEvent.VisibilityChanged.class)
+				.matching(ArtifactoryEvent.VisibilityChanged::key, key)
+				.matching(ArtifactoryEvent.VisibilityChanged::owner, Owners.konfigyr())
+				.matching(ArtifactoryEvent.VisibilityChanged::visibility, ArtifactVisibility.PUBLIC);
+	}
+
+	@Test
+	@DisplayName("should fail to change visibility of an unknown artifact")
+	void shouldFailToChangeVisibilityOfUnknownArtifact() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-does-not-exist");
+
+		assertThatExceptionOfType(ArtifactDefinitionNotFoundException.class)
+				.isThrownBy(() -> publications.changeVisibility(Owners.konfigyr(), key, ArtifactVisibility.PUBLIC))
+				.returns(key, ArtifactDefinitionNotFoundException::getKey);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should fail to change visibility of an artifact owned by a different namespace")
+	void shouldFailToChangeVisibilityForDifferentNamespace() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-internal-secrets");
+
+		assertThatExceptionOfType(ArtifactDefinitionNotFoundException.class)
+				.isThrownBy(() -> publications.changeVisibility(Owners.johnDoe(), key, ArtifactVisibility.PUBLIC))
+				.returns(key, ArtifactDefinitionNotFoundException::getKey);
+
+		assertThat(publications.get(Owners.konfigyr(), key))
+				.as("visibility must remain unchanged after a rejected attempt")
+				.isPresent()
+				.get(InstanceOfAssertFactories.type(ArtifactDefinition.class))
+				.returns(ArtifactVisibility.PRIVATE, ArtifactDefinition::visibility);
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/batch/ArtifactoryJobListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/batch/ArtifactoryJobListenerTest.java
@@ -2,6 +2,7 @@ package com.konfigyr.artifactory.batch;
 
 import com.konfigyr.artifactory.ArtifactCoordinates;
 import com.konfigyr.artifactory.ArtifactoryEvent;
+import com.konfigyr.artifactory.Owners;
 import com.konfigyr.entity.EntityId;
 import org.apache.commons.lang3.function.Consumers;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,7 @@ class ArtifactoryJobListenerTest {
 	void launchPublishJob() throws Exception {
 		final var event = new ArtifactoryEvent.PublicationCreated(
 				EntityId.from(1L),
+				Owners.konfigyr(),
 				ArtifactCoordinates.parse("com.konfigyr:konfigyr-licences:1.0.0")
 		);
 

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/batch/ArtifactoryPublicationJobTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/batch/ArtifactoryPublicationJobTest.java
@@ -47,13 +47,13 @@ class ArtifactoryPublicationJobTest extends AbstractIntegrationTest {
 
 	@AfterAll
 	static void cleanup(ApplicationContext context) {
-		final long id = context.getBean(DSLContext.class).deleteFrom(ARTIFACT_VERSIONS)
+		final List<Long> versions = context.getBean(DSLContext.class).deleteFrom(ARTIFACT_VERSIONS)
 				.where(ARTIFACT_VERSIONS.ARTIFACT_ID.eq(4L))
 				.returning(ARTIFACT_VERSIONS.ID)
-				.execute();
+				.fetch(ARTIFACT_VERSIONS.ID);
 
 		context.getBean(DSLContext.class).deleteFrom(AUDIT_EVENTS)
-				.where(AUDIT_EVENTS.ENTITY_ID.eq(id))
+				.where(AUDIT_EVENTS.ENTITY_ID.in(versions))
 				.execute();
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/batch/ArtifactoryPublicationJobTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/batch/ArtifactoryPublicationJobTest.java
@@ -25,6 +25,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 
 import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
+import static com.konfigyr.data.tables.AuditEvents.AUDIT_EVENTS;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.doReturn;
 
@@ -46,8 +47,13 @@ class ArtifactoryPublicationJobTest extends AbstractIntegrationTest {
 
 	@AfterAll
 	static void cleanup(ApplicationContext context) {
-		context.getBean(DSLContext.class).deleteFrom(ARTIFACT_VERSIONS)
+		final long id = context.getBean(DSLContext.class).deleteFrom(ARTIFACT_VERSIONS)
 				.where(ARTIFACT_VERSIONS.ARTIFACT_ID.eq(4L))
+				.returning(ARTIFACT_VERSIONS.ID)
+				.execute();
+
+		context.getBean(DSLContext.class).deleteFrom(AUDIT_EVENTS)
+				.where(AUDIT_EVENTS.ENTITY_ID.eq(id))
 				.execute();
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactoryControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactoryControllerTest.java
@@ -552,6 +552,8 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 	@Transactional
 	@DisplayName("should fail to change visibility when the caller does not own the artifact")
 	void shouldRejectChangeArtifactVisibilityForDifferentOwner() {
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-internal-secrets");
+
 		mvc.put().uri(uriForVisibility("com.konfigyr", "konfigyr-internal-secrets").toUri())
 				.with(publishingTo(EntityId.from(1L)))
 				.contentType(MediaType.APPLICATION_JSON)
@@ -559,15 +561,11 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 				.exchange()
 				.assertThat()
 				.apply(log())
-				.satisfies(hasFailedWithException(ArtifactOwnershipMismatchException.class, ex -> ex
-						.returns(HttpStatus.CONFLICT, ArtifactOwnershipMismatchException::getStatusCode)
-						.returns("com.konfigyr", ArtifactOwnershipMismatchException::getGroupId)
-						.returns("konfigyr-internal-secrets", ArtifactOwnershipMismatchException::getArtifactId)
+				.satisfies(hasFailedWithException(ArtifactDefinitionNotFoundException.class, ex -> ex
+						.returns(key, ArtifactDefinitionNotFoundException::getKey)
 				))
-				.satisfies(problemDetailFor(HttpStatus.CONFLICT, problem -> problem
-						.hasTitleContaining("Artifact ownership conflict")
-						.hasDetailContaining("The artifact 'com.konfigyr:konfigyr-internal-secrets' is owned by a different " +
-								"namespace and cannot be published to or modified by 'john-doe'.")
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitleContaining("Artifact not found")
 				));
 
 		mvc.get().uri(uriForArtifact(ArtifactCoordinates.of("com.konfigyr", "konfigyr-internal-secrets", "1.0.0")).toUri())

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/PublicationsControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/PublicationsControllerTest.java
@@ -1,0 +1,450 @@
+package com.konfigyr.artifactory.controller;
+
+import com.konfigyr.artifactory.*;
+import com.konfigyr.entity.EntityId;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.test.AbstractControllerTest;
+import com.konfigyr.test.TestPrincipals;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+
+class PublicationsControllerTest extends AbstractControllerTest {
+
+	@Test
+	@DisplayName("should list artifacts owned by the namespace")
+	void shouldListOwnedArtifacts() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(ArtifactDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(ArtifactDefinition::id)
+						.containsExactlyInAnyOrder(
+								EntityId.from(2), EntityId.from(3), EntityId.from(4), EntityId.from(5),
+								EntityId.from(6), EntityId.from(7), EntityId.from(8), EntityId.from(9),
+								EntityId.from(10), EntityId.from(11), EntityId.from(12), EntityId.from(14)
+						));
+	}
+
+	@Test
+	@DisplayName("should list artifacts filtered by groupId query parameter")
+	void shouldListArtifactsFilteredByGroupIdQueryParam() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts?groupId=org.springframework.modulith", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(ArtifactDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(ArtifactDefinition::id)
+						.containsExactlyInAnyOrder(EntityId.from(9), EntityId.from(10)));
+	}
+
+	@Test
+	@DisplayName("should list artifacts filtered by groupId path segment")
+	void shouldListArtifactsByGroupIdPathSegment() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}", "konfigyr", "org.springframework.modulith")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(ArtifactDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(ArtifactDefinition::id)
+						.containsExactlyInAnyOrder(EntityId.from(9), EntityId.from(10)));
+	}
+
+	@Test
+	@DisplayName("should forbid listing artifacts for a namespace the caller is not a member of")
+	void shouldForbidListForNonMember() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts", "john-doe")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should forbid listing artifacts without the read-artifacts scope")
+	void shouldForbidListWithoutScope() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts", "konfigyr")
+				.with(authentication(TestPrincipals.john()))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.READ_ARTIFACTS));
+	}
+
+	@Test
+	@DisplayName("should retrieve an artifact definition owned by the namespace")
+	void shouldGetOwnedArtifactDefinition() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "com.konfigyr", "konfigyr-api")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ArtifactDefinition.class)
+				.returns(EntityId.from(5), ArtifactDefinition::id)
+				.returns(Owners.konfigyr(), ArtifactDefinition::owner)
+				.returns(ArtifactVisibility.PUBLIC, ArtifactDefinition::visibility);
+	}
+
+	@Test
+	@DisplayName("should never retrieve an artifact definition owned by a different namespace, even when public")
+	void shouldFailToGetArtifactDefinitionOwnedByDifferentNamespace() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "john-doe", "com.konfigyr", "konfigyr-crypto-api")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(hasFailedWithException(ArtifactDefinitionNotFoundException.class));
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve an unknown artifact definition")
+	void shouldFailToGetUnknownArtifactDefinition() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "com.konfigyr", "does-not-exist")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(hasFailedWithException(ArtifactDefinitionNotFoundException.class));
+	}
+
+	@Test
+	@DisplayName("should forbid retrieving an artifact definition for a namespace the caller is not a member of")
+	void shouldForbidGetForNonMember() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "john-doe", "doe.john", "website")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should perform an existence check for an artifact owned by the namespace")
+	void shouldCheckExistingOwnedArtifact() {
+		mvc.head().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "com.konfigyr", "konfigyr-api")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.body()
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should perform an existence check for an artifact owned by a different namespace, even when public")
+	void shouldCheckNonExistentArtifactOwnedByDifferentNamespace() {
+		mvc.head().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "john-doe", "com.konfigyr", "konfigyr-crypto-api")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.body()
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should forbid the existence check for a namespace the caller is not a member of")
+	void shouldForbidExistsForNonMember() {
+		mvc.head().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "john-doe", "doe.john", "website")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.FORBIDDEN);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should change the visibility of an owned artifact")
+	void shouldChangeVisibilityOfOwnedArtifact() {
+		mvc.put().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/visibility", "konfigyr", "com.konfigyr", "konfigyr-internal-secrets")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_ARTIFACTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new PublicationsController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NO_CONTENT);
+
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "com.konfigyr", "konfigyr-internal-secrets")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.bodyJson()
+				.convertTo(ArtifactDefinition.class)
+				.returns(ArtifactVisibility.PUBLIC, ArtifactDefinition::visibility);
+	}
+
+	@Test
+	@DisplayName("should fail to change visibility of an unknown artifact")
+	void shouldFailToChangeVisibilityOfUnknownArtifact() {
+		mvc.put().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/visibility", "konfigyr", "com.konfigyr", "does-not-exist")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_ARTIFACTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new PublicationsController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(hasFailedWithException(ArtifactDefinitionNotFoundException.class));
+	}
+
+	@Test
+	@DisplayName("should forbid changing visibility for a member that is not an admin of the namespace")
+	void shouldForbidChangeVisibilityForNonAdminMember() {
+		mvc.put().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/visibility", "konfigyr", "com.konfigyr", "konfigyr-internal-secrets")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_ARTIFACTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new PublicationsController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should forbid changing visibility without the publish-artifacts scope")
+	void shouldForbidChangeVisibilityWithoutScope() {
+		mvc.put().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/visibility", "konfigyr", "com.konfigyr", "konfigyr-internal-secrets")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new PublicationsController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.PUBLISH_ARTIFACTS));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should deregister an owned artifact together with all of its versions")
+	void shouldDeregisterOwnedArtifact() {
+		mvc.delete().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "com.konfigyr", "konfigyr-crypto-tink")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NO_CONTENT);
+
+		mvc.head().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "com.konfigyr", "konfigyr-crypto-tink")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.hasStatus(HttpStatus.NOT_FOUND);
+	}
+
+	@Test
+	@DisplayName("should fail to deregister an unknown artifact")
+	void shouldFailToDeregisterUnknownArtifact() {
+		mvc.delete().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "com.konfigyr", "does-not-exist")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(hasFailedWithException(ArtifactDefinitionNotFoundException.class));
+	}
+
+	@Test
+	@DisplayName("should forbid deregistering an artifact for a member that is not an admin of the namespace")
+	void shouldForbidDeregisterForNonAdminMember() {
+		mvc.delete().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "com.konfigyr", "konfigyr-crypto-tink")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should search artifact versions owned by the namespace")
+	void shouldSearchOwnedArtifactVersions() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/versions", "konfigyr", "com.konfigyr", "konfigyr-crypto-api")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(VersionedArtifact.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(VersionedArtifact::id)
+						.containsExactlyInAnyOrder(EntityId.from(2), EntityId.from(3), EntityId.from(4)));
+	}
+
+	@Test
+	@DisplayName("should filter searched artifact versions by version query parameter")
+	void shouldSearchOwnedArtifactVersionsFilteredByVersion() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/versions?version=1.0.1", "konfigyr", "com.konfigyr", "konfigyr-crypto-api")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(VersionedArtifact.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(VersionedArtifact::id)
+						.containsExactly(EntityId.from(3)));
+	}
+
+	@Test
+	@DisplayName("should fail to search versions for an unknown artifact")
+	void shouldFailToSearchVersionsForUnknownArtifact() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/versions", "konfigyr", "com.konfigyr", "does-not-exist")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(hasFailedWithException(ArtifactDefinitionNotFoundException.class));
+	}
+
+	@Test
+	@DisplayName("should forbid searching versions for a namespace the caller is not a member of")
+	void shouldForbidVersionsForNonMember() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/versions", "john-doe", "doe.john", "website")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should retrieve an artifact version owned by the namespace")
+	void shouldGetOwnedArtifactVersion() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "konfigyr", "com.konfigyr", "konfigyr-crypto-api", "1.0.0")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(VersionedArtifact.class)
+				.returns(EntityId.from(2), VersionedArtifact::id)
+				.returns(Owners.konfigyr(), VersionedArtifact::owner);
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve an unknown artifact version")
+	void shouldFailToGetUnknownArtifactVersion() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "konfigyr", "com.konfigyr", "konfigyr-crypto-api", "99.0.0")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(hasFailedWithException(ArtifactVersionNotFoundException.class));
+	}
+
+	@Test
+	@DisplayName("should forbid retrieving an artifact version for a namespace the caller is not a member of")
+	void shouldForbidGetVersionForNonMember() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "john-doe", "doe.john", "website", "1.0.0")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should perform an existence check for an artifact version owned by the namespace")
+	void shouldCheckExistingOwnedArtifactVersion() {
+		mvc.head().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "konfigyr", "com.konfigyr", "konfigyr-crypto-api", "1.0.0")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.body()
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should perform an existence check for an unknown artifact version")
+	void shouldCheckNonExistentArtifactVersion() {
+		mvc.head().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "konfigyr", "com.konfigyr", "konfigyr-crypto-api", "99.0.0")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.body()
+				.isEmpty();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should retract a single owned artifact version, leaving the definition and other versions untouched")
+	void shouldRetractOwnedVersion() {
+		mvc.delete().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "konfigyr", "org.springframework.boot", "spring-boot-jooq", "4.0.4")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NO_CONTENT);
+
+		mvc.head().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "konfigyr", "org.springframework.boot", "spring-boot-jooq", "4.0.4")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.hasStatus(HttpStatus.NOT_FOUND);
+
+		mvc.head().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}", "konfigyr", "org.springframework.boot", "spring-boot-jooq")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.hasStatusOk();
+	}
+
+	@Test
+	@DisplayName("should fail to retract an unknown artifact version")
+	void shouldFailToRetractUnknownVersion() {
+		mvc.delete().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "konfigyr", "com.konfigyr", "konfigyr-crypto-api", "99.0.0")
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(hasFailedWithException(ArtifactVersionNotFoundException.class));
+	}
+
+	@Test
+	@DisplayName("should forbid retracting an artifact version for a member that is not an admin of the namespace")
+	void shouldForbidRetractForNonAdminMember() {
+		mvc.delete().uri("/namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}", "konfigyr", "com.konfigyr", "konfigyr-crypto-api", "1.0.0")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
@@ -892,12 +892,13 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 	void shouldAuditPublicationCreated() {
 		setSecurityContext(TestPrincipals.application("test-oauth-application"));
 
+		final var owner = Owners.konfigyr();
 		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-core", "2.0.0");
 
-		listener.on(new ArtifactoryEvent.PublicationCreated(EntityId.from(1200), coordinates));
+		listener.on(new ArtifactoryEvent.PublicationCreated(EntityId.from(1200), owner, coordinates));
 
 		assertAuditRecord("artifact-version", EntityId.from(1200))
-				.returns(null, AuditRecord::namespaceId)
+				.returns(owner.id(), AuditRecord::namespaceId)
 				.returns("artifact-version", AuditRecord::entityType)
 				.returns("artifact-version.publication-created", AuditRecord::eventType)
 				.satisfies(it -> assertThat(it.details())
@@ -916,9 +917,11 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 	void shouldAuditPublicationCompleted() {
 		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-core", "2.0.0");
 
-		listener.on(new ArtifactoryEvent.PublicationCompleted(EntityId.from(1201), coordinates));
+		final var owner = Owners.konfigyr();
+		listener.on(new ArtifactoryEvent.PublicationCompleted(EntityId.from(1201), owner, coordinates));
 
 		assertAuditRecord("artifact-version", EntityId.from(1201))
+				.returns(owner.id(), AuditRecord::namespaceId)
 				.returns("artifact-version.publication-completed", AuditRecord::eventType)
 				.returns(AuditEventListener.SYSTEM_ACTOR, AuditRecord::actor)
 				.satisfies(assertAuditRecordMessage("Artifact %s has been successfully published", coordinates.format()));
@@ -929,12 +932,66 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 	void shouldAuditPublicationFailed() {
 		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-core", "2.0.0");
 
-		listener.on(new ArtifactoryEvent.PublicationFailed(EntityId.from(1202), coordinates));
+		final var owner = Owners.konfigyr();
+		listener.on(new ArtifactoryEvent.PublicationFailed(EntityId.from(1202), owner, coordinates));
 
 		assertAuditRecord("artifact-version", EntityId.from(1202))
+				.returns(owner.id(), AuditRecord::namespaceId)
 				.returns("artifact-version.publication-failed", AuditRecord::eventType)
 				.returns(AuditEventListener.SYSTEM_ACTOR, AuditRecord::actor)
 				.satisfies(assertAuditRecordMessage("Failed to publish %s Artifact", coordinates.format()));
+	}
+
+	@Test
+	@DisplayName("should persist audit record for artifact publication retracted event")
+	void shouldAuditPublicationRetracted() {
+		final var owner = Owners.konfigyr();
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-core", "2.0.0");
+
+		listener.on(new ArtifactoryEvent.PublicationRetracted(EntityId.from(1203), owner, coordinates));
+
+		assertAuditRecord("artifact-version", EntityId.from(1203))
+				.returns(owner.id(), AuditRecord::namespaceId)
+				.returns("artifact-version.publication-retracted", AuditRecord::eventType)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("coordinates", coordinates.format())
+				)
+				.satisfies(assertAuditRecordMessage("Artifact %s was retracted", coordinates.format()));
+	}
+
+	@Test
+	@DisplayName("should persist audit record for artifact deregistered event")
+	void shouldAuditArtifactDeregistered() {
+		final var owner = Owners.konfigyr();
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-core");
+
+		listener.on(new ArtifactoryEvent.Deregistered(EntityId.from(1204), owner, key));
+
+		assertAuditRecord("artifact-definition", EntityId.from(1204))
+				.returns(owner.id(), AuditRecord::namespaceId)
+				.returns("artifact-definition.deregistered", AuditRecord::eventType)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("key", key.format())
+				)
+				.satisfies(assertAuditRecordMessage("Artifact %s was deregistered", key.format()));
+	}
+
+	@Test
+	@DisplayName("should persist audit record for artifact visibility changed event")
+	void shouldAuditArtifactVisibilityChanged() {
+		final var owner = Owners.konfigyr();
+		final var key = ArtifactKey.of("com.konfigyr", "konfigyr-core");
+
+		listener.on(new ArtifactoryEvent.VisibilityChanged(EntityId.from(1205), owner, key, ArtifactVisibility.PUBLIC));
+
+		assertAuditRecord("artifact-definition", EntityId.from(1205))
+				.returns(owner.id(), AuditRecord::namespaceId)
+				.returns("artifact-definition.visibility-changed", AuditRecord::eventType)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("key", key.format())
+						.containsEntry("visibility", ArtifactVisibility.PUBLIC.name())
+				)
+				.satisfies(assertAuditRecordMessage("Visibility of artifact %s was changed to %s", key.format(), ArtifactVisibility.PUBLIC.name()));
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ServiceCatalogQueueListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/catalog/ServiceCatalogQueueListenerTest.java
@@ -3,6 +3,7 @@ package com.konfigyr.namespace.catalog;
 import com.konfigyr.artifactory.ArtifactCoordinates;
 import com.konfigyr.artifactory.ArtifactoryEvent;
 import com.konfigyr.artifactory.Manifest;
+import com.konfigyr.artifactory.Owner;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.Service;
 import com.konfigyr.namespace.ServiceEvent;
@@ -217,7 +218,7 @@ class ServiceCatalogQueueListenerTest extends AbstractIntegrationTest {
 	}
 
 	static ArtifactoryEvent.PublicationCompleted createReleaseCompletedEvent(long id) {
-		return new ArtifactoryEvent.PublicationCompleted(EntityId.from(id), mock(ArtifactCoordinates.class));
+		return new ArtifactoryEvent.PublicationCompleted(EntityId.from(id), mock(Owner.class), mock(ArtifactCoordinates.class));
 	}
 
 	static ServiceEvent.Released createManifestReleasedEvent(long id) {


### PR DESCRIPTION
Artifactory conflated two different personas' needs: OAuth/machine clients (build-tool plugins) that should see `PUBLIC` artifacts from any namespace plus their own `PRIVATE` ones, and a namespace's own registry management, which must never leak an artifact it doesn't own regardless of visibility. This splits those apart.

- New `Publications` interface: strictly scoped to a given `Owner`, with no visibility branching
- Artifactory keeps only the visibility-based reads (get/exists/existing); publish/changeVisibility moved to Publications.
- New `ArtifactoryQueries` centralizes the jOOQ query building and row-to-domain mapping shared by both services, so the join/mapping logic isn't duplicated between them.
- New `PublicationsController`: the namespace-scoped (`/namespaces/{namespace}/artifacts/...`) REST API backing the registry: list/search, get, exists, versions, change visibility, deregister, retract. Read endpoints require namespace membership, mutations require namespace admin plus the `PUBLISH_ARTIFACTS` scope.
- New domain events (`PublicationRetracted`, `Deregistered`, `VisibilityChanged`) with matching audit listeners and message templates, following the existing publish/complete/failed event pattern. All `ArtifactoryEvent` types now carry the affected artifact's `Owner`.
- Fixed a cross-namespace ownership bypass in `publish()`: without an explicit ownership check, a different namespace's existing artifact could be silently overwritten (name/description) and gain an unauthorized new version instead of being rejected with `ArtifactOwnershipMismatchException`.
