### PR TITLE
Fix stale entity names, routes, and scopes in project-overview skill

### DIFF
--- a/.claude/skills/shared/project-overview/SKILL.md
+++ b/.claude/skills/shared/project-overview/SKILL.md
@@ -22,7 +22,7 @@ Three independently deployed services:
 ┌─────────▼─────────────────┐    ┌──────────▼─────────────┐
 │ Identity Provider         │    │ REST API                │
 │ konfigyr-identity         │    │ konfigyr-api            │
-│ - Spring AuthServer       │    │ - Spring Boot 3.5+      │
+│ - Spring AuthServer       │    │ - Spring Boot 4.1       │
 │ - OAuth2/OIDC broker      │    │ - Spring Modulith       │
 │ - JWT issuance (PS256)    │    │ - jOOQ + Liquibase      │
 │ - External IdP federation │    │ - @RequiresScope auth   │
@@ -38,27 +38,34 @@ Three independently deployed services:
 ### Identity Provider: Protocol Broker
 
 The IdP is not a plain JWT issuer — it is an **identity broker and protocol translator**. It accepts
-authentication from upstream external providers (GitHub, GitLab, Google, SAML-based enterprise IdPs, or
-customer-managed OIDC providers) and translates those identities into a single, standardized OIDC JWT
-issued by Konfigyr. Application code never needs to handle provider-specific token formats.
+authentication from upstream external providers and translates those identities into a single,
+standardized OIDC JWT issued by Konfigyr. Application code never needs to handle provider-specific
+token formats.
+
+Currently configured login providers: **GitHub** and generic **OIDC** (Keycloak-compatible). GitLab is
+supported in code as a *trusted issuer* for token-exchange/workload-identity flows, not as a login
+provider. Google and SAML are not implemented.
 
 Key responsibilities:
 - Delegates authentication to external providers; never stores credentials itself
 - Maps external user identities to local `Account` records
-- Issues PS256/ES256 JWT access tokens and ID tokens
-- Exposes standard OIDC endpoints: JWKS, discovery (`.well-known`), token introspection, and revocation
+- Issues PS256-signed JWT access tokens and ID tokens (ES256 is only used to *verify* tokens from
+  trusted external issuers, never for Konfigyr-issued tokens)
+- Exposes standard OIDC endpoints: JWKS (`/oauth/jwks`), discovery (`.well-known`), userinfo
+  (`/oauth/userinfo`), token introspection (`/oauth/introspect`), and revocation (`/oauth/revoke`)
 
 ## Business Domains (Modules)
 
 | Module | Responsibility | Key Entities |
 |--------|---|---|
-| **namespace** | Multi-tenancy | Namespace, Member, Role |
-| **vault** | Config management | Profile, Entry, ChangeRequest, ChangeHistory |
-| **artifactory** | Metadata registry | Artifact, ArtifactVersion, PropertyDescriptor, PropertyOccurrence, ServiceManifest |
-| **kms** | Encryption | KeysetMetadata, KeyVersion |
-| **audit** | Event logging | AuditEvent, AuditLog |
+| **namespace** | Multi-tenancy | Namespace, NamespaceRole (enum: ADMIN/USER), NamespaceApplicationDefinition (OAuth2 clients) |
+| **membership** | Namespace membership | Member, Invitation |
+| **vault** | Config management | Profile, ProfilePolicy, PropertyChange(s), ChangeRequest, ChangeHistory |
+| **artifactory** | Metadata registry | ArtifactDefinition, VersionedArtifact, PropertyDefinition, ArtifactKey/ArtifactCoordinates, Owner, ArtifactVisibility (see dedicated section below) |
+| **kms** | Encryption | KeysetMetadata, KeyMetadata |
+| **audit** | Event logging | AuditEvent, AuditRecord |
 | **account** | User management | Account (from OAuth) |
-| **feature** | Feature flags | FeatureFlag (per-namespace limits) |
+| **feature** | Feature flags | FeatureDefinition, FeatureValue (per-namespace limits, e.g. `NamespaceFeatures.MEMBERS_COUNT`) |
 
 ## Key Design Decisions
 
@@ -76,32 +83,29 @@ Key responsibilities:
 - Rich UI rendering based on schema
 - Version-to-version diff analysis
 
-### 3. Three-Tier Metadata Deduplication
+### 3. Property Metadata Deduplication
 
-```
-Property Definition (identity: name + typeName → SHA-256)
-    ↓
-Property Occurrence (schema + description + deprecation → SHA-256)
-    ↓
-Version-to-Property Links
-```
-
-Identical schemas across thousands of artifact versions stored once.
+`PropertyDefinition` is a single entity (not a two-tier definition/occurrence split) keyed by a checksum
+over its full contents (name, type, schema, description, deprecation). It belongs to an `ArtifactDefinition`
+but is shared many-to-many across the artifact's versions, tracked via an `occurrences` count and
+`firstSeen`/`lastSeen` version markers — so identical property definitions across many artifact versions
+are still stored once.
 
 ### 4. Change Workflow
 
 ```
-Create → Submit Change Request → Approve → Apply
-         (optional if PROTECTED)
+Submit Change Request → Review (approve/comment) → Merge
 ```
 
-Profiles can be `UNPROTECTED` (direct apply) or `PROTECTED` (requires approval).
+or, for `UNPROTECTED` profiles, skip straight to a direct `apply`. Profiles can be `UNPROTECTED` (direct
+apply), `PROTECTED` (submit → review → merge required), or `IMMUTABLE` (no changes permitted).
 
 ### 5. Namespace OAuth2 Clients
 
-Namespaces can register OAuth2 clients (service tokens) with scoped permissions for CI/CD pipelines,
-Gradle/Maven plugins, and other automated integrations. These clients authenticate against the Identity
-Provider and receive access tokens scoped to specific operations (e.g. `metadata:upload`, `config:read`).
+Namespaces can register OAuth2 clients (`NamespaceApplicationDefinition`/`NamespaceApplication`, identified
+by a `NamespaceClientId`) with scoped permissions for CI/CD pipelines, Gradle/Maven plugins, and other
+automated integrations. These clients authenticate against the Identity Provider and receive access tokens
+scoped to specific operations from the real `OAuthScope` enum, e.g. `artifactory:publish`, `profiles:write`.
 This is the primary integration mechanism for build-time metadata ingestion.
 
 ## Module Dependencies
@@ -112,13 +116,12 @@ Frontend
   └── REST API (all domain operations)
 
 REST API
-  ├── namespace → vault (config belongs to service in namespace)
-  ├── namespace → audit (all changes logged)
-  ├── vault → kms (encrypt vault data)
-  ├── vault → artifactory (get property metadata)
-  ├── artifactory → (read-only)
-  ├── kms → (standalone, no outbound)
-  └── audit → (listens to all events via @TransactionalEventListener)
+  ├── namespace → artifactory, feature
+  ├── vault → namespace, crypto (konfigyr-core library, to encrypt vault data)
+  ├── kms → namespace (NamespaceManager)
+  ├── artifactory → (no outbound dependency on vault or kms)
+  └── audit → (listens to all events via @TransactionalEventListener: account, namespace, service,
+      invitation, vault, kms, artifactory)
 
 Identity Provider
   └── Account provisioning (standalone)
@@ -140,8 +143,10 @@ KEK (Key Encryption Key) — master key, NEVER stored in the database
             vault entries, sensitive fields
 ```
 
-- **SaaS deployment**: KEK lives in an external KMS (AWS KMS, GCP KMS)
-- **On-premise deployment**: KEK provided as a Kubernetes Secret
+- The KEK is provided to the application via `CryptoProperties.MasterKey` — a base64-encoded value, or a
+  set of Shamir secret shares — typically delivered as a Kubernetes Secret. There is currently no AWS KMS
+  or GCP KMS provider implementation in the codebase; SaaS and on-premise deployments use the same
+  config-provided master key mechanism today.
 - **DEKs** are stored in the database only in their encrypted (wrapped) form
 
 ### Key Components (konfigyr-crypto)
@@ -155,15 +160,24 @@ KEK (Key Encryption Key) — master key, NEVER stored in the database
 
 ### Key Purposes
 
-Each `KeysetMetadata` is assigned exactly one `KeyPurpose` at creation. Purpose cannot be changed.
+Each `KeysetMetadata` is assigned exactly one `KeysetPurpose` at creation. Purpose cannot be changed.
 
-| Purpose | Operations | Algorithms |
+| Purpose | Operations | Algorithms (`KeysetMetadataAlgorithm`) |
 |---------|-----------|------------|
-| `ENCRYPT` | `encrypt(plaintext)` / `decrypt(ciphertext)` | AES-GCM (symmetric) |
-| `KEY_ENCAPSULATION` | `wrap(key)` / `unwrap(ciphertext)` | RSA, EC, or ML-KEM (post-quantum) |
-| `SIGN` | `sign(data)` / `verify(signature)` — exposes public key | ECDSA, Ed25519, ML-DSA |
+| `ENCRYPTION` | `encrypt(plaintext)` / `decrypt(ciphertext)` | AES128/256-GCM, ECIES-P256 |
+| `SIGNING` | `sign(data)` / `verify(signature)` — exposes public key | ED25519, ECDSA-P256/384/521, RSA-SSA-PKCS1 |
+
+There is no third "key encapsulation"/wrap-only purpose and no post-quantum (ML-KEM/ML-DSA) algorithm
+support today.
 
 ### Key Lifecycle States
+
+Two related but distinct enums exist — don't conflate them:
+
+- **`KeyStatus`** (per-key, library-level, `com.konfigyr.crypto`): `INITIALIZING`, `INITIALIZATION_FAILED`,
+  `ENABLED`, `DISABLED`, `COMPROMISED`, `PENDING_DESTRUCTION`, `DESTRUCTION_FAILED`, `DESTROYED`.
+- **`KeysetMetadataState`** (per-keyset, app-level, `com.konfigyr.kms`): `ACTIVE`, `INACTIVE`,
+  `PENDING_DESTRUCTION`, `DESTROYED` — a coarser view that buckets the underlying keys' `KeyStatus` values.
 
 ```
 ENABLED → DISABLED → PENDING_DESTRUCTION → DESTROYED
@@ -173,50 +187,103 @@ ENABLED → DISABLED → PENDING_DESTRUCTION → DESTROYED
 - `ENABLED` — active; primary key is used for new crypto operations
 - `DISABLED` — inactive; excluded from new operations, still readable for decrypt/verify
 - `COMPROMISED` — emergency state; triggers immediate rotation
-- `PENDING_DESTRUCTION` — grace period before material is wiped (scheduled tasks run hourly by default)
-- `DESTROYED` — material deleted; record retained for audit
+- `PENDING_DESTRUCTION` — grace period before material is wiped (scheduled task runs hourly by default,
+  `KeysetTaskAutoConfiguration.KeysetDestructionTask`, configurable via
+  `konfigyr.crypto.tasks.keyset-destruction.interval`)
+- `DESTROYED` — key material deleted (`data()` set to null); record retained for audit
 
 ### Business Rules (invariants to never violate)
 
-1. **Purpose consistency** — a `KeyVersion` spec must be compatible with the parent keyset's `KeyPurpose`
+1. **Purpose consistency** — a `KeyMetadata`'s algorithm must be compatible with the parent keyset's `KeysetPurpose`
 2. **Immutability of material** — once generated, key material can never be altered
-3. **Single primary key** — a keyset should have exactly one primary version for crypto operations
-4. **Soft-deletion** — `KeysetMetadata` cannot be destroyed while it has active `KeyVersion` records; versions must be scheduled for destruction first
+3. **Single primary key** — a keyset should have exactly one primary `KeyMetadata` for crypto operations
+4. **Soft-deletion** — `KeysetMetadata` cannot be destroyed while it has active `KeyMetadata` records; keys must be scheduled for destruction first
 
-## Artifactory Domain: SDK and Key Entities
+## Artifactory Domain: Two Distinct Layers
 
-The Artifactory module is backed by the **konfigyr-artifactory** SDK
-(GitHub: https://github.com/konfigyr/konfigyr-artifactory, Maven: `com.konfigyr:konfigyr-artifactory`),
-a lightweight Java library providing the shared abstractions used by the backend, Gradle/Maven plugins,
-and third-party integrations alike.
+The Artifactory domain has two layers that must not be conflated:
 
-### Key SDK Entities
+1. **konfigyr-artifactory SDK** — a separate, standalone library
+   (GitHub: https://github.com/konfigyr/konfigyr-artifactory, Maven: `com.konfigyr:konfigyr-artifactory`)
+   used by Gradle/Maven build plugins to model and serialize artifact metadata. It ships **no HTTP client
+   and no wire route of its own** — it's a pure domain-model + Jackson-serialization library. Its types
+   are consumed on the `konfigyr-api` side as the payload shape for publish requests.
+2. **`com.konfigyr.artifactory`** in `konfigyr-api` — the REST API's own persisted domain and service
+   layer, built by ingesting the SDK's `ArtifactMetadata`. This is where namespace ownership, visibility,
+   search, and the REST endpoints actually live.
+
+### SDK Entities (`com.konfigyr.artifactory` in the konfigyr-artifactory library)
+
+Each entity is a `public interface` backed by a `Default<Interface>` record implementation.
 
 | Entity | Description |
 |--------|-------------|
-| `Artifact` | Unique component identified by Maven coordinates (`groupId:artifactId`). Parent of all versions. |
-| `ArtifactVersion` | Immutable snapshot of a specific release. Owns `PropertyOccurrence` links. |
-| `PropertyDescriptor` | Configuration property metadata: name, type, description, default, JSON Schema. |
-| `ArtifactMetadata` | Upload envelope — aggregates all `PropertyDescriptor`s for one artifact version. Uploaded by build plugins via REST. |
-| `Publication` | Version change event with lifecycle: `PENDING → PUBLISHED → FAILED`. |
-| `Manifest` | A Konfigyr service's current metadata state — used to detect property differences across environments. |
-| `ServiceManifest` | Relational link between a namespace-owned service and one or more artifact versions. Enables metadata reuse (shared library configs) across services. |
+| `Artifact` (+ `ArtifactDescriptor`) | Unique component identified by Maven coordinates (`groupId:artifactId:version`). |
+| `PropertyDescriptor` | Configuration property metadata: name, type, description, default, JSON Schema, deprecation. |
+| `ArtifactMetadata` | Upload envelope — aggregates all `PropertyDescriptor`s for one artifact version, plus a checksum. This is the publish payload uploaded by build plugins. |
+| `Publication` | A version-change/upload event. Lifecycle via `PublicationState`: `PENDING → PUBLISHED → FAILED`. |
+| `Manifest` / `ManifestEntry` | A Konfigyr service's current artifact snapshot — used to detect metadata drift across environments. |
+| `ServiceRelease` / `ServiceReleaseCandidate` / `ServiceReleaseEntry` | Transient publish/build-attempt report for a service, separate from the content-only `Manifest`. Lifecycle via `ReleaseState`: `PENDING → RELEASED → FAILED` (note: `RELEASED`, not `PUBLISHED` — distinct from `PublicationState`). |
+
+There is no SDK type linking a namespace-owned service to artifact versions — that concept exists only
+on the `konfigyr-api` side.
+
+### `konfigyr-api` Domain & Service Layer (`com.konfigyr.artifactory`)
+
+Persisted entities:
+
+| Entity | Description |
+|--------|-------------|
+| `ArtifactDefinition` | Aggregate root for an artifact identity (`groupId:artifactId`) — owner, visibility, name/description/links. |
+| `VersionedArtifact` | Aggregate root for one published version — coordinates, `PublicationState`, checksum, publish timestamp. |
+| `PropertyDefinition` | A persisted configuration property for a given artifact/version. |
+| `ArtifactKey` / `ArtifactCoordinates` | `ArtifactKey` = `groupId:artifactId` identity pair; `ArtifactCoordinates` extends it with `version`. |
+| `Owner` | Minimal namespace projection (`EntityId id`, `String slug`) resolved via `OwnerResolver`. |
+| `ArtifactVisibility` | Enum: `PUBLIC` (visible to any caller) / `PRIVATE` (visible only to the owning namespace). |
+
+Two service interfaces — don't conflate their semantics:
+
+- **`Artifactory`** (impl `DefaultArtifactory`) — visibility-based **reads only**: `get`/`exists`/`existing`.
+  `PUBLIC` artifacts are visible to any caller; `PRIVATE` artifacts only to their owning namespace (a
+  `null` `Owner` sees only `PUBLIC`). Used by machine/OAuth clients via `ArtifactoryController`, routes
+  `/artifacts/{groupId}/{artifactId}[/{version}]`, scope `READ_ARTIFACTS` (mutations `PUBLISH_ARTIFACTS`).
+- **`Publications`** (impl `DefaultPublications`) — strict **per-namespace ownership**, no visibility
+  branching: search (`artifacts`/`versions`), `get`/`exists` at both `ArtifactKey` and `ArtifactCoordinates`
+  level, `publish`, `retract` (remove one version), `deregister` (remove an artifact + all versions),
+  `changeVisibility`. Used by the namespace registry via `PublicationsController`, routes
+  `/namespaces/{namespace}/artifacts/{groupId}/{artifactId}[/{version}]`, authorized via
+  `isMember`/`isAdmin` SpEL + `PUBLISH_ARTIFACTS` scope for mutations.
+- **`ArtifactoryQueries`** — package-private shared class centralizing jOOQ query building and row
+  mapping, used by both `DefaultArtifactory` and `DefaultPublications`.
+
+Related controllers in the same package: `ArtifactOwnershipTransfersController` and
+`GroupVerificationsController` (both under `/namespaces/{namespace}/...`, `isAdmin` + `READ_NAMESPACES`/
+`WRITE_NAMESPACES` scopes).
+
+Domain events — `ArtifactoryEvent` is a sealed hierarchy, every event carries the artifact's `Owner`:
+
+- `ArtifactEvent` (keyed by `ArtifactCoordinates`): `PublicationCreated`, `PublicationCompleted`,
+  `PublicationFailed`, `PublicationRetracted`.
+- `DefinitionEvent` (keyed by `ArtifactKey`): `Deregistered`, `VisibilityChanged`.
+- `OwnershipTransferEvent` (carries `groupId` + `from`/`to` `Owner`s): `OwnershipTransferAccepted`,
+  `OwnershipTransferRejected`, `OwnershipTransferCancelled`.
+
+All of the above are consumed by `AuditEventListener` and have matching message templates in
+`audit.properties`.
 
 ### Metadata Ingestion Flow
 
 ```
 Build (Gradle/Maven plugin)
   1. Extract spring-configuration-metadata.json from classpath
-  2. Translate property types → JSON Schema
-  3. POST /artifactory/artifacts/{group}/{artifact}/{version}
-     (ArtifactMetadata payload, authenticated as namespace OAuth2 client)
+  2. Translate property types → JSON Schema, build an SDK ArtifactMetadata payload
+  3. POST /namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}
+     (authenticated as a namespace OAuth2 client with PUBLISH_ARTIFACTS scope)
   ↓
-Artifactory module
-  4. Compute Definition Checksum (name + typeName)
-  5. Compute Occurrence Checksum (schema + description + deprecation)
-  6. Deduplicate: reuse existing PropertyOccurrence if checksum matches
-  7. Create Version-to-Property links
-  8. Update Publication status: PENDING → PUBLISHED
+konfigyr-api Publications.publish(Owner, ArtifactMetadata)
+  4. Persist/update ArtifactDefinition (groupId:artifactId) and PropertyDefinition rows
+  5. Create a new VersionedArtifact, state PENDING → PUBLISHED
+  6. Publish PublicationCreated / PublicationCompleted (or PublicationFailed) events
 ```
 
 ## API Contracts
@@ -224,36 +291,90 @@ Artifactory module
 ### Namespace Endpoints
 
 ```
-GET    /namespaces/:slug           @RequiresScope(READ_NAMESPACES)
+GET    /namespaces/{slug}          @RequiresScope(READ_NAMESPACES)
 POST   /namespaces                 @RequiresScope(WRITE_NAMESPACES)
-PATCH  /namespaces/:slug           @RequiresScope(WRITE_NAMESPACES)
-DELETE /namespaces/:slug           @RequiresScope(DELETE_NAMESPACES)
+PUT    /namespaces/{slug}          @RequiresScope(WRITE_NAMESPACES)
+DELETE /namespaces/{slug}          @RequiresScope(DELETE_NAMESPACES)
 ```
 
 ### Vault Endpoints
 
+There is no `/vaults` resource — profiles and change requests are scoped under a namespace's service.
+Scopes are `READ_PROFILES`/`WRITE_PROFILES`, not `READ_VAULT`.
+
 ```
-GET    /namespaces/:ns/vaults      @RequiresScope(READ_VAULT)
-GET    /namespaces/:ns/vaults/:id/profiles/:prof
-POST   /namespaces/:ns/vaults/:id/entries
-PATCH  /namespaces/:ns/vaults/:id/entries/:eid
+GET    /namespaces/{namespace}/services/{service}/profiles                          @RequiresScope(READ_PROFILES)
+GET    /namespaces/{namespace}/services/{service}/profiles/{profileName}            @RequiresScope(READ_PROFILES)
+POST   /namespaces/{namespace}/services/{service}/profiles/{profileName}/submit     @RequiresScope(WRITE_PROFILES)
+POST   /namespaces/{namespace}/services/{service}/profiles/{profileName}/apply      (UNPROTECTED profiles only)
+POST   /namespaces/{namespace}/services/{service}/changes/{number}/review           (approve/comment)
+POST   /namespaces/{namespace}/services/{service}/changes/{number}/merge            (apply an approved change request)
 ```
+
+`ProfilePolicy` has three values, not two: `UNPROTECTED` (direct `apply`), `PROTECTED` (requires
+`submit` → `review`/approve → `merge`), and `IMMUTABLE` (no changes permitted at all). Note the workflow
+direction: it's the direct **apply** step that's skipped for `PROTECTED` profiles — `merge` is what makes
+an approved change request authoritative, and is always required to actually apply a submitted change.
 
 ### Audit Endpoints
 
+There is no top-level `/audit` resource or single-record lookup — audit records are only listed nested
+under a namespace, scoped `READ_NAMESPACES` (not a `READ_AUDIT` scope, which doesn't exist).
+
 ```
-GET    /audit                      @RequiresScope(READ_AUDIT)
-GET    /audit/:id                  @RequiresScope(READ_AUDIT)
+GET    /namespaces/{slug}/audit    @RequiresScope(READ_NAMESPACES), @PreAuthorize("isMember(#slug)")
+```
+
+### Artifactory / Publications Endpoints
+
+```
+GET/HEAD /artifacts/{groupId}/{artifactId}[/{version}]                              @RequiresScope(READ_ARTIFACTS)
+POST     /artifacts/{groupId}/{artifactId}/{version}                                @RequiresScope(PUBLISH_ARTIFACTS)
+PUT      /artifacts/{groupId}/{artifactId}/visibility                               @RequiresScope(PUBLISH_ARTIFACTS)
+
+GET/HEAD /namespaces/{namespace}/artifacts[/{groupId}[/{artifactId}[/{version}]]]    isMember, @RequiresScope(READ_ARTIFACTS)
+PUT      /namespaces/{namespace}/artifacts/{groupId}/{artifactId}/visibility        isAdmin, @RequiresScope(PUBLISH_ARTIFACTS)
+DELETE   /namespaces/{namespace}/artifacts/{groupId}/{artifactId}                   isAdmin, @RequiresScope(PUBLISH_ARTIFACTS)  (deregister)
+DELETE   /namespaces/{namespace}/artifacts/{groupId}/{artifactId}/{version}         isAdmin, @RequiresScope(PUBLISH_ARTIFACTS)  (retract)
+```
+
+### KMS Endpoints
+
+```
+GET      /namespaces/{namespace}/kms                              isMember, @RequiresScope(READ_NAMESPACES)
+GET      /namespaces/{namespace}/kms/{id}                         isMember
+POST     /namespaces/{namespace}/kms                              isAdmin,  @RequiresScope(WRITE_NAMESPACES)
+PUT      /namespaces/{namespace}/kms/{id}/rotate                  isAdmin,  @RequiresScope(WRITE_NAMESPACES)
+DELETE   /namespaces/{namespace}/kms/{id}                         isAdmin,  @RequiresScope(WRITE_NAMESPACES)
+PUT      /namespaces/{namespace}/kms/{id}/keys/{key}/{deactivate|reactivate|compromised|restore}
+                                                                   isAdmin,  @RequiresScope(WRITE_NAMESPACES)
+POST     /namespaces/{namespace}/kms/{id}/{encrypt|decrypt|sign|verify}   isMember, @RequiresScope(WRITE_NAMESPACES)
 ```
 
 ## Frontend Routes
 
+File-based TanStack Start routing under `konfigyr-frontend/src/routes`. Most app routes sit under a
+pathless `_authenticated` layout; `/auth/*`, `/api/$`, and `/error` do not.
+
 ```
-/                            Dashboard
-/namespace/:slug             Namespace detail
-/namespace/:slug/members     Member management
-/namespace/:slug/services/:svc/profiles/:prof   Vault access
-/auth/code                   OAuth2 callback
+/                                                          Dashboard
+/account                                                   User account page
+/join/$key                                                 Invitation acceptance
+/namespace/provision                                       Namespace onboarding
+/namespace/$namespace                                      Namespace detail
+/namespace/$namespace/settings                             Namespace settings
+/namespace/$namespace/members                              Member management
+/namespace/$namespace/groups[/create|/$groupId[/edit]]     RBAC groups
+/namespace/$namespace/invitations                          Pending invitations
+/namespace/$namespace/applications[/create|/$id]           OAuth2 client applications
+/namespace/$namespace/audit                                Audit log
+/namespace/$namespace/kms[/create|/$keyset]                Keysets
+/namespace/$namespace/services/$service                    Service detail/settings/create-profile
+/namespace/$namespace/services/$service/manifest[/artifacts]   Service manifest / artifact metadata
+/namespace/$namespace/services/$service/profiles/$profile[/history]   Vault profile access
+/namespace/$namespace/services/$service/requests[/$number]      Change requests
+/auth/code                                                 OAuth2 callback
+/auth/scopes                                               OAuth scopes
 ```
 
 ## Data Flow Example: Creating a Namespace
@@ -277,7 +398,7 @@ REST API - KMS module
   ↓
 Frontend
   9. Receive 201 Created response
-  10. Redirect to /namespace/:slug
+  10. Redirect to /namespace/$namespace
   11. Load namespace data (already cached server-side from loader)
 ```
 
@@ -292,26 +413,30 @@ Frontend
 ### SaaS (Multi-tenant)
 - Shared database (PostgreSQL managed service)
 - Shared IdP (konfigyr-identity)
-- KEK managed by external KMS (AWS KMS, GCP KMS)
+- KEK provided via `CryptoProperties.MasterKey`, typically delivered as a Kubernetes Secret
 - CDN for static assets, load-balanced API instances
 
 ### On-Premise
 - Isolated database per deployment
 - On-premise IdP (konfigyr-identity)
-- KEK provided as a Kubernetes Secret
+- KEK provided via `CryptoProperties.MasterKey`, typically delivered as a Kubernetes Secret
 - Behind customer firewall, per-deployment SSL certificates
 
 ## Namespace Access Control
 
-Two roles, namespace-scoped:
+Two `NamespaceRole` values, namespace-scoped, enforced via `@PreAuthorize("isMember(#namespace)")` /
+`@PreAuthorize("isAdmin(#namespace)")` SpEL (backed by `KonfigyrMethodSecurityExpressionRoot`), combined
+with `@RequiresScope` for OAuth-scope checks:
 
 | Role | Permissions |
 |------|-------------|
 | `ADMIN` | Manage members, billing, services, all configurations |
 | `USER` | Manage configurations and deployments only |
 
-OAuth2 clients registered by a namespace authenticate as that namespace and carry permission scopes
-(`metadata:upload`, `config:read`, etc.) rather than a user role.
+OAuth2 clients registered by a namespace (`NamespaceApplicationDefinition`) authenticate as that namespace
+and carry permission scopes from the real `OAuthScope` enum — `namespaces:read/write/delete/invite/
+publish-releases`, `artifactory:read/publish`, `profiles:read/write/delete`, `openid` — rather than a
+user role.
 
 ## Verification Checklist
 


### PR DESCRIPTION
`project-overview` had drifted from the codebase across several sections, some of it predating the recent Artifactory rework, some introduced by it. This audits and fixes every section against current source.

  - **Artifactory**: split into two clearly separated layers — the standalone `konfigyr-artifactory` SDK (pure domain-model/serialization library, no HTTP client of its own) vs. `konfigyr-api`'s own persisted domain (`ArtifactDefinition`, `VersionedArtifact`, `PropertyDefinition`, `Owner`, `ArtifactVisibility`) and services (`Artifactory` read-only/visibility-based, `Publications` per-namespace ownership), including the new `PublicationsController`, `ArtifactOwnershipTransfersController`, `GroupVerificationsController` routes and the `ArtifactEvent`/`DefinitionEvent`/`OwnershipTransferEvent` hierarchy.
  - **KMS**: corrected enum names (`KeysetPurpose` not `KeyPurpose`, values `ENCRYPTION`/`SIGNING` — no `KEY_ENCAPSULATION` or post-quantum algorithms exist), `KeyMetadata` not `KeyVersion`, disambiguated `KeyStatus` (per-key) vs `KeysetMetadataState` (per-keyset), and corrected the KEK story (no AWS/GCP KMS integration exists — both SaaS and on-prem use the same config-provided master key).
  - **Vault/Audit/Namespace API contracts**: fixed nonexistent routes/scopes (no `/vaults` or `/audit` top-level resources, no `READ_VAULT`/`READ_AUDIT` scopes), added the missing `IMMUTABLE` `ProfilePolicy` value, and corrected the change-request workflow direction (direct `apply` is what's skippable for `PROTECTED` profiles, not approval).
  - **Module dependency graph**: several edges were backwards or missing (`vault → namespace`, `kms → namespace`, `namespace → artifactory/feature`).
  - **Frontend routes**: added ~10 route sections missing from the doc (`applications`, `groups`, `invitations`, `kms`, `settings`, `audit`, service `manifest/artifacts`, `requests`, `/account`, `/join/$key`, `/namespace/provision`, `/auth/scopes`).
  - **Identity Provider**: corrected JWT issuance (PS256 only — ES256 is inbound-verification-only) and the configured provider list (GitHub + generic OIDC; GitLab is a trusted issuer for token-exchange, not a login provider; Google/SAML aren't implemented).
  - Misc: Spring Boot version (4.1, not 3.5+), several entity name corrections in the module table (`NamespaceRole` not `Role`, `PropertyChange` not `Entry`, `FeatureDefinition`/`FeatureValue` not `FeatureFlag`, `AuditRecord` not `AuditLog`).
