### PR TITLE
Add full-text property search across artifacts and the service catalog

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/Artifactory.java
@@ -1,7 +1,9 @@
 package com.konfigyr.artifactory;
 
-import org.jspecify.annotations.NonNull;
+import com.konfigyr.support.SearchQuery;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
 
 import java.util.Collection;
 import java.util.List;
@@ -22,6 +24,7 @@ import java.util.Set;
  * @since 1.0.0
  * @see Publications
  */
+@NullMarked
 public interface Artifactory {
 
 	/**
@@ -36,8 +39,7 @@ public interface Artifactory {
 	 * @param key the artifact key identifying the artifact, can't {@literal null}
 	 * @return the resolved {@link ArtifactDefinition}, or {@code empty} if no artifact exists for the given key
 	 */
-	@NonNull
-	Optional<ArtifactDefinition> get(@NonNull ArtifactKey key);
+	Optional<ArtifactDefinition> get(ArtifactKey key);
 
 	/**
 	 * Resolves a specific artifact definition identified by the provided key, restricted to
@@ -53,8 +55,7 @@ public interface Artifactory {
 	 * @param key the artifact key identifying the artifact version, can't {@literal null}
 	 * @return the resolved {@link ArtifactDefinition}, or {@code empty} if none exists or is visible to {@code owner}
 	 */
-	@NonNull
-	Optional<ArtifactDefinition> get(@Nullable Owner owner, @NonNull ArtifactKey key);
+	Optional<ArtifactDefinition> get(@Nullable Owner owner, ArtifactKey key);
 
 	/**
 	 * Determines whether an artifact definition exists for the given artifact key.
@@ -65,7 +66,7 @@ public interface Artifactory {
 	 * @param key the artifact key identifying the artifact, can't {@literal null}
 	 * @return {@code true} if an artifact definition exists, otherwise {@code false}
 	 */
-	boolean exists(@NonNull ArtifactKey key);
+	boolean exists(ArtifactKey key);
 
 	/**
 	 * Determines whether an artifact definition exists for the given key and is visible to the
@@ -76,7 +77,7 @@ public interface Artifactory {
 	 * @param key the artifact key identifying the artifact, can't {@literal null}
 	 * @return {@code true} if an artifact definition exists and is visible to {@code owner}, otherwise {@code false}
 	 */
-	boolean exists(@Nullable Owner owner, @NonNull ArtifactKey key);
+	boolean exists(@Nullable Owner owner, ArtifactKey key);
 
 	/**
 	 * Resolves a specific artifact version identified by the provided coordinates.
@@ -90,8 +91,7 @@ public interface Artifactory {
 	 * @param coordinates the artifact coordinates identifying the artifact version, can't {@literal null}
 	 * @return the resolved {@link VersionedArtifact}, or {@code empty} if no artifact exists for the given coordinates
 	 */
-	@NonNull
-	Optional<VersionedArtifact> get(@NonNull ArtifactCoordinates coordinates);
+	Optional<VersionedArtifact> get(ArtifactCoordinates coordinates);
 
 	/**
 	 * Resolves a specific artifact version identified by the provided coordinates, restricted to
@@ -107,8 +107,7 @@ public interface Artifactory {
 	 * @param coordinates the artifact coordinates identifying the artifact version, can't {@literal null}
 	 * @return the resolved {@link VersionedArtifact}, or {@code empty} if none exists or is visible to {@code owner}
 	 */
-	@NonNull
-	Optional<VersionedArtifact> get(@Nullable Owner owner, @NonNull ArtifactCoordinates coordinates);
+	Optional<VersionedArtifact> get(@Nullable Owner owner, ArtifactCoordinates coordinates);
 
 	/**
 	 * Returns the property definitions associated with the specified artifact version.
@@ -123,8 +122,43 @@ public interface Artifactory {
 	 * @return the list of property definitions associated with the artifact, never {@literal null}
 	 * @throws ArtifactVersionNotFoundException if no artifact exists for the given coordinates
 	 */
-	@NonNull
-	List<PropertyDefinition> properties(@NonNull ArtifactCoordinates coordinates);
+	List<PropertyDefinition> properties(ArtifactCoordinates coordinates);
+
+	/**
+	 * Searches {@link PropertyDefinition property definitions} across every artifact indexed by this
+	 * {@code Artifactory}, restricted to what the given {@code owner} is allowed to see, the same
+	 * {@link ArtifactVisibility#PUBLIC PUBLIC}/{@link ArtifactVisibility#PRIVATE PRIVATE} rule described
+	 * on {@link #get(Owner, ArtifactKey)} applies here, evaluated per property's owning artifact.
+	 * <p>
+	 * The {@link SearchQuery} may combine:
+	 * <ul>
+	 *     <li>{@link SearchQuery#term()}: split into words and matched, each as a prefix, against the
+	 *     property's {@code name} and {@code description} using the {@code property_definitions.search_vector}
+	 *     column (a {@code tsvector} maintained by a database trigger). Splitting on non-alphanumeric
+	 *     characters means a dotted/hyphenated term like {@code spring.datasource.url} is treated as three
+	 *     separate words, each of which must be present (as a prefix) somewhere in the match — so a partial
+	 *     term like {@code spring.appl} still matches {@code spring.application.name}. A property whose
+	 *     {@code name} matches is ranked above one that only matches through its {@code description}; the
+	 *     ranking replaces whatever sort the {@link SearchQuery#pageable()} would otherwise apply,
+	 *     matching-name-first always wins when a term is present.</li>
+	 *     <li>{@link ArtifactKey#GROUP_ID_CRITERIA} / {@link ArtifactKey#ARTIFACT_ID_CRITERIA}: restricts
+	 *     results to properties owned by artifacts with a matching {@code groupId}/{@code artifactId}.</li>
+	 *     <li>{@link ArtifactCoordinates#VERSION_CRITERIA}: restricts results to properties that are
+	 *     still declared by at least one artifact version matching this exact version string.</li>
+	 * </ul>
+	 * None of the above are required; a {@link SearchQuery} with no term and no criteria returns every
+	 * property visible to {@code owner}, sorted by name.
+	 * <p>
+	 * Implementation note: pagination and sorting here are handled directly rather than through the
+	 * shared {@code PageableExecutor}, since the term-based ranking is a computed SQL expression, not a
+	 * field that a static sort-field mapping could express.
+	 *
+	 * @param owner the namespace on whose behalf this search is performed, or {@literal null} if the
+	 *        caller has no namespace context, in which case only {@code PUBLIC} properties are returned
+	 * @param query the search query used to filter, rank, and page through the results, can't be {@literal null}
+	 * @return the page of matching property definitions visible to {@code owner}, never {@literal null}
+	 */
+	Page<PropertyDefinition> search(@Nullable Owner owner, SearchQuery query);
 
 	/**
 	 * Determines whether an artifact version exists for the given coordinates.
@@ -135,7 +169,7 @@ public interface Artifactory {
 	 * @param coordinates the artifact coordinates identifying the artifact version, can't {@literal null}
 	 * @return {@code true} if an artifact version exists, otherwise {@code false}
 	 */
-	boolean exists(@NonNull ArtifactCoordinates coordinates);
+	boolean exists(ArtifactCoordinates coordinates);
 
 	/**
 	 * Determines whether an artifact version exists for the given coordinates and is visible to the
@@ -146,7 +180,7 @@ public interface Artifactory {
 	 * @param coordinates the artifact coordinates identifying the artifact version, can't {@literal null}
 	 * @return {@code true} if an artifact version exists and is visible to {@code owner}, otherwise {@code false}
 	 */
-	boolean exists(@Nullable Owner owner, @NonNull ArtifactCoordinates coordinates);
+	boolean exists(@Nullable Owner owner, ArtifactCoordinates coordinates);
 
 	/**
 	 * Returns the {@link Publication} for each of the given {@link ArtifactCoordinates} that is already
@@ -170,7 +204,6 @@ public interface Artifactory {
 	 * @param coordinates coordinates to check, can be empty
 	 * @return the publications matching the given coordinates that exist, never {@literal null}, empty if the input is empty
 	 */
-	@NonNull
-	Set<Publication> existing(@NonNull Owner owner, @NonNull Collection<ArtifactCoordinates> coordinates);
+	Set<Publication> existing(Owner owner, Collection<ArtifactCoordinates> coordinates);
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryQueries.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryQueries.java
@@ -10,6 +10,7 @@ import org.jspecify.annotations.NullMarked;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.Objects;
 import java.util.Optional;
 
 import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
@@ -37,11 +38,6 @@ final class ArtifactoryQueries {
 			.sortField("version", ARTIFACT_VERSIONS.VERSION)
 			.build();
 
-	private static final PageableExecutor propertySearchPageableExecutor = PageableExecutor.builder()
-			.defaultSortField(PROPERTY_DEFINITIONS.NAME.asc())
-			.sortField("name", PROPERTY_DEFINITIONS.NAME)
-			.build();
-
 	private final DSLContext context;
 	private final ArtifactoryConverters converters;
 
@@ -55,10 +51,10 @@ final class ArtifactoryQueries {
 
 	Page<ArtifactDefinition> definitions(Condition condition, Pageable pageable) {
 		return artifactDefinitionPageableExecutor.execute(
-				createArtifactDefinitionQuery().where(condition),
+				this::createArtifactDefinitionQuery,
+				() -> condition,
 				ArtifactoryQueries::toArtifactDefinition,
-				pageable,
-				() -> context.fetchCount(createArtifactDefinitionQuery().where(condition))
+				pageable
 		);
 	}
 
@@ -70,10 +66,10 @@ final class ArtifactoryQueries {
 
 	Page<VersionedArtifact> versions(Condition condition, Pageable pageable) {
 		return versionedArtifactPageableExecutor.execute(
-				createVersionedArtifactQuery().where(condition),
+				this::createVersionedArtifactQuery,
+				() -> condition,
 				ArtifactoryQueries::toVersionedArtifact,
-				pageable,
-				() -> context.fetchCount(createVersionedArtifactQuery().where(condition))
+				pageable
 		);
 	}
 
@@ -83,12 +79,12 @@ final class ArtifactoryQueries {
 				.fetchOptional(ArtifactoryQueries::toVersionedArtifact);
 	}
 
-	Page<PropertyDefinition> properties(Condition condition, Pageable pageable) {
-		return propertySearchPageableExecutor.execute(
-				createPropertySearchQuery().where(condition),
+	Page<PropertyDefinition> properties(PageableExecutor executor, Condition condition, Pageable pageable) {
+		return executor.execute(
+				this::createPropertySearchQuery,
+				() -> condition,
 				record -> toPropertyDefinition(record, converters),
-				pageable,
-				() -> context.fetchCount(createPropertySearchQuery().where(condition))
+				pageable
 		);
 	}
 
@@ -98,7 +94,7 @@ final class ArtifactoryQueries {
 				.fetchOptional(record -> toPropertyDefinition(record, converters));
 	}
 
-	SelectJoinStep<? extends Record> createArtifactDefinitionQuery() {
+	SelectJoinStep<Record> createArtifactDefinitionQuery() {
 		return context.select(ARTIFACTS.fields())
 				.select(NAMESPACES.ID, NAMESPACES.SLUG)
 				.from(ARTIFACTS)
@@ -106,7 +102,7 @@ final class ArtifactoryQueries {
 				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
 	}
 
-	SelectJoinStep<? extends Record> createVersionedArtifactQuery() {
+	SelectJoinStep<Record> createVersionedArtifactQuery() {
 		return context.select(ARTIFACT_VERSIONS.fields())
 				.select(ARTIFACTS.ID, ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, ARTIFACTS.VISIBILITY,
 						ARTIFACTS.NAME, ARTIFACTS.DESCRIPTION, ARTIFACTS.WEBSITE, ARTIFACTS.REPOSITORY)
@@ -118,7 +114,7 @@ final class ArtifactoryQueries {
 				.on(NAMESPACES.ID.eq(ARTIFACTS.NAMESPACE_ID));
 	}
 
-	SelectJoinStep<? extends Record> createPropertySearchQuery() {
+	SelectJoinStep<Record> createPropertySearchQuery() {
 		return context.select(PROPERTY_DEFINITIONS.fields())
 				.select(ARTIFACTS.GROUP_ID, ARTIFACTS.ARTIFACT_ID, NAMESPACES.ID, NAMESPACES.SLUG)
 				.from(PROPERTY_DEFINITIONS)
@@ -175,6 +171,11 @@ final class ArtifactoryQueries {
 	}
 
 	static PropertyDefinition toPropertyDefinition(Record record, ArtifactoryConverters converters) {
+		final JsonSchema schema = Objects.requireNonNullElseGet(
+				record.get(PROPERTY_DEFINITIONS.SCHEMA, converters.schema()),
+				NullSchema::instance
+		);
+
 		return PropertyDefinition.builder()
 				.id(record.get(PROPERTY_DEFINITIONS.ID))
 				.artifact(record.get(PROPERTY_DEFINITIONS.ARTIFACT_ID))
@@ -186,7 +187,7 @@ final class ArtifactoryQueries {
 				.typeName(record.get(PROPERTY_DEFINITIONS.TYPE_NAME))
 				.defaultValue(record.get(PROPERTY_DEFINITIONS.DEFAULT_VALUE))
 				.description(record.get(PROPERTY_DEFINITIONS.DESCRIPTION))
-				.schema(record.get(PROPERTY_DEFINITIONS.SCHEMA, converters.schema()))
+				.schema(schema)
 				.deprecation(record.get(PROPERTY_DEFINITIONS.DEPRECATION, converters.deprecation()))
 				.occurrences(record.get(PROPERTY_DEFINITIONS.OCCURRENCES))
 				.firstSeen(record.get(PROPERTY_DEFINITIONS.FIRST_SEEN))

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/DefaultArtifactory.java
@@ -1,17 +1,20 @@
 package com.konfigyr.artifactory;
 
+import com.konfigyr.data.PageableExecutor;
+import com.konfigyr.support.SearchQuery;
+import com.konfigyr.support.Tokenizer;
+import com.konfigyr.support.Tokens;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.Condition;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
+import java.util.*;
 
 import static com.konfigyr.data.tables.ArtifactVersionProperties.ARTIFACT_VERSION_PROPERTIES;
 import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
@@ -21,6 +24,18 @@ import static com.konfigyr.data.tables.PropertyDefinitions.PROPERTY_DEFINITIONS;
 @Slf4j
 @RequiredArgsConstructor
 class DefaultArtifactory implements Artifactory {
+
+	/**
+	 * Splits a search term into words the same way the {@code property_definitions} search vector trigger
+	 * normalizes {@code name} (see {@code artifactory-1.0.0.xml}), any run of non-alphanumeric characters,
+	 * so a dotted/hyphenated term like {@code spring.datasource.url} is treated as three separate words.
+	 */
+	private static final Tokenizer TERM_TOKENIZER = Tokenizer.alphanumeric();
+
+	private static final PageableExecutor propertySearchPageableExecutor = PageableExecutor.builder()
+			.defaultSortField(PROPERTY_DEFINITIONS.NAME.asc())
+			.sortField("name", PROPERTY_DEFINITIONS.NAME)
+			.build();
 
 	private final ArtifactoryQueries queries;
 
@@ -113,6 +128,43 @@ class DefaultArtifactory implements Artifactory {
 
 	@NonNull
 	@Override
+	@SuppressWarnings("deprecation")
+	@Transactional(readOnly = true, label = "artifactory.search-properties")
+	public Page<PropertyDefinition> search(@Nullable Owner owner, @NonNull SearchQuery query) {
+		final List<Condition> conditions = new ArrayList<>();
+		conditions.add(visibilityCondition(owner));
+		query.criteria(ArtifactKey.GROUP_ID_CRITERIA)
+				.map(ARTIFACTS.GROUP_ID::equalIgnoreCase)
+				.ifPresent(conditions::add);
+		query.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA)
+				.map(ARTIFACTS.ARTIFACT_ID::equalIgnoreCase)
+				.ifPresent(conditions::add);
+		query.criteria(ArtifactCoordinates.VERSION_CRITERIA)
+				.map(version -> DSL.exists(
+						DSL.select(ARTIFACT_VERSION_PROPERTIES.PROPERTY_DEFINITION_ID)
+								.from(ARTIFACT_VERSION_PROPERTIES)
+								.innerJoin(ARTIFACT_VERSIONS)
+								.on(ARTIFACT_VERSIONS.ID.eq(ARTIFACT_VERSION_PROPERTIES.ARTIFACT_VERSION_ID))
+								.where(
+										ARTIFACT_VERSION_PROPERTIES.PROPERTY_DEFINITION_ID.eq(PROPERTY_DEFINITIONS.ID),
+										ARTIFACT_VERSIONS.VERSION.equalIgnoreCase(version)
+								)
+				))
+				.ifPresent(conditions::add);
+
+		final String rankSearchTerm = query.term(TERM_TOKENIZER)
+				.map(DefaultArtifactory::toPrefixTsQuery)
+				.filter(StringUtils::hasText)
+				.orElse(null);
+
+		return queries.properties(
+				propertySearchPageableExecutor.rankBy(rankSearchTerm, PROPERTY_DEFINITIONS.SEARCH_VECTOR),
+				DSL.and(conditions), query.pageable()
+		);
+	}
+
+	@NonNull
+	@Override
 	@Transactional(readOnly = true, label = "artifactory.version-properties")
 	public List<PropertyDefinition> properties(@NonNull ArtifactCoordinates coordinates) {
 		final Long artifactVersionId = queries.context().select(ARTIFACT_VERSIONS.ID)
@@ -158,4 +210,22 @@ class DefaultArtifactory implements Artifactory {
 				ARTIFACT_VERSIONS.VERSION.eq(coordinates.version().get())
 		);
 	}
+
+	/**
+	 * Builds a {@code tsquery} expression from a search term already split into words by {@link #TERM_TOKENIZER}
+	 * (the same normalization the search vector trigger applies to {@code name}), requiring every word to be
+	 * present as a prefix ({@code word:*}), so a partial term like {@code spring.appl} matches a property
+	 * named {@code spring.application.name}, and a full dotted name matches by requiring each of its segments
+	 * as its own word.
+	 *
+	 * @param words the search term, already split into words, can't be {@literal null}
+	 * @return the {@code tsquery} expression text, or blank if {@code words} has no alphanumeric words
+	 */
+	@NonNull
+	static String toPrefixTsQuery(Tokens words) {
+		return words.filter(StringUtils::hasText)
+				.map(word -> word + ":*")
+				.join(" & ");
+	}
+
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
@@ -3,10 +3,12 @@ package com.konfigyr.artifactory.controller;
 import com.konfigyr.artifactory.*;
 import com.konfigyr.hateoas.CollectionModel;
 import com.konfigyr.hateoas.EntityModel;
+import com.konfigyr.hateoas.PagedModel;
 import com.konfigyr.security.AuthenticatedPrincipal;
 import com.konfigyr.security.NamespacedPrincipal;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
+import com.konfigyr.support.SearchQuery;
 import com.konfigyr.version.Version;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
@@ -15,6 +17,8 @@ import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
@@ -40,6 +44,25 @@ class ArtifactoryController {
 	private final OwnerResolver resolver;
 	private final Artifactory artifactory;
 	private final Publications publications;
+
+	@GetMapping("/search")
+	PagedModel<EntityModel<PropertyDefinition>> search(
+			@Nullable @RequestParam(required = false) String groupId,
+			@Nullable @RequestParam(required = false) String artifactId,
+			@Nullable @RequestParam(required = false) String version,
+			@NotBlank @RequestParam String term,
+			Pageable pageable
+	) {
+		final SearchQuery query = SearchQuery.builder()
+				.criteria(ArtifactKey.GROUP_ID_CRITERIA, groupId)
+				.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA, artifactId)
+				.criteria(ArtifactCoordinates.VERSION_CRITERIA, version)
+				.pageable(pageable)
+				.term(term)
+				.build();
+
+		return Assemblers.property().assemble(artifactory.search(resolveOwner().orElse(null), query));
+	}
 
 	@GetMapping("/{groupId}/{artifactId}")
 	EntityModel<ArtifactDefinition> definition(

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/Assemblers.java
@@ -39,6 +39,10 @@ interface Assemblers {
 				.add(linkBuilder(owner, (Artifact) artifact).method(HttpMethod.DELETE).rel("Retract artifact version"));
 	}
 
+	static RepresentationModelAssembler<PropertyDefinition, EntityModel<PropertyDefinition>> property() {
+		return EntityModel::of;
+	}
+
 	static RepresentationModelAssembler<PropertyDefinition, EntityModel<PropertyDefinition>> property(ArtifactCoordinates coordinates) {
 		return property -> EntityModel.of(property, linkBuilder(coordinates).path(property.id().serialize()).selfRel());
 	}

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/PublicationsController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/PublicationsController.java
@@ -6,6 +6,7 @@ import com.konfigyr.hateoas.PagedModel;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
 import com.konfigyr.support.SearchQuery;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiresScope(OAuthScope.READ_ARTIFACTS)
 class PublicationsController {
 
+	private final Artifactory artifactory;
 	private final Publications publications;
 	private final OwnerResolver ownerResolver;
 
@@ -185,6 +187,27 @@ class PublicationsController {
 	) {
 		final Owner owner = ownerResolver.resolve(namespace);
 		publications.retract(owner, ArtifactCoordinates.of(groupId, artifactId, version));
+	}
+
+	@GetMapping("/artifacts/search")
+	@PreAuthorize("isMember(#namespace)")
+	PagedModel<EntityModel<PropertyDefinition>> search(
+			@PathVariable String namespace,
+			@Nullable @RequestParam(required = false) String groupId,
+			@Nullable @RequestParam(required = false) String artifactId,
+			@Nullable @RequestParam(required = false) String version,
+			@NotBlank @RequestParam String term,
+			Pageable pageable
+	) {
+		final SearchQuery query = SearchQuery.builder()
+				.criteria(ArtifactKey.GROUP_ID_CRITERIA, groupId)
+				.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA, artifactId)
+				.criteria(ArtifactCoordinates.VERSION_CRITERIA, version)
+				.pageable(pageable)
+				.term(term)
+				.build();
+
+		return Assemblers.property().assemble(artifactory.search(ownerResolver.resolve(namespace), query));
 	}
 
 	record ChangeVisibilityRequest(@NotNull ArtifactVisibility visibility) { /* noop */ }

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/DefaultGroupVerifications.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ownership/DefaultGroupVerifications.java
@@ -8,10 +8,8 @@ import com.konfigyr.support.SearchQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.codec.binary.Hex;
-import org.jooq.Condition;
-import org.jooq.DSLContext;
+import org.jooq.*;
 import org.jooq.Record;
-import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.data.domain.Page;
@@ -87,10 +85,10 @@ class DefaultGroupVerifications implements GroupVerifications {
 		));
 
 		return groupVerificationPageableExecutor.execute(
-				createGroupVerificationsQuery(DSL.and(conditions)),
+				this::createGroupVerificationsQuery,
+				() -> DSL.and(conditions),
 				DefaultGroupVerifications::toGroupVerification,
-				query.pageable(),
-				() -> context.fetchCount(createGroupVerificationsQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
@@ -261,12 +259,11 @@ class DefaultGroupVerifications implements GroupVerifications {
 		return Hex.encodeHexString(seed);
 	}
 
-	private SelectConditionStep<? extends Record> createGroupVerificationsQuery(Condition condition) {
+	private SelectWhereStep<Record> createGroupVerificationsQuery() {
 		return context.select(GROUP_VERIFICATIONS.fields())
 				.select(NAMESPACES.SLUG)
 				.from(GROUP_VERIFICATIONS)
-				.join(NAMESPACES).on(GROUP_VERIFICATIONS.NAMESPACE_ID.eq(NAMESPACES.ID))
-				.where(condition);
+				.join(NAMESPACES).on(GROUP_VERIFICATIONS.NAMESPACE_ID.eq(NAMESPACES.ID));
 	}
 
 	private void expireActiveChallenges(GroupVerification verification) {

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfers.java
@@ -11,10 +11,8 @@ import com.konfigyr.entity.EntityId;
 import com.konfigyr.support.SearchQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jooq.Condition;
-import org.jooq.DSLContext;
+import org.jooq.*;
 import org.jooq.Record;
-import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NullMarked;
 import org.springframework.context.ApplicationEventPublisher;
@@ -100,10 +98,12 @@ class DefaultArtifactOwnershipTransfers implements ArtifactOwnershipTransfers {
 	@Override
 	@Transactional(readOnly = true, label = "artifact-ownership-transfers.find-by-id")
 	public Optional<ArtifactOwnershipTransfer> findById(Owner owner, EntityId id) {
-		return createTransferQuery(DSL.and(
+		return createTransferQuery().where(DSL.and(
 				ARTIFACT_OWNERSHIP_TRANSFERS.ID.eq(id.get()),
-				ARTIFACT_OWNERSHIP_TRANSFERS.FROM_NAMESPACE_ID.eq(owner.id().get())
-						.or(ARTIFACT_OWNERSHIP_TRANSFERS.TO_NAMESPACE_ID.eq(owner.id().get()))
+				DSL.or(
+						ARTIFACT_OWNERSHIP_TRANSFERS.FROM_NAMESPACE_ID.eq(owner.id().get()),
+						ARTIFACT_OWNERSHIP_TRANSFERS.TO_NAMESPACE_ID.eq(owner.id().get())
+				)
 		)).fetchOptional(DefaultArtifactOwnershipTransfers::toArtifactOwnershipTransfer);
 	}
 
@@ -239,20 +239,19 @@ class DefaultArtifactOwnershipTransfers implements ArtifactOwnershipTransfers {
 		query.term().ifPresent(term -> conditions.add(ARTIFACT_OWNERSHIP_TRANSFERS.GROUP_ID.containsIgnoreCase(term)));
 
 		return transferPageableExecutor.execute(
-				createTransferQuery(DSL.and(conditions)),
+				this::createTransferQuery,
+				() -> DSL.and(conditions),
 				DefaultArtifactOwnershipTransfers::toArtifactOwnershipTransfer,
-				query.pageable(),
-				() -> context.fetchCount(createTransferQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
-	private SelectConditionStep<? extends Record> createTransferQuery(Condition condition) {
+	private SelectWhereStep<Record> createTransferQuery() {
 		return context.select(ARTIFACT_OWNERSHIP_TRANSFERS.fields())
 				.select(FROM_NAMESPACES.SLUG, TO_NAMESPACES.SLUG)
 				.from(ARTIFACT_OWNERSHIP_TRANSFERS)
 				.innerJoin(FROM_NAMESPACES).on(FROM_NAMESPACES.ID.eq(ARTIFACT_OWNERSHIP_TRANSFERS.FROM_NAMESPACE_ID))
-				.innerJoin(TO_NAMESPACES).on(TO_NAMESPACES.ID.eq(ARTIFACT_OWNERSHIP_TRANSFERS.TO_NAMESPACE_ID))
-				.where(condition);
+				.innerJoin(TO_NAMESPACES).on(TO_NAMESPACES.ID.eq(ARTIFACT_OWNERSHIP_TRANSFERS.TO_NAMESPACE_ID));
 	}
 
 	private static ArtifactOwnershipTransfer toArtifactOwnershipTransfer(Record record) {

--- a/konfigyr-api/src/main/java/com/konfigyr/kms/DefaultKeysetManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/kms/DefaultKeysetManager.java
@@ -133,20 +133,22 @@ class DefaultKeysetManager implements KeysetManager {
 		}
 
 		return keysetMetadataExecutor.execute(
-				createKeysetMetadataQuery(DSL.and(conditions)),
+				this::createKeysetMetadataQuery,
+				() -> DSL.and(conditions),
 				DefaultKeysetManager::toKeysetMetadata,
-				query.pageable(),
-				() -> context.fetchCount(createKeysetMetadataQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
 	@Override
 	@Transactional(readOnly = true, label = "kms.find-by-id")
 	public Optional<KeysetMetadata> get(Namespace namespace, EntityId id) {
-		return createKeysetMetadataQuery(DSL.and(
-				KMS_KEYSET_METADATA.ID.eq(id.get()),
-				KMS_KEYSET_METADATA.NAMESPACE_ID.eq(namespace.id().get())
-		)).fetchOptional(DefaultKeysetManager::toKeysetMetadata);
+		return createKeysetMetadataQuery()
+				.where(DSL.and(
+						KMS_KEYSET_METADATA.ID.eq(id.get()),
+						KMS_KEYSET_METADATA.NAMESPACE_ID.eq(namespace.id().get())
+				))
+				.fetchOptional(DefaultKeysetManager::toKeysetMetadata);
 	}
 
 	@Override
@@ -161,7 +163,8 @@ class DefaultKeysetManager implements KeysetManager {
 	@Override
 	@Transactional(readOnly = true, label = "kms.keys-by-id")
 	public List<KeyMetadata> keys(KeysetMetadata keyset) {
-		return createKeyMetadataQuery(KMS_KEYSET_METADATA.ID.eq(keyset.id().get()))
+		return createKeyMetadataQuery()
+				.where(KMS_KEYSET_METADATA.ID.eq(keyset.id().get()))
 				.orderBy(KEYSET_KEYS.CREATED_AT.desc())
 				.fetch(DefaultKeysetManager::toKeyMetadata);
 	}
@@ -324,7 +327,8 @@ class DefaultKeysetManager implements KeysetManager {
 
 	// used internally to retrieve the metadata from the db, usually after a successful update...
 	private KeysetMetadata lookup(EntityId id) {
-		return createKeysetMetadataQuery(KMS_KEYSET_METADATA.ID.eq(id.get()))
+		return createKeysetMetadataQuery()
+				.where(KMS_KEYSET_METADATA.ID.eq(id.get()))
 				.fetchOptional(DefaultKeysetManager::toKeysetMetadata)
 				.orElseThrow(() -> new IllegalStateException("Failed to lookup keyset metadata with id: " + id.get()));
 	}
@@ -349,7 +353,7 @@ class DefaultKeysetManager implements KeysetManager {
 		}
 	}
 
-	private SelectConditionStep<Record> createKeysetMetadataQuery(Condition condition) {
+	private SelectWhereStep<Record> createKeysetMetadataQuery() {
 		return context.select(KEYSET_METADATA_FIELDS)
 				.from(KMS_KEYSET_METADATA)
 				.innerJoin(KEYSETS)
@@ -357,18 +361,16 @@ class DefaultKeysetManager implements KeysetManager {
 				.innerJoin(KEYSET_KEYS)
 				.on(KEYSET_KEYS.KEYSET_NAME.eq(KEYSETS.KEYSET_NAME).and(KEYSET_KEYS.KEY_PRIMARY.isTrue()))
 				.innerJoin(NAMESPACES)
-				.on(NAMESPACES.ID.eq(KMS_KEYSET_METADATA.NAMESPACE_ID))
-				.where(condition);
+				.on(NAMESPACES.ID.eq(KMS_KEYSET_METADATA.NAMESPACE_ID));
 	}
 
-	private SelectConditionStep<Record> createKeyMetadataQuery(Condition condition) {
+	private SelectWhereStep<Record> createKeyMetadataQuery() {
 		return context.select(KEYS_METADATA_FIELDS)
 				.from(KMS_KEYSET_METADATA)
 				.innerJoin(KEYSETS)
 				.on(KEYSETS.KEYSET_NAME.eq(KMS_KEYSET_METADATA.KEYSET_ID))
 				.innerJoin(KEYSET_KEYS)
-				.on(KEYSET_KEYS.KEYSET_NAME.eq(KEYSETS.KEYSET_NAME))
-				.where(condition);
+				.on(KEYSET_KEYS.KEYSET_NAME.eq(KEYSETS.KEYSET_NAME));
 	}
 
 	private Optional<KeysetInformation> lookupKeysetInformation(Namespace namespace, EntityId id) {

--- a/konfigyr-api/src/main/java/com/konfigyr/membership/DefaultInvitations.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/membership/DefaultInvitations.java
@@ -12,10 +12,8 @@ import com.konfigyr.feature.LimitedFeatureValue;
 import com.konfigyr.namespace.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jooq.Condition;
-import org.jooq.DSLContext;
+import org.jooq.*;
 import org.jooq.Record;
-import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -31,6 +29,7 @@ import org.springframework.util.StringUtils;
 
 import java.time.Duration;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -71,26 +70,22 @@ class DefaultInvitations implements Invitations {
 	@Override
 	@Transactional(readOnly = true, label = "invitations-find-for-recipient")
 	public Page<Invitation> find(Account recipient, Pageable pageable) {
-		final Condition condition = INVITATIONS.RECIPIENT_EMAIL.equalIgnoreCase(recipient.email());
-
 		return executor.execute(
-				createInvitationsQuery(condition),
+				this::createInvitationsQuery,
+				() -> INVITATIONS.RECIPIENT_EMAIL.equalIgnoreCase(recipient.email()),
 				DefaultInvitations::invitation,
-				pageable,
-				() -> context.fetchCount(createInvitationsQuery(condition))
+				pageable
 		);
 	}
 
 	@Override
 	@Transactional(readOnly = true, label = "invitations-find-for-namespace")
 	public Page<Invitation> find(Namespace namespace, Pageable pageable) {
-		final Condition condition = INVITATIONS.NAMESPACE_ID.eq(namespace.id().get());
-
 		return executor.execute(
-				createInvitationsQuery(condition),
+				this::createInvitationsQuery,
+				() -> INVITATIONS.NAMESPACE_ID.eq(namespace.id().get()),
 				DefaultInvitations::invitation,
-				pageable,
-				() -> context.fetchCount(createInvitationsQuery(condition))
+				pageable
 		);
 	}
 
@@ -250,8 +245,10 @@ class DefaultInvitations implements Invitations {
 		}
 	}
 
-	private Optional<Invitation> lookupInvitation(Condition predicate) {
-		return createInvitationsQuery(predicate).fetchOptional(DefaultInvitations::invitation);
+	private Optional<Invitation> lookupInvitation(Condition condition) {
+		return createInvitationsQuery()
+				.where(condition)
+				.fetchOptional(DefaultInvitations::invitation);
 	}
 
 	private void removeInvitation(Invitation invitation) {
@@ -263,9 +260,9 @@ class DefaultInvitations implements Invitations {
 				.execute();
 	}
 
-	private SelectConditionStep<? extends Record> createInvitationsQuery(Condition condition) {
+	private SelectOnConditionStep<Record> createInvitationsQuery() {
 		return context
-				.select(
+				.select(List.of(
 						NAMESPACES.ID,
 						NAMESPACES.SLUG,
 						NAMESPACES.NAME,
@@ -281,15 +278,14 @@ class DefaultInvitations implements Invitations {
 						INVITATIONS.RECIPIENT_EMAIL,
 						INVITATIONS.ROLE,
 						INVITATIONS.CREATED_AT,
-						INVITATIONS.EXPIRY_DATE)
+						INVITATIONS.EXPIRY_DATE))
 				.from(INVITATIONS)
 				.fullOuterJoin(SENDER_ACCOUNTS)
 				.on(SENDER_ACCOUNTS.ID.eq(INVITATIONS.SENDER_ID))
 				.fullOuterJoin(RECIPIENT_ACCOUNTS)
 				.on(RECIPIENT_ACCOUNTS.ID.eq(INVITATIONS.RECIPIENT_ID))
 				.innerJoin(NAMESPACES)
-				.on(NAMESPACES.ID.eq(INVITATIONS.NAMESPACE_ID))
-				.where(condition);
+				.on(NAMESPACES.ID.eq(INVITATIONS.NAMESPACE_ID));
 	}
 
 	private Optional<NamespaceInvitationContext> lookupNamespaceInvitationContext(Namespace namespace, Invite invite) {

--- a/konfigyr-api/src/main/java/com/konfigyr/membership/DefaultMemberships.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/membership/DefaultMemberships.java
@@ -10,10 +10,8 @@ import com.konfigyr.support.FullName;
 import com.konfigyr.support.SearchQuery;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jooq.Condition;
-import org.jooq.DSLContext;
+import org.jooq.*;
 import org.jooq.Record;
-import org.jooq.SelectConditionStep;
 import org.jooq.impl.DSL;
 import org.jspecify.annotations.NonNull;
 import org.springframework.context.ApplicationEventPublisher;
@@ -67,10 +65,10 @@ class DefaultMemberships implements Memberships {
 		}
 
 		return membersExecutor.execute(
-				createMembersQuery(DSL.and(conditions)),
+				this::createMembersQuery,
+				() -> DSL.and(conditions),
 				DefaultMemberships::toMember,
-				query.pageable(),
-				() -> context.fetchCount(createMembersQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
@@ -78,7 +76,7 @@ class DefaultMemberships implements Memberships {
 	@Override
 	@Transactional(readOnly = true, label = "namespace-get-member")
 	public Optional<Member> get(@NonNull Namespace namespace, @NonNull EntityId id) {
-		return createMembersQuery(DSL.and(
+		return createMembersQuery().where(DSL.and(
 				NAMESPACE_MEMBERS.ID.eq(id.get()),
 				NAMESPACE_MEMBERS.NAMESPACE_ID.eq(namespace.id().get())
 		)).fetchOptional(DefaultMemberships::toMember);
@@ -100,7 +98,8 @@ class DefaultMemberships implements Memberships {
 				))
 				.execute();
 
-		final Member member = createMembersQuery(NAMESPACE_MEMBERS.ID.eq(id.get()))
+		final Member member = createMembersQuery()
+				.where(NAMESPACE_MEMBERS.ID.eq(id.get()))
 				.fetchOptional(DefaultMemberships::toMember)
 				.orElseThrow(() -> new NamespaceException("Failed to update unknown member with: " + id));
 
@@ -162,8 +161,8 @@ class DefaultMemberships implements Memberships {
 	}
 
 	@NonNull
-	private SelectConditionStep<? extends Record> createMembersQuery(@NonNull Condition condition) {
-		return context.select(
+	private SelectOnConditionStep<Record> createMembersQuery() {
+		return context.select(List.of(
 						NAMESPACE_MEMBERS.ID,
 						NAMESPACE_MEMBERS.NAMESPACE_ID,
 						NAMESPACE_MEMBERS.ACCOUNT_ID,
@@ -173,13 +172,12 @@ class DefaultMemberships implements Memberships {
 						ACCOUNTS.FIRST_NAME,
 						ACCOUNTS.LAST_NAME,
 						ACCOUNTS.AVATAR
-				)
+				))
 				.from(NAMESPACE_MEMBERS)
 				.innerJoin(NAMESPACES)
 				.on(NAMESPACES.ID.eq(NAMESPACE_MEMBERS.NAMESPACE_ID))
 				.innerJoin(ACCOUNTS)
-				.on(ACCOUNTS.ID.eq(NAMESPACE_MEMBERS.ACCOUNT_ID))
-				.where(condition);
+				.on(ACCOUNTS.ID.eq(NAMESPACE_MEMBERS.ACCOUNT_ID));
 	}
 
 	@NonNull

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultNamespaceManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultNamespaceManager.java
@@ -106,10 +106,10 @@ class DefaultNamespaceManager implements NamespaceManager {
 		}
 
 		return namespaceExecutor.execute(
-				createNamespaceQuery(DSL.and(conditions)),
+				this::createNamespaceQuery,
+				() -> DSL.and(conditions),
 				DefaultNamespaceManager::toNamespace,
-				query.pageable(),
-				() -> context.fetchCount(createNamespaceQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
@@ -276,10 +276,10 @@ class DefaultNamespaceManager implements NamespaceManager {
 		}
 
 		return applicationsExecutor.execute(
-				createApplicationsQuery(DSL.and(conditions)),
+				this::createApplicationsQuery,
+				() -> DSL.and(conditions),
 				this::toApplication,
-				query.pageable(),
-				() -> context.fetchCount(createApplicationsQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 
 	}
@@ -288,7 +288,8 @@ class DefaultNamespaceManager implements NamespaceManager {
 	@Override
 	@Transactional(label = "namespace-get-application", readOnly = true)
 	public Optional<NamespaceApplication> getApplication(@NonNull EntityId application) {
-		return createApplicationsQuery(OAUTH_APPLICATIONS.ID.eq(application.get()))
+		return createApplicationsQuery()
+				.where(OAUTH_APPLICATIONS.ID.eq(application.get()))
 				.fetchOptional(this::toApplication);
 	}
 
@@ -445,10 +446,10 @@ class DefaultNamespaceManager implements NamespaceManager {
 		)));
 
 		return trustedIssuersExecutor.execute(
-				createTrustedIssuersQuery(DSL.and(conditions)),
+				this::createTrustedIssuersQuery,
+				() -> DSL.and(conditions),
 				this::toTrustedIssuer,
-				query.pageable(),
-				() -> context.fetchCount(createTrustedIssuersQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
@@ -456,7 +457,7 @@ class DefaultNamespaceManager implements NamespaceManager {
 	@Override
 	@Transactional(readOnly = true, label = "namespace-get-trusted-issuer")
 	public Optional<NamespaceTrustedIssuer> getTrustedIssuer(@NonNull Namespace namespace, @NonNull EntityId id) {
-		return createTrustedIssuersQuery(DSL.and(
+		return createTrustedIssuersQuery().where(DSL.and(
 				NAMESPACE_TRUSTED_ISSUERS.NAMESPACE_ID.eq(namespace.id().get()),
 				NAMESPACE_TRUSTED_ISSUERS.ID.eq(id.get())
 		)).fetchOptional(this::toTrustedIssuer);
@@ -557,10 +558,9 @@ class DefaultNamespaceManager implements NamespaceManager {
 	}
 
 	@NonNull
-	private SelectConditionStep<? extends Record> createTrustedIssuersQuery(@NonNull Condition condition) {
+	private SelectWhereStep<Record> createTrustedIssuersQuery() {
 		return context.select(NAMESPACE_TRUSTED_ISSUERS.fields())
-				.from(NAMESPACE_TRUSTED_ISSUERS)
-				.where(condition);
+				.from(NAMESPACE_TRUSTED_ISSUERS);
 	}
 
 	@NonNull
@@ -581,16 +581,17 @@ class DefaultNamespaceManager implements NamespaceManager {
 	}
 
 	@NonNull
-	private SelectConditionStep<Record> createNamespaceQuery(@NonNull Condition condition) {
+	private SelectWhereStep<Record> createNamespaceQuery() {
 		return context
 				.select(NAMESPACES.fields())
-				.from(NAMESPACES)
-				.where(condition);
+				.from(NAMESPACES);
 	}
 
 	@NonNull
 	private Optional<Namespace> fetch(@NonNull Condition condition) {
-		return createNamespaceQuery(condition).fetchOptional(DefaultNamespaceManager::toNamespace);
+		return createNamespaceQuery()
+				.where(condition)
+				.fetchOptional(DefaultNamespaceManager::toNamespace);
 	}
 
 	@NonNull
@@ -633,8 +634,8 @@ class DefaultNamespaceManager implements NamespaceManager {
 	}
 
 	@NonNull
-	private SelectConditionStep<? extends Record> createApplicationsQuery(@NonNull Condition condition) {
-		return context.select(
+	private SelectOnConditionStep<Record> createApplicationsQuery() {
+		return context.select(List.of(
 						OAUTH_APPLICATIONS.ID,
 						OAUTH_APPLICATIONS.NAMESPACE_ID,
 						OAUTH_APPLICATIONS.TYPE,
@@ -645,16 +646,15 @@ class DefaultNamespaceManager implements NamespaceManager {
 						OAUTH_APPLICATIONS.EXPIRES_AT,
 						OAUTH_APPLICATIONS.CREATED_AT,
 						OAUTH_APPLICATIONS.UPDATED_AT
-				)
+				))
 				.from(OAUTH_APPLICATIONS)
 				.innerJoin(NAMESPACES)
-				.on(NAMESPACES.ID.eq(OAUTH_APPLICATIONS.NAMESPACE_ID))
-				.where(condition);
+				.on(NAMESPACES.ID.eq(OAUTH_APPLICATIONS.NAMESPACE_ID));
 	}
 
 	@NonNull
 	private Optional<? extends Record> lookupApplication(@NonNull EntityId namespace, @NonNull EntityId application) {
-		return createApplicationsQuery(DSL.and(
+		return createApplicationsQuery().where(DSL.and(
 				OAUTH_APPLICATIONS.ID.eq(application.get()),
 				OAUTH_APPLICATIONS.NAMESPACE_ID.eq(namespace.get())
 		)).fetchOptional();

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/DefaultServices.java
@@ -62,10 +62,10 @@ class DefaultServices implements Services {
 		}
 
 		return servicesExecutor.execute(
-				createServicesQuery(DSL.and(conditions)),
+				this::createServicesQuery,
+				() -> DSL.and(conditions),
 				DefaultServices::toService,
-				query.pageable(),
-				() -> context.fetchCount(createServicesQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
@@ -231,16 +231,17 @@ class DefaultServices implements Services {
 	}
 
 	@NonNull
-	private SelectConditionStep<Record> createServicesQuery(@NonNull Condition condition) {
+	private SelectWhereStep<Record> createServicesQuery() {
 		return context
 				.select(SERVICES.fields())
-				.from(SERVICES)
-				.where(condition);
+				.from(SERVICES);
 	}
 
 	@NonNull
 	private Optional<Service> fetch(@NonNull Condition condition) {
-		return createServicesQuery(condition).fetchOptional(DefaultServices::toService);
+		return createServicesQuery()
+				.where(condition)
+				.fetchOptional(DefaultServices::toService);
 	}
 
 	@NonNull

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/catalog/ConfigurationCatalogService.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/catalog/ConfigurationCatalogService.java
@@ -1,13 +1,14 @@
 package com.konfigyr.namespace.catalog;
 
-import com.konfigyr.artifactory.ArtifactoryConverters;
-import com.konfigyr.artifactory.PropertyDescriptor;
+import com.konfigyr.artifactory.*;
 import com.konfigyr.data.PageableExecutor;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.namespace.Service;
 import com.konfigyr.namespace.ServiceCatalog;
 import com.konfigyr.namespace.ServiceEvent;
 import com.konfigyr.support.SearchQuery;
+import com.konfigyr.support.Tokenizer;
+import com.konfigyr.support.Tokens;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.*;
@@ -21,10 +22,13 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import static com.konfigyr.data.tables.PropertyDefinitions.PROPERTY_DEFINITIONS;
 import static com.konfigyr.data.tables.ServiceConfigurationCatalog.SERVICE_CONFIGURATION_CATALOG;
 
 /**
@@ -61,6 +65,14 @@ class ConfigurationCatalogService implements ServiceCatalogSource {
 	 */
 	private static final String CREATE_PARTITION_COMMAND = "CREATE TABLE {0} PARTITION OF {1} FOR VALUES IN ({2});";
 
+	/**
+	 * Splits a search term into words the same way the {@code service_configuration_catalog} search vector
+	 * trigger normalizes {@code name} (see {@code namespaces-1.0.0.xml}), any run of non-alphanumeric
+	 * characters, so a dotted/hyphenated term like {@code spring.datasource.url} is treated as three
+	 * separate words.
+	 */
+	private static final Tokenizer TERM_TOKENIZER = Tokenizer.alphanumeric();
+
 	static final PageableExecutor serviceCatalogExecutor = PageableExecutor.builder()
 			.defaultSortField(SERVICE_CONFIGURATION_CATALOG.NAME.asc())
 			.build();
@@ -71,8 +83,8 @@ class ConfigurationCatalogService implements ServiceCatalogSource {
 	@Override
 	@Transactional(readOnly = true, label = "retrieve-service-catalog")
 	public ServiceCatalog get(Service service) {
-		final List<ServiceCatalog.Property> properties =
-				createServiceCatalogQuery(SERVICE_CONFIGURATION_CATALOG.SERVICE_ID.eq(service.id().get()))
+		final List<ServiceCatalog.Property> properties = createServiceCatalogQuery()
+				.where(SERVICE_CONFIGURATION_CATALOG.SERVICE_ID.eq(service.id().get()))
 				.orderBy(SERVICE_CONFIGURATION_CATALOG.NAME)
 				.fetch(this::toPropertyDescriptor);
 
@@ -80,21 +92,22 @@ class ConfigurationCatalogService implements ServiceCatalogSource {
 	}
 
 	@Override
+	@SuppressWarnings("deprecation")
 	@Transactional(readOnly = true, label = "search-service-catalog")
 	public Page<PropertyDescriptor> query(Service service, SearchQuery query) {
 		final List<Condition> conditions = new ArrayList<>();
 		conditions.add(SERVICE_CONFIGURATION_CATALOG.SERVICE_ID.eq(service.id().get()));
 
-		query.term().ifPresent(term -> conditions.add(DSL.or(
-				SERVICE_CONFIGURATION_CATALOG.NAME.likeIgnoreCase(term),
-				DSL.condition("search_vector @@ plainto_tsquery('simple', ?)", term)
-		)));
+		final String rankSearchTerm = query.term(TERM_TOKENIZER)
+				.map(ConfigurationCatalogService::toPrefixTsQuery)
+				.filter(StringUtils::hasText)
+				.orElse(null);
 
-		return serviceCatalogExecutor.execute(
-				createServiceCatalogQuery(DSL.and(conditions)),
+		return serviceCatalogExecutor.rankBy(rankSearchTerm, SERVICE_CONFIGURATION_CATALOG.SEARCH_VECTOR).execute(
+				this::createServiceCatalogQuery,
+				() -> DSL.and(conditions),
 				this::toPropertyDescriptor,
-				query.pageable(),
-				() -> context.fetchCount(createServiceCatalogQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
@@ -124,20 +137,24 @@ class ConfigurationCatalogService implements ServiceCatalogSource {
 		log.info(PARTITION_MARKER, "Successfully dropped configuration catalog partition for service: {}", event.id());
 	}
 
-	private SelectConditionStep<Record> createServiceCatalogQuery(Condition condition) {
+	private SelectJoinStep<Record> createServiceCatalogQuery() {
 		return context.select(SERVICE_CONFIGURATION_CATALOG.fields())
-				.from(SERVICE_CONFIGURATION_CATALOG)
-				.where(condition);
+				.from(SERVICE_CONFIGURATION_CATALOG);
 	}
 
 	private ServiceCatalog.Property toPropertyDescriptor(Record record) {
+		final JsonSchema schema = Objects.requireNonNullElseGet(
+				record.get(PROPERTY_DEFINITIONS.SCHEMA, converters.schema()),
+				NullSchema::instance
+		);
+
 		return ServiceCatalog.Property.builder()
 				.groupId(record.get(SERVICE_CONFIGURATION_CATALOG.GROUP_ID))
 				.artifactId(record.get(SERVICE_CONFIGURATION_CATALOG.ARTIFACT_ID))
 				.version(record.get(SERVICE_CONFIGURATION_CATALOG.VERSION))
 				.name(record.get(SERVICE_CONFIGURATION_CATALOG.NAME))
 				.typeName(record.get(SERVICE_CONFIGURATION_CATALOG.TYPE_NAME))
-				.schema(record.get(SERVICE_CONFIGURATION_CATALOG.SCHEMA, converters.schema()))
+				.schema(schema)
 				.description(record.get(SERVICE_CONFIGURATION_CATALOG.DESCRIPTION))
 				.defaultValue(record.get(SERVICE_CONFIGURATION_CATALOG.DEFAULT_VALUE))
 				.deprecation(record.get(SERVICE_CONFIGURATION_CATALOG.DEPRECATION, converters.deprecation()))
@@ -146,5 +163,21 @@ class ConfigurationCatalogService implements ServiceCatalogSource {
 
 	static Name formatPartitionTableName(EntityId id) {
 		return DSL.name(SERVICE_CONFIGURATION_CATALOG.getName() + "_" + id.get());
+	}
+
+	/**
+	 * Builds a {@code tsquery} expression from a search term already split into words by {@link #TERM_TOKENIZER}
+	 * (the same normalization the search vector trigger applies to {@code name}), requiring every word to be
+	 * present as a prefix ({@code word:*}), so a partial term like {@code spring.appl} matches a property
+	 * named {@code spring.application.name}, and a full dotted name matches by requiring each of its segments
+	 * as its own word.
+	 *
+	 * @param words the search term, already split into words, can't be {@literal null}
+	 * @return the {@code tsquery} expression text, or {@literal empty} if {@code words} has no alphanumeric words
+	 */
+	static String toPrefixTsQuery(Tokens words) {
+		return words.filter(StringUtils::hasText)
+				.map(word -> word + ":*")
+				.join(" & ");
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/support/SearchQuery.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/support/SearchQuery.java
@@ -88,6 +88,18 @@ public sealed interface SearchQuery permits CriteriaSearchQuery {
 	}
 
 	/**
+	 * Returns an {@link Optional} that may contain the search term, split into {@link Tokens} by the
+	 * given {@code tokenizer}.
+	 *
+	 * @param tokenizer the tokenizer used to split the search term, can't be {@literal null}
+	 * @return the tokenized search term or an empty {@link Optional}, never {@literal null}.
+	 */
+	@NonNull
+	default Optional<Tokens> term(Tokenizer tokenizer) {
+		return term().map(tokenizer::tokenize);
+	}
+
+	/**
 	 * Returns an {@link Optional} that may contain the {@link Criteria search query critera}
 	 * value that is used to filter results.
 	 *

--- a/konfigyr-api/src/main/java/com/konfigyr/support/Tokenizer.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/support/Tokenizer.java
@@ -1,0 +1,127 @@
+package com.konfigyr.support;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.util.regex.Pattern;
+
+/**
+ * Splits a value into an ordered sequence of {@link Tokens}.
+ * <p>
+ * Implementations decide how a value is split, e.g., by whitespace, punctuation, pattern, or n-grams,
+ * but are only responsible for splitting. What the resulting tokens are used for is entirely up to
+ * the caller.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@NullMarked
+@FunctionalInterface
+public interface Tokenizer {
+
+	/**
+	 * Returns a {@link Tokenizer} that treats the entire input as a single token, performing no
+	 * splitting at all.
+	 *
+	 * @return a {@link Tokenizer} that yields the input unchanged as its only token
+	 */
+	static Tokenizer identity() {
+		return value -> new Tokens(new String[] {value});
+	}
+
+	/**
+	 * Returns a {@link Tokenizer} that splits a value on runs of whitespace.
+	 * <p>
+	 * Leading and trailing whitespace is ignored, so a value consisting entirely of whitespace
+	 * (or the empty string) produces a single empty token, use {@link Tokens#filter(java.util.function.Predicate)}
+	 * afterward if blank tokens should be discarded.
+	 *
+	 * @return a {@link Tokenizer} that splits on whitespace
+	 */
+	static Tokenizer whitespace() {
+		return value -> new Tokens(Patterns.WHITESPACE.split(value.strip()));
+	}
+
+	/**
+	 * Returns a {@link Tokenizer} that splits a value into its alphanumeric runs, treating any run of
+	 * non-alphanumeric characters (e.g. {@code .}, {@code -}, {@code _}) as a delimiter, so a dotted or
+	 * hyphenated identifier like {@code spring.datasource.url} tokenizes as {@code ["spring", "datasource", "url"]}.
+	 * <p>
+	 * This mirrors the Spring Configuration property name normalization performed by the search vector triggers
+	 * ({@code regexp_replace(name, '[^a-zA-Z0-9]+', ' ', 'g')}). If this pattern is ever changed (e.g., to a
+	 * Unicode-aware {@code [^\p{L}\p{N}]+}), those triggers must be updated to match, or indexed search terms
+	 * and query terms will tokenize differently.
+	 *
+	 * @return a {@link Tokenizer} that splits on runs of non-alphanumeric characters
+	 */
+	static Tokenizer alphanumeric() {
+		return pattern(Patterns.ALPHANUMERIC);
+	}
+
+	/**
+	 * Returns a {@link Tokenizer} that splits a value using the given regular expression as a delimiter,
+	 * as if by {@link Pattern#compile(String)} followed by {@link Pattern#split(CharSequence)}.
+	 * <p>
+	 * The expression is treated as a delimiter to split <em>on</em>, not as a pattern that tokens must
+	 * match, e.g. {@code "[^a-zA-Z0-9]+"} splits on runs of non-alphanumeric characters, yielding the
+	 * alphanumeric runs in between as tokens.
+	 *
+	 * @param pattern the regular expression to compile and split on, can't be {@code null}
+	 * @return a {@link Tokenizer} backed by the compiled pattern, never {@code null}
+	 * @throws java.util.regex.PatternSyntaxException if {@code pattern}'s syntax is invalid
+	 * @see Pattern#compile(String)
+	 */
+	static Tokenizer pattern(String pattern) {
+		return pattern(Pattern.compile(pattern));
+	}
+
+	/**
+	 * Returns a {@link Tokenizer} that splits a value using the given {@link Pattern} as a delimiter,
+	 * as if by {@link Pattern#split(CharSequence)}.
+	 * <p>
+	 * The pattern is treated as a delimiter to split <em>on</em>, not as a pattern that tokens must
+	 * match, e.g. {@code Pattern.compile("[^a-zA-Z0-9]+")} splits on runs of non-alphanumeric characters,
+	 * yielding the alphanumeric runs in between as tokens.
+	 *
+	 * @param pattern the delimiter pattern to split on, can't be {@code null}
+	 * @return a {@link Tokenizer} backed by the given pattern, never {@code null}
+	 * @see Pattern#split(CharSequence)
+	 */
+	static Tokenizer pattern(Pattern pattern) {
+		return pattern(pattern, 0);
+	}
+
+	/**
+	 * Returns a {@link Tokenizer} that splits a value using the given {@link Pattern} as a delimiter,
+	 * as if by {@link Pattern#split(CharSequence, int)}.
+	 * <p>
+	 * The pattern is treated as a delimiter to split <em>on</em>, not as a pattern that tokens must match.
+	 * The {@code limit} parameter controls the resulting array as per {@link Pattern#split(CharSequence, int)}: a
+	 * positive value applies the pattern at most {@code limit - 1} times and keeps any trailing content
+	 * (including trailing empty strings) as the final token; zero applies the pattern as many times as
+	 * possible and discards trailing empty strings; a negative value applies the pattern as many times
+	 * as possible and keeps trailing empty strings.
+	 *
+	 * @param pattern the delimiter pattern to split on, can't be {@code null}
+	 * @param limit   the result-limit/behavior control, per {@link Pattern#split(CharSequence, int)}
+	 * @return a {@link Tokenizer} backed by the given pattern and limit, never {@code null}
+	 * @see Pattern#split(CharSequence, int)
+	 */
+	static Tokenizer pattern(Pattern pattern, int limit) {
+		return input -> new Tokens(pattern.split(input, limit));
+	}
+
+	/**
+	 * Splits the given value into tokens.
+	 *
+	 * @param value the value to split; may be empty but must not be {@code null}
+	 * @return the resulting {@link Tokens}, in the order produced by this
+	 *         tokenizer; never {@code null}, may be empty
+	 */
+	Tokens tokenize(String value);
+
+	final class Patterns {
+		private static final Pattern WHITESPACE = Pattern.compile("\\s+");
+		private static final Pattern ALPHANUMERIC = Pattern.compile("[^a-zA-Z0-9]+");
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/support/Tokens.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/support/Tokens.java
@@ -1,0 +1,167 @@
+package com.konfigyr.support;
+
+import lombok.EqualsAndHashCode;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.core.convert.converter.Converter;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+/**
+ * An immutable, ordered collection of tokens produced by a {@link Tokenizer}.
+ * <p>
+ * This type carries tokens between a {@link Tokenizer} and whatever consumes them; it makes
+ * no assumptions about the tokens' content or their intended use.
+ * <p>
+ * Instances of this class are immutable and safe to share and reuse.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see Tokenizer
+ */
+@NullMarked
+@EqualsAndHashCode
+public final class Tokens implements Iterable<String> {
+
+	private static final Tokens EMPTY = new Tokens(List.of());
+
+	private final List<String> values;
+
+	/**
+	 * Creates a new {@link Tokens} from the given values.
+	 *
+	 * @param values the token values, in order; none may be {@code null}
+	 */
+	Tokens(String[] values) {
+		this(List.of(values));
+	}
+
+	private Tokens(List<String> values) {
+		this.values = values;
+	}
+
+	/**
+	 * Returns an empty {@link Tokens}.
+	 *
+	 * @return an empty {@link Tokens} instance
+	 */
+	public static Tokens empty() {
+		return EMPTY;
+	}
+
+	/**
+	 * Returns whether this instance contains no tokens.
+	 *
+	 * @return {@code true} if there are no tokens, {@code false} otherwise
+	 */
+	public boolean isEmpty() {
+		return values.isEmpty();
+	}
+
+	/**
+	 * Returns the number of tokens.
+	 *
+	 * @return the token count
+	 */
+	public int size() {
+		return values.size();
+	}
+
+	/**
+	 * Returns a sequential stream over the tokens, in their original order.
+	 *
+	 * @return a {@link Stream} of tokens; never {@code null}
+	 */
+	public Stream<String> stream() {
+		return values.stream();
+	}
+
+	/**
+	 * Returns a new {@link Tokens} containing only the tokens that satisfy the given predicate,
+	 * preserving their original order.
+	 *
+	 * @param predicate the condition a token must satisfy to be kept
+	 * @return a new {@link Tokens} with non-matching tokens removed, never {@code null}
+	 */
+	public Tokens filter(Predicate<String> predicate) {
+		return new Tokens(stream().filter(predicate).toList());
+	}
+
+	/**
+	 * Returns a new {@link Tokens} with each token transformed by the given function, preserving
+	 * order and count.
+	 *
+	 * @param mapper the per-token transformation; must not return {@code null} for any input
+	 * @return a new {@link Tokens} with each token replaced by the result of {@code mapper}, never {@code null}
+	 */
+	public Tokens map(UnaryOperator<String> mapper) {
+		return new Tokens(stream().map(mapper).toList());
+	}
+
+	/**
+	 * Returns an immutable {@link List} view of the tokens, in their
+	 * original order.
+	 *
+	 * @return a {@link List} of tokens; never {@code null}
+	 */
+	public List<String> toList() {
+		return values;
+	}
+
+	/**
+	 * Joins the tokens into a single {@link String}, in their original order, separated by {@code delimiter}.
+	 * <p>
+	 * Joining zero tokens yields an empty string, same as {@link String#join(CharSequence, CharSequence...)}
+	 * and {@link Collectors#joining(CharSequence)}. This method makes no assumption about whether an empty
+	 * result is meaningful to the caller; that judgment belongs to whatever consumes the result.
+	 *
+	 * @param delimiter the separator placed between each token, can't be {@code null}
+	 * @return the joined string, never {@code null}
+	 */
+	public String join(CharSequence delimiter) {
+		return stream().collect(Collectors.joining(delimiter));
+	}
+
+	/**
+	 * Joins the tokens into a single {@link String}, in their original order, separated by {@code delimiter}
+	 * and wrapped with {@code prefix} and {@code suffix}.
+	 * <p>
+	 * Joining zero tokens yields {@code prefix + suffix}, same as
+	 * {@link Collectors#joining(CharSequence, CharSequence, CharSequence)}.
+	 *
+	 * @param delimiter the separator placed between each token, can't be {@code null}
+	 * @param prefix the text prepended to the result, can't be {@code null}
+	 * @param suffix the text appended to the result, can't be {@code null}
+	 * @return the joined string, never {@code null}
+	 */
+	public String join(CharSequence delimiter, CharSequence prefix, CharSequence suffix) {
+		return stream().collect(Collectors.joining(delimiter, prefix, suffix));
+	}
+
+	/**
+	 * Applies {@code transformer} to this {@link Tokens} and returns its result, letting a fluent
+	 * {@code filter}/{@code map} pipeline finish with a conversion to some other type in a single
+	 * expression, rather than breaking out into a separate statement.
+	 *
+	 * @param transformer the conversion applied to this {@link Tokens}, can't be {@code null}
+	 * @param <T> the type produced by {@code transformer}
+	 * @return the result of applying {@code transformer} to this {@link Tokens}
+	 */
+	public <T> T transform(Converter<Tokens, T> transformer) {
+		return transformer.convert(this);
+	}
+
+	@Override
+	public Iterator<String> iterator() {
+		return values.iterator();
+	}
+
+	@Override
+	public String toString() {
+		return join(", ", "Tokens(", ")");
+	}
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/DefaultProfileManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/DefaultProfileManager.java
@@ -76,10 +76,10 @@ class DefaultProfileManager implements ProfileManager {
 		}
 
 		return profilesExecutor.execute(
-				createProfilesQuery(DSL.and(conditions)),
+				this::createProfilesQuery,
+				() -> DSL.and(conditions),
 				DefaultProfileManager::toProfile,
-				query.pageable(),
-				() -> context.fetchCount(createProfilesQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
@@ -190,7 +190,9 @@ class DefaultProfileManager implements ProfileManager {
 	}
 
 	private Optional<Profile> fetchProfile(Condition condition) {
-		return createProfilesQuery(condition).fetchOptional(DefaultProfileManager::toProfile);
+		return createProfilesQuery()
+				.where(condition)
+				.fetchOptional(DefaultProfileManager::toProfile);
 	}
 
 	private void delete(Profile profile) {
@@ -205,10 +207,9 @@ class DefaultProfileManager implements ProfileManager {
 		publisher.publishEvent(new ProfileEvent.Deleted(profile));
 	}
 
-	private SelectConditionStep<Record> createProfilesQuery(Condition condition) {
+	private SelectWhereStep<Record> createProfilesQuery() {
 		return context.select(PROFILE_FIELDS)
-				.from(VAULT_PROFILES)
-				.where(condition);
+				.from(VAULT_PROFILES);
 	}
 
 	private void assertServiceExists(EntityId service) {

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/changes/ChangeRequestManager.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/changes/ChangeRequestManager.java
@@ -91,10 +91,10 @@ public class ChangeRequestManager {
 		)));
 
 		return pageableExecutor.execute(
-				createChangeRequestQuery(DSL.and(conditions)),
+				this::createChangeRequestQuery,
+				() -> DSL.and(conditions),
 				record -> toChangeRequest(service, record),
-				query.pageable(),
-				() -> context.fetchCount(createChangeRequestQuery(DSL.and(conditions)))
+				query.pageable()
 		);
 	}
 
@@ -304,9 +304,10 @@ public class ChangeRequestManager {
 	 * @throws ChangeRequestNotFoundException if the change request does not exist
 	 */
 	public ChangeRequest update(ChangeRequestUpdateCommand command) {
-		final Record record = createChangeRequestQuery(
-				toChangeRequestNumberCondition(command.service(), command.number())
-		).fetchOptional().orElseThrow(() -> new ChangeRequestNotFoundException(command.service(), command.number()));
+		final Record record = createChangeRequestQuery()
+				.where(toChangeRequestNumberCondition(command.service(), command.number()))
+				.fetchOptional()
+				.orElseThrow(() -> new ChangeRequestNotFoundException(command.service(), command.number()));
 
 		final Long id = record.get(VAULT_CHANGE_REQUESTS.ID);
 		boolean transitioned = false;
@@ -443,8 +444,8 @@ public class ChangeRequestManager {
 		return request;
 	}
 
-	private SelectConditionStep<? extends Record> createChangeRequestQuery(Condition condition) {
-		return context.select(
+	private SelectOnConditionStep<Record> createChangeRequestQuery() {
+		return context.select(List.of(
 						VAULT_PROFILES.ID,
 						VAULT_PROFILES.SERVICE_ID,
 						VAULT_PROFILES.SLUG,
@@ -465,15 +466,15 @@ public class ChangeRequestManager {
 						VAULT_CHANGE_REQUESTS.CREATED_BY,
 						VAULT_CHANGE_REQUESTS.CREATED_AT,
 						VAULT_CHANGE_REQUESTS.UPDATED_AT
-				)
+				))
 				.from(VAULT_CHANGE_REQUESTS)
 				.innerJoin(VAULT_PROFILES)
-				.on(VAULT_PROFILES.ID.eq(VAULT_CHANGE_REQUESTS.PROFILE_ID))
-				.where(condition);
+				.on(VAULT_PROFILES.ID.eq(VAULT_CHANGE_REQUESTS.PROFILE_ID));
 	}
 
 	private Optional<ChangeRequest> lookupChangeRequest(Service service, Condition condition) {
-		return createChangeRequestQuery(condition)
+		return createChangeRequestQuery()
+				.where(condition)
 				.fetchOptional(record -> toChangeRequest(service, record));
 	}
 

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/ArtifactoryTest.java
@@ -2,11 +2,13 @@ package com.konfigyr.artifactory;
 
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.io.ByteArray;
+import com.konfigyr.support.SearchQuery;
 import com.konfigyr.test.AbstractIntegrationTest;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 
 import java.net.URI;
@@ -343,6 +345,182 @@ class ArtifactoryTest extends AbstractIntegrationTest {
 		assertThat(artifactory.exists(null, coordinates))
 				.as("a caller with no namespace context should not see a private artifact exists")
 				.isFalse();
+	}
+
+	@Test
+	@DisplayName("should search public property definitions for a caller with no namespace context")
+	void shouldSearchPublicPropertyDefinitionsForAnyOwner() {
+		final var result = artifactory.search(null, SearchQuery.of(Pageable.ofSize(20)));
+
+		assertThat(result.stream())
+				.as("only properties owned by PUBLIC artifacts should be visible")
+				.extracting(PropertyDefinition::id)
+				.containsExactlyInAnyOrder(
+						EntityId.from(1), EntityId.from(2), EntityId.from(3), EntityId.from(4),
+						EntityId.from(5), EntityId.from(6), EntityId.from(7), EntityId.from(8),
+						EntityId.from(9), EntityId.from(10), EntityId.from(11), EntityId.from(12),
+						EntityId.from(13), EntityId.from(14), EntityId.from(15), EntityId.from(16)
+				);
+	}
+
+	@Test
+	@DisplayName("should include a namespace's own private property definitions alongside public ones")
+	void shouldSearchIncludesOwnPrivatePropertyDefinitions() {
+		final var result = artifactory.search(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("internal")
+				.build());
+
+		assertThat(result.stream())
+				.as("konfigyr should see its own private konfigyr-internal-secrets properties")
+				.extracting(PropertyDefinition::id)
+				.containsExactlyInAnyOrder(EntityId.from(19), EntityId.from(20), EntityId.from(21));
+	}
+
+	@Test
+	@DisplayName("should never surface a private property definition owned by a different namespace")
+	void shouldSearchNeverIncludesPrivatePropertyDefinitionsOwnedByDifferentNamespace() {
+		final var query = SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("internal")
+				.build();
+
+		assertThat(artifactory.search(Owners.johnDoe(), query))
+				.as("john-doe must not see konfigyr's private properties, even by term match")
+				.isEmpty();
+
+		assertThat(artifactory.search(null, query))
+				.as("a caller with no namespace context must not see private properties")
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should only surface a private property definition for its owning namespace")
+	void shouldSearchPrivatePropertyDefinitionOnlyForOwner() {
+		final var query = SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("notes")
+				.build();
+
+		assertThat(artifactory.search(Owners.johnDoe(), query).stream())
+				.as("john-doe should see its own private-notes properties")
+				.extracting(PropertyDefinition::id)
+				.containsExactlyInAnyOrder(EntityId.from(17), EntityId.from(18));
+
+		assertThat(artifactory.search(Owners.konfigyr(), query))
+				.as("konfigyr must not see john-doe's private properties")
+				.isEmpty();
+
+		assertThat(artifactory.search(null, query))
+				.as("a caller with no namespace context must not see john-doe's private properties")
+				.isEmpty();
+	}
+
+	@Test
+	@DisplayName("should match a property definition by its description alone, without a name match")
+	void shouldSearchMatchPropertyByDescriptionOnly() {
+		final var result = artifactory.search(null, SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("logging")
+				.build());
+
+		assertThat(result.stream())
+				.as("'logging' only appears in spring.application.name's description, never in its name")
+				.extracting(PropertyDefinition::id)
+				.containsExactly(EntityId.from(1));
+	}
+
+	@Test
+	@DisplayName("should rank a property definition matching by name above one matching only by description")
+	void shouldSearchRankNameMatchAboveDescriptionOnlyMatch() {
+		final var result = artifactory.search(null, SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("application")
+				.build());
+
+		assertThat(result.stream())
+				.as("id=1 and id=11 match 'application' by name, id=12 only matches through its description")
+				.extracting(PropertyDefinition::id)
+				.containsExactly(EntityId.from(1), EntityId.from(11), EntityId.from(12));
+	}
+
+	@Test
+	@DisplayName("should match a property definition by a partial, autocomplete-style term")
+	void shouldSearchMatchByPartialTerm() {
+		final var result = artifactory.search(null, SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("spring.appl")
+				.build());
+
+		assertThat(result.stream())
+				.as("'spring.appl' should prefix-match 'spring' and 'application' as separate words")
+				.extracting(PropertyDefinition::id)
+				.containsExactly(EntityId.from(1), EntityId.from(12));
+	}
+
+	@Test
+	@DisplayName("should filter property definition search by groupId criteria")
+	void shouldSearchFilterByGroupIdCriteria() {
+		final var result = artifactory.search(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.criteria(ArtifactKey.GROUP_ID_CRITERIA, "org.springframework.modulith")
+				.build());
+
+		assertThat(result.stream())
+				.extracting(PropertyDefinition::id)
+				.containsExactlyInAnyOrder(
+						EntityId.from(12), EntityId.from(13), EntityId.from(14),
+						EntityId.from(15), EntityId.from(16)
+				);
+	}
+
+	@Test
+	@DisplayName("should filter property definition search by artifactId criteria")
+	void shouldSearchFilterByArtifactIdCriteria() {
+		final var result = artifactory.search(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.criteria(ArtifactKey.ARTIFACT_ID_CRITERIA, "spring-boot-actuator")
+				.build());
+
+		assertThat(result.stream())
+				.extracting(PropertyDefinition::id)
+				.containsExactlyInAnyOrder(EntityId.from(8), EntityId.from(9), EntityId.from(10), EntityId.from(11));
+	}
+
+	@Test
+	@DisplayName("should filter property definition search by version criteria")
+	void shouldSearchFilterByVersionCriteria() {
+		final var matchingBothVersions = artifactory.search(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("internal")
+				.criteria(ArtifactCoordinates.VERSION_CRITERIA, "1.0.0")
+				.build());
+
+		assertThat(matchingBothVersions.stream())
+				.as("id=21 was only ever declared on version 1.1.0, not 1.0.0")
+				.extracting(PropertyDefinition::id)
+				.containsExactlyInAnyOrder(EntityId.from(19), EntityId.from(20));
+
+		final var matchingLatestVersion = artifactory.search(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("internal")
+				.criteria(ArtifactCoordinates.VERSION_CRITERIA, "1.1.0")
+				.build());
+
+		assertThat(matchingLatestVersion.stream())
+				.extracting(PropertyDefinition::id)
+				.containsExactlyInAnyOrder(EntityId.from(19), EntityId.from(20), EntityId.from(21));
+	}
+
+	@Test
+	@DisplayName("should return an empty search result when no property definition matches the term")
+	void shouldSearchReturnEmptyResultForUnmatchedTerm() {
+		final var result = artifactory.search(Owners.konfigyr(), SearchQuery.builder()
+				.pageable(Pageable.ofSize(20))
+				.term("does-not-match-anything")
+				.build());
+
+		assertThat(result).isEmpty();
 	}
 
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactoryControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactoryControllerTest.java
@@ -681,6 +681,149 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 				));
 	}
 
+	@Test
+	@DisplayName("should search properties, ranking a name match above a description-only match")
+	void shouldSearchPropertiesRankingNameMatchFirst() {
+		mvc.get().uri("/artifacts/search?term=application")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.as("id=1 and id=11 match by name, id=12 only matches through its description")
+						.extracting(PropertyDefinition::id)
+						.containsExactly(EntityId.from(1), EntityId.from(11), EntityId.from(12))
+				);
+	}
+
+	@Test
+	@DisplayName("should search properties by a partial, autocomplete-style term")
+	void shouldSearchPropertiesByPartialTerm() {
+		mvc.get().uri("/artifacts/search?term=spring.appl")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(PropertyDefinition::id)
+						.containsExactly(EntityId.from(1), EntityId.from(12))
+				);
+	}
+
+	@Test
+	@DisplayName("should only surface a private property in search results for its owning namespace")
+	void shouldScopePropertySearchToOwningNamespace() {
+		mvc.get().uri("/artifacts/search?term=notes")
+				.with(readingAs(EntityId.from(1L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.as("john-doe should see its own private-notes properties")
+						.extracting(PropertyDefinition::id)
+						.containsExactlyInAnyOrder(EntityId.from(17), EntityId.from(18))
+				);
+
+		mvc.get().uri("/artifacts/search?term=notes")
+				.with(readingAs(EntityId.from(2L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.as("konfigyr must not see john-doe's private properties")
+						.isEmpty()
+				);
+	}
+
+	@Test
+	@DisplayName("should filter property search by groupId, artifactId and version query parameters")
+	void shouldFilterPropertySearchByQueryParameters() {
+		mvc.get().uri("/artifacts/search?term=internal&artifactId=konfigyr-internal-secrets&version=1.0.0")
+				.with(readingAs(EntityId.from(2L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.as("id=21 was only ever declared on version 1.1.0, not 1.0.0")
+						.extracting(PropertyDefinition::id)
+						.containsExactlyInAnyOrder(EntityId.from(19), EntityId.from(20))
+				);
+
+		mvc.get().uri("/artifacts/search?term=internal&groupId=doe.john")
+				.with(readingAs(EntityId.from(1L)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent()).isEmpty());
+	}
+
+	@Test
+	@DisplayName("should return an empty search result when no property matches the term")
+	void shouldReturnEmptySearchResultForUnmatchedTerm() {
+		mvc.get().uri("/artifacts/search?term=does-not-match-anything")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent()).isEmpty());
+	}
+
+	@Test
+	@DisplayName("should reject a property search with a blank term")
+	void shouldRejectSearchWithBlankTerm() {
+		mvc.get().uri("/artifacts/search?term=")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST);
+	}
+
+	@Test
+	@DisplayName("should reject a property search with a missing term")
+	void shouldRejectSearchWithMissingTerm() {
+		mvc.get().uri("/artifacts/search")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST);
+	}
+
+	@Test
+	@DisplayName("should fail to search properties when the artifactory:read scope is not present")
+	void shouldRejectSearchWithoutScope() {
+		mvc.get().uri("/artifacts/search?term=application")
+				.with(authentication(claims -> claims
+						.subject(TestAccounts.jane().build().id().serialize())
+						.claim(KonfigyrClaimNames.NAMESPACE, EntityId.from(2L).serialize())))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.READ_ARTIFACTS));
+	}
+
 	/**
 	 * Creates an authentication post-processor whose access token carries the {@code namespace} claim,
 	 * so the publishing principal resolves to the given namespace owner, and the {@code artifactory:publish}

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/PublicationsControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/PublicationsControllerTest.java
@@ -447,4 +447,141 @@ class PublicationsControllerTest extends AbstractControllerTest {
 				.satisfies(forbidden());
 	}
 
+	@Test
+	@DisplayName("should include the namespace's own private properties in search results")
+	void shouldSearchIncludeOwnPrivateProperties() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=internal", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(PropertyDefinition::id)
+						.containsExactlyInAnyOrder(EntityId.from(19), EntityId.from(20), EntityId.from(21)));
+	}
+
+	@Test
+	@DisplayName("should never include a private property owned by a different namespace in search results")
+	void shouldSearchNeverIncludePrivatePropertiesOwnedByDifferentNamespace() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=internal", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent()).isEmpty());
+	}
+
+	@Test
+	@DisplayName("should include a different namespace's own private properties when searching as its member")
+	void shouldSearchIncludeOwnPrivatePropertiesForDifferentNamespace() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=notes", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(PropertyDefinition::id)
+						.containsExactlyInAnyOrder(EntityId.from(17), EntityId.from(18)));
+	}
+
+	@Test
+	@DisplayName("should rank a public property matching by name above one matching only by description, regardless of namespace")
+	void shouldSearchRankPublicPropertiesAcrossNamespaces() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=application", "john-doe")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(PropertyDefinition::id)
+						.containsExactly(EntityId.from(1), EntityId.from(11), EntityId.from(12)));
+	}
+
+	@Test
+	@DisplayName("should filter property search by groupId, artifactId and version query parameters")
+	void shouldSearchFilterByQueryParameters() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=internal&artifactId=konfigyr-internal-secrets&version=1.0.0", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.as("id=21 was only ever declared on version 1.1.0, not 1.0.0")
+						.extracting(PropertyDefinition::id)
+						.containsExactlyInAnyOrder(EntityId.from(19), EntityId.from(20)));
+	}
+
+	@Test
+	@DisplayName("should return an empty search result when no property matches the term")
+	void shouldSearchReturnEmptyResultForUnmatchedTerm() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=does-not-match-anything", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent()).isEmpty());
+	}
+
+	@Test
+	@DisplayName("should reject a property search with a blank term")
+	void shouldRejectSearchWithBlankTerm() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST);
+	}
+
+	@Test
+	@DisplayName("should reject a property search with a missing term")
+	void shouldRejectSearchWithMissingTerm() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST);
+	}
+
+	@Test
+	@DisplayName("should forbid searching properties for a namespace the caller is not a member of")
+	void shouldForbidSearchForNonMember() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=internal", "john-doe")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_ARTIFACTS))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should forbid searching properties without the read-artifacts scope")
+	void shouldForbidSearchWithoutScope() {
+		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=internal", "konfigyr")
+				.with(authentication(TestPrincipals.john()))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.READ_ARTIFACTS));
+	}
+
 }

--- a/konfigyr-api/src/test/java/com/konfigyr/support/TokenizerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/support/TokenizerTest.java
@@ -1,0 +1,99 @@
+package com.konfigyr.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import static org.assertj.core.api.Assertions.*;
+
+class TokenizerTest {
+
+	@Test
+	@DisplayName("should treat the entire input as a single token via identity")
+	void shouldTokenizeIdentity() {
+		assertThat(Tokenizer.identity().tokenize("hello world").toList())
+				.containsExactly("hello world");
+	}
+
+	@Test
+	@DisplayName("should treat blank input as a single empty token via identity")
+	void shouldTokenizeIdentityForBlankInput() {
+		assertThat(Tokenizer.identity().tokenize("").toList())
+				.containsExactly("");
+	}
+
+	@Test
+	@DisplayName("should split on runs of whitespace")
+	void shouldTokenizeOnWhitespace() {
+		assertThat(Tokenizer.whitespace().tokenize("hello   world foo").toList())
+				.containsExactly("hello", "world", "foo");
+	}
+
+	@Test
+	@DisplayName("should ignore leading and trailing whitespace before splitting")
+	void shouldIgnoreSurroundingWhitespace() {
+		assertThat(Tokenizer.whitespace().tokenize("  hello world  ").toList())
+				.containsExactly("hello", "world");
+	}
+
+	@Test
+	@DisplayName("should produce a single empty token for blank input")
+	void shouldTokenizeBlankInputToSingleEmptyToken() {
+		assertThat(Tokenizer.whitespace().tokenize("   ").toList())
+				.containsExactly("");
+	}
+
+	@Test
+	@DisplayName("should split a dotted or hyphenated identifier into its alphanumeric runs")
+	void shouldTokenizeAlphanumeric() {
+		assertThat(Tokenizer.alphanumeric().tokenize("spring.datasource.url").toList())
+				.containsExactly("spring", "datasource", "url");
+	}
+
+	@Test
+	@DisplayName("should split on a delimiter pattern given as a string")
+	void shouldTokenizeOnPatternString() {
+		assertThat(Tokenizer.pattern("[^a-zA-Z0-9]+").tokenize("spring.datasource.url").toList())
+				.containsExactly("spring", "datasource", "url");
+	}
+
+	@Test
+	@DisplayName("should throw for an invalid pattern syntax")
+	void shouldThrowForInvalidPatternSyntax() {
+		assertThatExceptionOfType(PatternSyntaxException.class)
+				.isThrownBy(() -> Tokenizer.pattern("[unterminated"));
+	}
+
+	@Test
+	@DisplayName("should split on a compiled delimiter pattern")
+	void shouldTokenizeOnCompiledPattern() {
+		final Pattern pattern = Pattern.compile("[^a-zA-Z0-9]+");
+
+		assertThat(Tokenizer.pattern(pattern).tokenize("foo-bar_baz").toList())
+				.containsExactly("foo", "bar", "baz");
+	}
+
+	@Test
+	@DisplayName("should apply a positive split limit as per Pattern#split(CharSequence, int)")
+	void shouldTokenizeWithPositiveLimit() {
+		assertThat(Tokenizer.pattern(Pattern.compile(","), 2).tokenize("a,b,c").toList())
+				.containsExactly("a", "b,c");
+	}
+
+	@Test
+	@DisplayName("should discard trailing empty tokens with a zero limit")
+	void shouldDiscardTrailingEmptyTokensWithZeroLimit() {
+		assertThat(Tokenizer.pattern(Pattern.compile(","), 0).tokenize("a,b,,").toList())
+				.containsExactly("a", "b");
+	}
+
+	@Test
+	@DisplayName("should keep trailing empty tokens with a negative limit")
+	void shouldKeepTrailingEmptyTokensWithNegativeLimit() {
+		assertThat(Tokenizer.pattern(Pattern.compile(","), -1).tokenize("a,b,,").toList())
+				.containsExactly("a", "b", "", "");
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/support/TokensTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/support/TokensTest.java
@@ -1,0 +1,162 @@
+package com.konfigyr.support;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class TokensTest {
+
+	@Test
+	@DisplayName("should create an empty tokens instance")
+	void shouldCreateEmptyTokens() {
+		assertThatObject(Tokens.empty())
+				.returns(true, Tokens::isEmpty)
+				.returns(0, Tokens::size)
+				.returns(List.of(), Tokens::toList);
+	}
+
+	@Test
+	@DisplayName("should create tokens from values, preserving order")
+	void shouldCreateTokensFromValues() {
+		final Tokens tokens = new Tokens(new String[] { "one", "two", "three" });
+
+		assertThatObject(tokens)
+				.returns(false, Tokens::isEmpty)
+				.returns(3, Tokens::size)
+				.returns(List.of("one", "two", "three"), Tokens::toList);
+	}
+
+	@Test
+	@DisplayName("should defensively copy the given values array")
+	void shouldDefensivelyCopyValues() {
+		final String[] values = { "one", "two" };
+		final Tokens tokens = new Tokens(values);
+
+		values[0] = "mutated";
+
+		assertThat(tokens.toList()).containsExactly("one", "two");
+	}
+
+	@Test
+	@DisplayName("should stream tokens in order")
+	void shouldStreamTokensInOrder() {
+		final Tokens tokens = new Tokens(new String[] { "a", "b", "c" });
+
+		assertThat(tokens.stream()).containsExactly("a", "b", "c");
+	}
+
+	@Test
+	@DisplayName("should filter tokens, preserving order")
+	void shouldFilterTokens() {
+		final Tokens tokens = new Tokens(new String[] { "one", "", "two", "", "three" });
+
+		assertThat(tokens.filter(StringUtils::hasText).toList())
+				.containsExactly("one", "two", "three");
+	}
+
+	@Test
+	@DisplayName("should return empty tokens when the filter matches nothing")
+	void shouldFilterToEmptyTokens() {
+		final Tokens tokens = new Tokens(new String[] { "a", "b" });
+
+		assertThatObject(tokens.filter(value -> false))
+				.returns(true, Tokens::isEmpty);
+	}
+
+	@Test
+	@DisplayName("should map tokens, preserving order and count")
+	void shouldMapTokens() {
+		final Tokens tokens = new Tokens(new String[] { "one", "two", "three" });
+
+		assertThat(tokens.map(String::toUpperCase).toList())
+				.containsExactly("ONE", "TWO", "THREE");
+	}
+
+	@Test
+	@DisplayName("should iterate tokens in order")
+	void shouldIterateTokensInOrder() {
+		final Tokens tokens = new Tokens(new String[] { "x", "y", "z" });
+
+		assertThat(tokens).containsExactly("x", "y", "z");
+	}
+
+	@Test
+	@DisplayName("should render a readable string representation")
+	void shouldRenderReadableToString() {
+		final Tokens tokens = new Tokens(new String[] { "a", "b" });
+
+		assertThat(tokens.toString()).isEqualTo("Tokens(a, b)");
+	}
+
+	@Test
+	@DisplayName("should join tokens with the given delimiter")
+	void shouldJoinTokensWithDelimiter() {
+		final Tokens tokens = new Tokens(new String[] { "one", "two", "three" });
+
+		assertThat(tokens.join(" & ")).isEqualTo("one & two & three");
+	}
+
+	@Test
+	@DisplayName("should join zero tokens into an empty string")
+	void shouldJoinEmptyTokensToEmptyString() {
+		assertThat(Tokens.empty().join(" & ")).isEmpty();
+	}
+
+	@Test
+	@DisplayName("should join a single token with no delimiter applied")
+	void shouldJoinSingleToken() {
+		final Tokens tokens = new Tokens(new String[] { "one" });
+
+		assertThat(tokens.join(" & ")).isEqualTo("one");
+	}
+
+	@Test
+	@DisplayName("should join tokens with a delimiter, prefix and suffix")
+	void shouldJoinTokensWithDelimiterPrefixAndSuffix() {
+		final Tokens tokens = new Tokens(new String[] { "a", "b" });
+
+		assertThat(tokens.join(", ", "[", "]")).isEqualTo("[a, b]");
+	}
+
+	@Test
+	@DisplayName("should join zero tokens into just the prefix and suffix")
+	void shouldJoinEmptyTokensToPrefixAndSuffix() {
+		assertThat(Tokens.empty().join(", ", "[", "]")).isEqualTo("[]");
+	}
+
+	@Test
+	@DisplayName("should apply the transformer to this tokens instance and return its result")
+	void shouldTransform() {
+		final Tokens tokens = new Tokens(new String[] { "one", "two", "three" });
+
+		final int result = tokens.transform(Tokens::size);
+
+		assertThat(result).isEqualTo(3);
+	}
+
+	@Test
+	@DisplayName("should pass this tokens instance, unmodified, to the transformer")
+	void shouldTransformPassThisInstanceToTransformer() {
+		final Tokens tokens = new Tokens(new String[] { "a", "b" });
+		final Tokens result = tokens.transform(received -> received);
+
+		assertThat(result).isSameAs(tokens);
+	}
+
+	@Test
+	@DisplayName("should compose with filter and map to finish a pipeline in a single expression")
+	void shouldTransformComposeWithFilterAndMap() {
+		final Tokens tokens = new Tokens(new String[] { "one", "", "two" });
+
+		final String result = tokens.filter(StringUtils::hasText)
+				.map(word -> word + ":*")
+				.transform(words -> words.join(" & "));
+
+		assertThat(result).isEqualTo("one:* & two:*");
+	}
+
+}

--- a/konfigyr-data/src/main/java/com/konfigyr/data/PageableExecutor.java
+++ b/konfigyr-data/src/main/java/com/konfigyr/data/PageableExecutor.java
@@ -3,6 +3,7 @@ package com.konfigyr.data;
 import lombok.RequiredArgsConstructor;
 import org.jooq.*;
 import org.jooq.Record;
+import org.jooq.impl.DSL;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 import org.springframework.core.convert.converter.Converter;
@@ -11,9 +12,10 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 
 import java.util.*;
-import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 /**
  * jOOQ support class for {@link Query} execution using {@link Pageable}. It would apply the pagination
@@ -44,42 +46,139 @@ public class PageableExecutor {
 	}
 
 	/**
-	 * Applies the {@link Pageable} instructions and executes the query to construct a {@link Page}
-	 * based on the retrieved result set, {@link Pageable} and {@link LongSupplier} applying optimizations
-	 * via {@link PageableExecutionUtils}.
+	 * Derives a {@link PageableExecutor} that additionally matches and ranks results against a {@code tsvector}
+	 * {@code field} using a full-text search {@code term}, sorting matches by {@code ts_rank} in descending
+	 * order (most relevant first) ahead of any other sort.
+	 * <p>
+	 * See {@link #rankBy(String, Field, SortOrder)} for the full contract, including the requirement that
+	 * {@code term} already be valid {@code tsquery} syntax.
 	 *
-	 * @param query query to be executed, must not be {@literal null}.
-	 * @param mapper result set mapper applied on the retrieved record result set, must not be {@literal null}.
-	 * @param pageable must not be {@literal null} but can be {@link Pageable#unpaged()}.
-	 * @param totalSupplier must not be {@literal null}.
-	 * @param <T> page content type that would be returned from the record converter
-	 * @return the {@link Page} for the retrieved and converted result set and a total size.
+	 * @param term the search term, already valid {@code tsquery} syntax, can be {@literal null} or blank
+	 * @param field the {@code tsvector} field to match and rank against, can't be {@literal null}
+	 * @return a ranked {@link PageableExecutor}, or this same executor if {@code term} is blank, never {@literal null}.
 	 */
-	public <T> Page<T> execute(
-			SelectOrderByStep<? extends Record> query,
-			Converter<Record, T> mapper,
-			Pageable pageable,
-			LongSupplier totalSupplier
-	) {
-		final List<T> results = applyPageable(query, pageable)
-				.fetch(mapper::convert);
-
-		return PageableExecutionUtils.getPage(results, pageable, totalSupplier);
+	public PageableExecutor rankBy(@Nullable String term, Field<?> field) {
+		return rankBy(term, field, SortOrder.DESC);
 	}
 
-	private <R extends Record> ResultQuery<R> applyPageable(SelectOrderByStep<R> query, Pageable pageable) {
+	/**
+	 * Derives a {@link PageableExecutor} that additionally matches and ranks results against a {@code tsvector}
+	 * {@code field} using a full-text search {@code term}.
+	 * <p>
+	 * The returned executor adds a {@code field @@ to_tsquery('simple', term)} condition to every query it
+	 * executes (see {@link #execute(Supplier, Supplier, Converter, Pageable)}), and sorts by
+	 * {@code ts_rank(field, to_tsquery('simple', term))} using the given {@code order}, ahead of whatever
+	 * sort the {@link Pageable} or the configured default sort field would otherwise apply.
+	 * <p>
+	 * {@code term} is passed as-is to {@code to_tsquery}, which parses {@code tsquery} operator syntax
+	 * (<code>&amp;</code>, <code>|</code>, <code>:*</code>, ...) rather than free text — callers must
+	 * already have converted a raw user-supplied phrase into a valid {@code tsquery} expression before
+	 * calling this method.
+	 * <p>
+	 * When {@code term} is blank, this same executor is returned unchanged: no condition or ranking sort
+	 * is applied.
+	 *
+	 * @param term the search term, already valid {@code tsquery} syntax, can be {@literal null} or blank
+	 * @param field the {@code tsvector} field to match and rank against, can't be {@literal null}
+	 * @param order the sort order applied to the {@code ts_rank} value, can't be {@literal null}
+	 * @return a ranked {@link PageableExecutor}, or this same executor if {@code term} is blank, never {@literal null}.
+	 */
+	public PageableExecutor rankBy(@Nullable String term, Field<?> field, SortOrder order) {
+		if (StringUtils.hasText(term)) {
+			return new RankedPageableExecutor(
+					DSL.condition("{0} @@ to_tsquery('simple', {1})", field, term),
+					DSL.field("ts_rank({0}, to_tsquery('simple', {1}))", Double.class, field, term).sort(order),
+					sortFields,
+					defaultSortField
+			);
+		}
+
+		return this;
+	}
+
+	/**
+	 * Applies the {@link Pageable} instructions and executes the query built by {@code querySupplier} to
+	 * construct a {@link Page}, with no additional filtering condition beyond whatever {@code querySupplier}
+	 * already builds in. Equivalent to {@link #execute(Supplier, Supplier, Converter, Pageable)} with a
+	 * condition supplier that always returns {@literal null}.
+	 *
+	 * @param querySupplier supplies the base query to execute; called once for the content fetch and once
+	 *        more, independently, to build the total row count, must not be {@literal null}.
+	 * @param mapper result set mapper applied on the retrieved record result set, must not be {@literal null}.
+	 * @param pageable must not be {@literal null} but can be {@link Pageable#unpaged()}.
+	 * @param <R> record type produced by the query returned from {@code querySupplier}
+	 * @param <Q> query type returned from {@code querySupplier}
+	 * @param <T> page content type that would be returned from the record converter
+	 * @return the {@link Page} for the retrieved and converted result set and a total size, never {@literal null}.
+	 */
+	public <R extends Record, Q extends SelectWhereStep<R>, T> Page<T> execute(
+			Supplier<Q> querySupplier,
+			Converter<R, T> mapper,
+			Pageable pageable
+	) {
+		return execute(querySupplier, () -> null, mapper, pageable);
+	}
+
+	/**
+	 * Applies the {@link Pageable} instructions and the {@code condition} supplied by {@code conditionSupplier}
+	 * to the query built by {@code querySupplier}, executing it to construct a {@link Page} of the mapped
+	 * result set and its total size, applying optimizations via {@link PageableExecutionUtils}.
+	 * <p>
+	 * {@code querySupplier} is invoked twice: once to fetch the page content (with sorting, offset and limit
+	 * applied), and once more, independently, to compute the total row count via
+	 * {@code DSL.using(query.configuration()).fetchCountLarge(...)} — both invocations get the same
+	 * {@code condition}, so the two stay consistent even when this executor was derived via
+	 * {@link #rankBy(String, Field, SortOrder)}, which augments {@code condition} with its own match clause.
+	 *
+	 * @param querySupplier supplies the base query to execute; called once for the content fetch and once
+	 *        more, independently, to build the total row count, must not be {@literal null}.
+	 * @param conditionSupplier supplies the filtering condition applied to both the content and count
+	 *        queries; may return {@literal null}, in which case no filtering condition is applied beyond
+	 *        whatever {@code querySupplier} already builds in, must not be {@literal null}.
+	 * @param mapper result set mapper applied on the retrieved record result set, must not be {@literal null}.
+	 * @param pageable must not be {@literal null} but can be {@link Pageable#unpaged()}.
+	 * @param <R> record type produced by the query returned from {@code querySupplier}
+	 * @param <Q> query type returned from {@code querySupplier}
+	 * @param <T> page content type that would be returned from the record converter
+	 * @return the {@link Page} for the retrieved and converted result set and a total size, never {@literal null}.
+	 */
+	public <R extends Record, Q extends SelectWhereStep<R>, T> Page<T> execute(
+			Supplier<Q> querySupplier,
+			Supplier<@Nullable Condition> conditionSupplier,
+			Converter<R, T> mapper,
+			Pageable pageable
+	) {
+		final Condition condition = createCondition(conditionSupplier.get());
+		final List<T> results = apply(querySupplier.get(), condition, pageable)
+				.fetch(mapper::convert);
+
+		return PageableExecutionUtils.getPage(results, pageable, () -> count(querySupplier.get(), condition));
+	}
+
+	private <R extends Record> ResultQuery<R> apply(SelectWhereStep<R> query, Condition condition, Pageable pageable) {
 		final Collection<OrderField<?>> orderBy = createOrderBy(pageable.getSort());
 
 		if (pageable.isUnpaged()) {
-			return query.orderBy(orderBy);
+			return query.where(condition)
+					.orderBy(orderBy);
 		}
 
-		return query.orderBy(orderBy)
+		return query.where(condition)
+				.orderBy(orderBy)
 				.offset(pageable.getOffset())
 				.limit(pageable.getPageSize());
 	}
 
-	private Collection<OrderField<?>> createOrderBy(@Nullable Sort sort) {
+	private <R extends Record> Long count(SelectWhereStep<R> query, Condition condition) {
+		final DSLContext context = DSL.using(query.configuration());
+		return context.fetchCountLarge(query.where(condition));
+	}
+
+	protected Condition createCondition(@Nullable Condition condition) {
+		return condition == null ? DSL.noCondition() : condition;
+	}
+
+	protected Collection<OrderField<?>> createOrderBy(@Nullable Sort sort) {
 		if (sort == null || sort.isUnsorted() || sortFields.isEmpty()) {
 			return Collections.singleton(defaultSortField);
 		}
@@ -154,6 +253,36 @@ public class PageableExecutor {
 			Assert.notNull(defaultSortField, "Default sort field is required");
 
 			return new PageableExecutor(Collections.unmodifiableMap(sortFields), defaultSortField);
+		}
+	}
+
+	private static final class RankedPageableExecutor extends PageableExecutor {
+
+		private final Condition rankedCondition;
+		private final OrderField<Double> rankedSort;
+
+		private RankedPageableExecutor(
+				Condition rankedCondition,
+				OrderField<Double> rankedSort,
+				Map<String, Field<?>> sortFields,
+				OrderField<?> defaultSortField
+		) {
+			super(sortFields, defaultSortField);
+			this.rankedCondition = rankedCondition;
+			this.rankedSort = rankedSort;
+		}
+
+		@Override
+		protected Condition createCondition(@Nullable Condition condition) {
+			return condition == null ? rankedCondition : condition.and(rankedCondition);
+		}
+
+		@Override
+		protected Collection<OrderField<?>> createOrderBy(@Nullable Sort sort) {
+			final List<OrderField<?>> sorts = new ArrayList<>();
+			sorts.add(rankedSort);
+			sorts.addAll(super.createOrderBy(sort));
+			return sorts;
 		}
 	}
 }

--- a/konfigyr-data/src/main/resources/migrations/artifactory/artifactory-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/artifactory/artifactory-1.0.0.xml
@@ -187,6 +187,8 @@
 			<column name="last_seen" type="varchar" remarks="The artifact version where this property was seen for the last time.">
 				<constraints nullable="true" />
 			</column>
+
+			<column name="search_vector" type="tsvector" />
 		</createTable>
 
 		<addUniqueConstraint
@@ -203,6 +205,57 @@
 				referencedColumnNames="id"
 				onDelete="CASCADE"
 		/>
+	</changeSet>
+
+	<changeSet author="vspasic" id="1.0.0-create-property-definitions-search-vector-trigger" context="api">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<indexExists tableName="property_definitions" indexName="idx_property_definitions_search" />
+			</not>
+		</preConditions>
+
+		<comment>
+			Creates a `generate_property_definitions_search_vector` function that would be used by the
+			`trg_property_definitions_search_vector` trigger to generate a `ts_vector` value for the `search_vector`
+			column. The trigger would be invoked for each insert event or when `name` or `description` fields are
+			updated. This migration also backfills the `search_vector` column for pre-existing rows and adds the
+			supporting GIN index.
+
+			`name` values are dotted/hyphenated identifiers (e.g. `spring.datasource.url`), which Postgres'
+			`simple` parser otherwise tokenizes as a single, indivisible "host"-like lexeme. Non-alphanumeric
+			separators are replaced with spaces before tokenizing so each segment becomes its own searchable word.
+		</comment>
+
+		<sql>
+			CREATE OR REPLACE FUNCTION generate_property_definitions_search_vector() RETURNS trigger AS '
+				BEGIN
+					NEW.search_vector :=
+					                  setweight(to_tsvector(''simple'', regexp_replace(NEW.name, ''[^a-zA-Z0-9]+'', '' '', ''g'')), ''A'') ||
+					                  setweight(to_tsvector(''simple'', coalesce(NEW.description,'''')), ''B'');
+					RETURN NEW;
+				END;
+			' LANGUAGE plpgsql;
+		</sql>
+
+		<sql>
+			CREATE OR REPLACE TRIGGER trg_property_definitions_search_vector
+				BEFORE INSERT OR UPDATE OF name, description
+								 ON property_definitions FOR EACH ROW EXECUTE FUNCTION generate_property_definitions_search_vector();
+		</sql>
+
+		<createIndex tableName="property_definitions" indexName="idx_property_definitions_search" using="gin">
+			<column name="search_vector"/>
+		</createIndex>
+
+		<sql>
+			UPDATE property_definitions SET name = name;
+		</sql>
+
+		<rollback>
+			DROP INDEX IF EXISTS idx_property_definitions_search;
+			DROP TRIGGER IF EXISTS trg_property_definitions_search_vector ON property_definitions;
+			DROP FUNCTION IF EXISTS generate_property_definitions_search_vector();
+		</rollback>
 	</changeSet>
 
 	<changeSet author="vspasic" id="1.0.0-create-artifact-version-properties-table" context="api">

--- a/konfigyr-data/src/main/resources/migrations/namespaces/namespaces-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/namespaces/namespaces-1.0.0.xml
@@ -474,6 +474,10 @@
 			fields are updated. This migration would also create a default partition with name:
 			`service_configuration_catalog_default` that would be used as a fallback in case the service specific
 			partition can't be created.
+
+			`name` values are dotted/hyphenated identifiers (e.g. `spring.datasource.url`), which Postgres'
+			`simple` parser otherwise tokenizes as a single, indivisible "host"-like lexeme. Non-alphanumeric
+			separators are replaced with spaces before tokenizing so each segment becomes its own searchable word.
 		</comment>
 
 		<sql>
@@ -517,7 +521,7 @@
 			CREATE OR REPLACE FUNCTION generate_service_configuration_catalog_search_vector() RETURNS trigger AS '
 				BEGIN
 					NEW.search_vector :=
-					                  setweight(to_tsvector(''simple'', NEW.name), ''A'') ||
+					                  setweight(to_tsvector(''simple'', regexp_replace(NEW.name, ''[^a-zA-Z0-9]+'', '' '', ''g'')), ''A'') ||
 					                  setweight(to_tsvector(''simple'', coalesce(NEW.description,'''')), ''B'');
 					RETURN NEW;
 				END;

--- a/konfigyr-data/src/test/java/com/konfigyr/data/PageableExecutorTest.java
+++ b/konfigyr-data/src/test/java/com/konfigyr/data/PageableExecutorTest.java
@@ -157,12 +157,71 @@ class PageableExecutorTest {
 				.containsExactly(1L, 2L);
 	}
 
+	@Test
+	@DisplayName("should apply the supplied condition to both the content and the total element count")
+	void shouldExecuteWithCondition() {
+		final var pageable = Pageable.ofSize(10);
+
+		assertThatObject(execute(pageable, TESTING_TABLE.STATUS.eq("ACTIVE")))
+				.isNotNull()
+				.returns(10, Page::getSize)
+				.returns(0, Page::getNumber)
+				.returns(1, Page::getTotalPages)
+				.returns(1L, Page::getTotalElements)
+				.returns(1, Page::getNumberOfElements)
+				.asInstanceOf(iterable(Long.class))
+				.containsExactly(1L);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should keep the total element count consistent with the condition across multiple pages")
+	void shouldExecuteWithConditionAcrossMultiplePages() {
+		insertTestData(3, "ACTIVE", OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(10));
+		insertTestData(4, "ACTIVE", OffsetDateTime.now(ZoneOffset.UTC).minusSeconds(20));
+
+		// page size equal to the number of matches on this page forces PageableExecutionUtils
+		// to invoke the total count query instead of deriving the total from the content size
+		final var pageable = PageRequest.of(0, 1, Sort.by("id"));
+
+		assertThatObject(execute(pageable, TESTING_TABLE.STATUS.eq("ACTIVE")))
+				.isNotNull()
+				.returns(1, Page::getNumberOfElements)
+				.returns(3, Page::getTotalPages)
+				.as("total must reflect only ACTIVE rows, not every row in the table")
+				.returns(3L, Page::getTotalElements)
+				.asInstanceOf(iterable(Long.class))
+				.containsExactly(1L);
+	}
+
+	@Test
+	@DisplayName("should return an empty page when the supplied condition matches nothing")
+	void shouldExecuteWithConditionMatchingNothing() {
+		final var pageable = Pageable.ofSize(10);
+
+		assertThatObject(execute(pageable, TESTING_TABLE.STATUS.eq("DOES-NOT-EXIST")))
+				.isNotNull()
+				.returns(0, Page::getTotalPages)
+				.returns(0L, Page::getTotalElements)
+				.returns(0, Page::getNumberOfElements)
+				.asInstanceOf(iterable(Long.class))
+				.isEmpty();
+	}
+
 	private Page<@NonNull Long> execute(Pageable pageable) {
 		return executor.execute(
-				context.select(TESTING_TABLE.fields()).from(TESTING_TABLE),
+				() -> context.select(TESTING_TABLE.fields()).from(TESTING_TABLE),
 				record -> record.get(TESTING_TABLE.ID),
-				pageable,
-				() -> context.fetchCount(context.select(TESTING_TABLE.ID).from(TESTING_TABLE))
+				pageable
+		);
+	}
+
+	private Page<@NonNull Long> execute(Pageable pageable, Condition condition) {
+		return executor.execute(
+				() -> context.select(TESTING_TABLE.fields()).from(TESTING_TABLE),
+				() -> condition,
+				record -> record.get(TESTING_TABLE.ID),
+				pageable
 		);
 	}
 


### PR DESCRIPTION
Adds full-text search over configuration property names and descriptions, usable both from the machine-client artifact registry and the namespace-scoped browser API, with private properties correctly scoped to their owning namespace.

  - **Search vector fix**: `property_definitions` and `service_configuration_catalog` both get a GIN/tsvector index, maintained by a trigger that normalizes `name` before tokenizing. Without this, Postgres treats a dotted identifier like `spring.datasource.url` as a single, indivisible token, searching `datasource` would never match it. The trigger now splits on non-alphanumeric runs, so each segment becomes its own searchable, prefix-matchable word (`spring.appl` matches `spring.application.name`).
  - **New shared types**: `Tokenizer`/`Tokens` (`com.konfigyr.support`), small, reusable word-splitting utilities used to build the prefix `tsquery` expressions, keeping Java-side term splitting and the SQL-side trigger normalization in sync.
  - **`PageableExecutor` rework**: added ranked-search support (`rankBy`) and changed `execute()` to build both the content and count queries from the same condition. This fixes a real bug where a paginated result's total element count silently ignored the extra full-text match condition, reporting the wrong total whenever a search term was combined with paging.
  - **New endpoints**: `GET /artifacts/search` (machine-client, owner resolved from JWT claim) and `GET /namespaces/{namespace}/artifacts/search` (namespace-scoped). The namespace-scoped route required an authorization fix, private properties must only be visible to members of the owning namespace, not to any caller who can guess a namespace slug.
  - **Ranking**: name matches are ranked above description-only matches via `ts_rank`, ahead of any explicit or default sort.
