### PR TITLE
Add artifact ownership transfer UI

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,10 @@ coverage:
         target: auto
         threshold: 5%
 
+codecov:
+  ## Codecov will reject reports that are over 12 hours old, this should be disabled
+  max_report_age: off
+
 component_management:
   default_rules:
     statuses:

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryEvent.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/ArtifactoryEvent.java
@@ -252,7 +252,7 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 	 * {@code com.konfigyr.artifactory.transfer.ArtifactOwnershipTransfer}.
 	 */
 	public static sealed abstract class OwnershipTransferEvent extends ArtifactoryEvent
-			permits OwnershipTransferAccepted, OwnershipTransferRejected, OwnershipTransferCancelled {
+			permits OwnershipTransferRequested, OwnershipTransferAccepted, OwnershipTransferRejected, OwnershipTransferCancelled {
 
 		private final String groupId;
 		private final Owner from;
@@ -301,6 +301,25 @@ public abstract sealed class ArtifactoryEvent extends EntityEvent
 		@NonNull
 		public Owner to() {
 			return to;
+		}
+	}
+
+	/**
+	 * Event that would be published when an artifact ownership transfer request is created by the owner.
+	 */
+	@DomainEvent(name = "ownership-transfer.requested", namespace = "artifactory")
+	public static final class OwnershipTransferRequested extends OwnershipTransferEvent {
+
+		/**
+		 * Create a new {@link OwnershipTransferAccepted} event for the created transfer request.
+		 *
+		 * @param id the entity identifier of the transfer request that was created, can't be {@literal null}.
+		 * @param groupId the artifact groupId coordinate whose artifacts were requested, can't be {@literal null}.
+		 * @param from the namespace that ownes the requested artifacts, can't be {@literal null}.
+		 * @param to the namespace that requested the artifact transfer, can't be {@literal null}.
+		 */
+		public OwnershipTransferRequested(EntityId id, @NonNull String groupId, @NonNull Owner from, @NonNull Owner to) {
+			super(id, groupId, from, to);
 		}
 	}
 

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/ArtifactOwnershipTransfers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/ArtifactOwnershipTransfers.java
@@ -84,6 +84,7 @@ public interface ArtifactOwnershipTransfers {
 	 * @throws ArtifactOwnershipTransferAlreadyRequestedException when a pending request already exists for the
 	 *         same {@code groupId}, {@code from} and {@code to} combination
 	 */
+	@DomainEventPublisher(publishes = "artifactory.ownership-transfer.requested")
 	ArtifactOwnershipTransfer request(Owner to, String groupId, Owner from);
 
 	/**

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/transfer/DefaultArtifactOwnershipTransfers.java
@@ -140,6 +140,8 @@ class DefaultArtifactOwnershipTransfers implements ArtifactOwnershipTransfers {
 			log.info("Successfully requested artifact ownership transfer {} for groupId '{}' from namespace {} ({}) to namespace {} ({})",
 					transfer.id(), groupId, from.slug(), from.id(), to.slug(), to.id());
 
+			eventPublisher.publishEvent(new ArtifactoryEvent.OwnershipTransferRequested(transfer.id(), groupId, from, to));
+
 			return transfer;
 		} catch (DataIntegrityViolationException ex) {
 			throw new ArtifactOwnershipTransferAlreadyRequestedException(groupId, from, to);

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/AuditEventListener.java
@@ -532,6 +532,28 @@ class AuditEventListener {
 		);
 	}
 
+	@TransactionalEventListener(id = "audit.ownership-transfer-requested", classes = ArtifactoryEvent.OwnershipTransferRequested.class)
+	void on(ArtifactoryEvent.OwnershipTransferRequested event) {
+		insert(event, builder -> builder
+				.namespace(event.to().id())
+				.entityType("artifact-ownership-transfer")
+				.entityId(event.id())
+				.eventType("artifact-ownership-transfer.sent")
+				.details("groupId", event.groupId())
+				.details("from", event.from().slug())
+				.details("to", event.to().slug())
+		);
+		insert(event, builder -> builder
+				.namespace(event.from().id())
+				.entityType("artifact-ownership-transfer")
+				.entityId(event.id())
+				.eventType("artifact-ownership-transfer.requested")
+				.details("groupId", event.groupId())
+				.details("from", event.from().slug())
+				.details("to", event.to().slug())
+		);
+	}
+
 	@TransactionalEventListener(id = "audit.ownership-transfer-accepted", classes = ArtifactoryEvent.OwnershipTransferAccepted.class)
 	void on(ArtifactoryEvent.OwnershipTransferAccepted event) {
 		insert(event, builder -> builder

--- a/konfigyr-api/src/main/java/com/konfigyr/audit/controller/AuditController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/audit/controller/AuditController.java
@@ -3,6 +3,7 @@ package com.konfigyr.audit.controller;
 import com.konfigyr.audit.AuditEventRepository;
 import com.konfigyr.audit.AuditRecord;
 import com.konfigyr.data.CursorPageable;
+import com.konfigyr.entity.EntityId;
 import com.konfigyr.hateoas.CursorModel;
 import com.konfigyr.hateoas.EntityModel;
 import com.konfigyr.hateoas.RepresentationModelAssembler;
@@ -15,6 +16,7 @@ import com.konfigyr.support.SearchQuery;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
@@ -36,35 +38,27 @@ class AuditController {
 	@PreAuthorize("isMember(#slug)")
 	CursorModel<EntityModel<AuditRecord>> find(
 			@PathVariable String slug,
-			@Nullable @RequestParam(required = false) String entityType,
 			@Nullable @RequestParam(required = false) String eventType,
+			@Nullable @RequestParam(required = false) String entityType,
+			@Nullable @RequestParam(required = false) EntityId entityId,
 			@Nullable @RequestParam(required = false) String actor,
 			@Nullable @RequestParam(required = false) OffsetDateTime from,
 			@Nullable @RequestParam(required = false) OffsetDateTime to,
 			CursorPageable pageable
 	) {
 		final Namespace namespace = namespaces.findBySlug(slug).orElseThrow(() -> new NamespaceNotFoundException(slug));
+		final SearchQuery query = SearchQuery.builder()
+				.criteria(AuditRecord.NAMESPACE_ID_CRITERIA, namespace.id())
+				.criteria(AuditRecord.EVENT_TYPE_CRITERIA, eventType)
+				.criteria(AuditRecord.ENTITY_TYPE_CRITERIA, entityType)
+				.criteria(AuditRecord.ENTITY_ID_CRITERIA, entityId)
+				.criteria(AuditRecord.ACTOR_ID_CRITERIA, actor)
+				.criteria(AuditRecord.FROM_CRITERIA, from)
+				.criteria(AuditRecord.TO_CRITERIA, to)
+				.pageable(Pageable.unpaged())
+				.build();
 
-		final SearchQuery.Builder builder = SearchQuery.builder()
-				.criteria(AuditRecord.NAMESPACE_ID_CRITERIA, namespace.id());
-
-		if (entityType != null) {
-			builder.criteria(AuditRecord.ENTITY_TYPE_CRITERIA, entityType);
-		}
-		if (eventType != null) {
-			builder.criteria(AuditRecord.EVENT_TYPE_CRITERIA, eventType);
-		}
-		if (actor != null) {
-			builder.criteria(AuditRecord.ACTOR_ID_CRITERIA, actor);
-		}
-		if (from != null) {
-			builder.criteria(AuditRecord.FROM_CRITERIA, from);
-		}
-		if (to != null) {
-			builder.criteria(AuditRecord.TO_CRITERIA, to);
-		}
-
-		return assembler.assemble(repository.find(builder.build(), pageable));
+		return assembler.assemble(repository.find(query, pageable));
 	}
 
 }

--- a/konfigyr-api/src/main/resources/messages/audit.properties
+++ b/konfigyr-api/src/main/resources/messages/audit.properties
@@ -63,9 +63,11 @@ audit.event.artifact-definition.visibility-changed=Visibility of artifact {0} wa
 
 ## Artifact ownership transfer events ##
 
-audit.event.artifact-ownership-transfer.received=You are now the owner of ''{1}''
-audit.event.artifact-ownership-transfer.transferred=You have transferred ''{1}'' to ''{2}''
-audit.event.artifact-ownership-transfer.request-rejected=Your request to transfer ''{1}'' was rejected by ''{0}''
-audit.event.artifact-ownership-transfer.rejected=You rejected the transfer request for ''{1}'' from ''{2}''
-audit.event.artifact-ownership-transfer.cancelled=You cancelled your request to transfer ''{1}''
-audit.event.artifact-ownership-transfer.request-cancelled=The transfer request for ''{1}'' from ''{2}'' was cancelled
+audit.event.artifact-ownership-transfer.requested=Ownership transfer for ''{1}'' was requested from ''{2}''
+audit.event.artifact-ownership-transfer.sent=Ownership transfer request for ''{1}'' was successfully sent to ''{0}''
+audit.event.artifact-ownership-transfer.received=Ownership of ''{1}'' was transferred from ''{0}''
+audit.event.artifact-ownership-transfer.transferred=Ownership of ''{1}'' was transferred to ''{2}''
+audit.event.artifact-ownership-transfer.request-rejected=Request to transfer ''{1}'' was rejected by ''{0}''
+audit.event.artifact-ownership-transfer.rejected=Transfer request for ''{1}'' from ''{2}'' was rejected
+audit.event.artifact-ownership-transfer.cancelled=Request to transfer ''{1}'' was cancelled
+audit.event.artifact-ownership-transfer.request-cancelled=Transfer request for ''{1}'' from ''{2}'' was cancelled

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/transfer/ArtifactOwnershipTransfersTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/transfer/ArtifactOwnershipTransfersTest.java
@@ -19,7 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
 import static org.assertj.core.api.Assertions.*;
 
-class DefaultArtifactOwnershipTransfersTest extends AbstractIntegrationTest {
+class ArtifactOwnershipTransfersTest extends AbstractIntegrationTest {
 
 	@Autowired
 	ArtifactOwnershipTransfers transfers;
@@ -62,6 +62,12 @@ class DefaultArtifactOwnershipTransfersTest extends AbstractIntegrationTest {
 				.fetchOne(ARTIFACTS.NAMESPACE_ID))
 				.as("artifact ownership should have moved to the new claimant")
 				.isEqualTo(to.id().get());
+
+		events.assertThat()
+				.contains(ArtifactoryEvent.OwnershipTransferRequested.class)
+				.matching(ArtifactoryEvent.OwnershipTransferRequested::groupId, groupId)
+				.matching(ArtifactoryEvent.OwnershipTransferRequested::from, from)
+				.matching(ArtifactoryEvent.OwnershipTransferRequested::to, to);
 
 		events.assertThat()
 				.contains(com.konfigyr.artifactory.ArtifactoryEvent.OwnershipTransferAccepted.class)

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventListenerTest.java
@@ -995,6 +995,28 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 	}
 
 	@Test
+	@DisplayName("should persist two audit records for a requested ownership transfer, one per namespace")
+	void shouldAuditOwnershipTransferRequested() {
+		final var from = new Owner(EntityId.from(1210), "from-namespace");
+		final var to = new Owner(EntityId.from(1211), "to-namespace");
+
+		listener.on(new ArtifactoryEvent.OwnershipTransferRequested(EntityId.from(1200), "com.konfigyr", from, to));
+
+		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1200), "artifact-ownership-transfer.sent")
+				.returns(to.id(), AuditRecord::namespaceId)
+				.satisfies(it -> assertThat(it.details())
+						.containsEntry("groupId", "com.konfigyr")
+						.containsEntry("from", from.slug())
+						.containsEntry("to", to.slug())
+				)
+				.satisfies(assertAuditRecordMessage("Ownership transfer request for '%s' was successfully sent to '%s'", "com.konfigyr", from.slug()));
+
+		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1200), "artifact-ownership-transfer.requested")
+				.returns(from.id(), AuditRecord::namespaceId)
+				.satisfies(assertAuditRecordMessage("Ownership transfer for '%s' was requested from '%s'", "com.konfigyr", to.slug()));
+	}
+
+	@Test
 	@DisplayName("should persist two audit records for an accepted ownership transfer, one per namespace")
 	void shouldAuditOwnershipTransferAccepted() {
 		final var from = new Owner(EntityId.from(1210), "from-namespace");
@@ -1009,11 +1031,11 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 						.containsEntry("from", from.slug())
 						.containsEntry("to", to.slug())
 				)
-				.satisfies(assertAuditRecordMessage("You are now the owner of '%s'", "com.konfigyr"));
+				.satisfies(assertAuditRecordMessage("Ownership of '%s' was transferred from '%s'", "com.konfigyr", from.slug()));
 
 		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1212), "artifact-ownership-transfer.transferred")
 				.returns(from.id(), AuditRecord::namespaceId)
-				.satisfies(assertAuditRecordMessage("You have transferred '%s' to '%s'", "com.konfigyr", to.slug()));
+				.satisfies(assertAuditRecordMessage("Ownership of '%s' was transferred to '%s'", "com.konfigyr", to.slug()));
 	}
 
 	@Test
@@ -1026,11 +1048,11 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 
 		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1222), "artifact-ownership-transfer.request-rejected")
 				.returns(to.id(), AuditRecord::namespaceId)
-				.satisfies(assertAuditRecordMessage("Your request to transfer '%s' was rejected by '%s'", "com.konfigyr", from.slug()));
+				.satisfies(assertAuditRecordMessage("Request to transfer '%s' was rejected by '%s'", "com.konfigyr", from.slug()));
 
 		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1222), "artifact-ownership-transfer.rejected")
 				.returns(from.id(), AuditRecord::namespaceId)
-				.satisfies(assertAuditRecordMessage("You rejected the transfer request for '%s' from '%s'", "com.konfigyr", to.slug()));
+				.satisfies(assertAuditRecordMessage("Transfer request for '%s' from '%s' was rejected", "com.konfigyr", to.slug()));
 	}
 
 	@Test
@@ -1043,11 +1065,11 @@ class AuditEventListenerTest extends AbstractIntegrationTest {
 
 		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1232), "artifact-ownership-transfer.cancelled")
 				.returns(to.id(), AuditRecord::namespaceId)
-				.satisfies(assertAuditRecordMessage("You cancelled your request to transfer '%s'", "com.konfigyr"));
+				.satisfies(assertAuditRecordMessage("Request to transfer '%s' was cancelled", "com.konfigyr"));
 
 		assertAuditRecord("artifact-ownership-transfer", EntityId.from(1232), "artifact-ownership-transfer.request-cancelled")
 				.returns(from.id(), AuditRecord::namespaceId)
-				.satisfies(assertAuditRecordMessage("The transfer request for '%s' from '%s' was cancelled", "com.konfigyr", to.slug()));
+				.satisfies(assertAuditRecordMessage("Transfer request for '%s' from '%s' was cancelled", "com.konfigyr", to.slug()));
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventRepositoryTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/AuditEventRepositoryTest.java
@@ -158,7 +158,7 @@ class AuditEventRepositoryTest extends AbstractIntegrationTest {
 
 		assertThatObject(thirdPage)
 				.as("Should return the last page of 3")
-				.returns(2, CursorPage::size)
+				.returns(3, CursorPage::size)
 				.returns(false, CursorPage::hasNext)
 				.returns(true, CursorPage::hasPrevious);
 

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/controller/AuditControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/controller/AuditControllerTest.java
@@ -33,7 +33,7 @@ class AuditControllerTest extends AbstractControllerTest {
 				.bodyJson()
 				.convertTo(cursorModel(AuditRecord.class))
 				.extracting(CursorModel::getContent, InstanceOfAssertFactories.iterable(AuditRecord.class))
-				.hasSize(10)
+				.hasSize(11)
 				.allSatisfy(record -> assertThat(record)
 						.returns(EntityId.from(2), AuditRecord::namespaceId)
 						.satisfies(it -> assertThat(it.message()).isNotBlank())
@@ -180,7 +180,7 @@ class AuditControllerTest extends AbstractControllerTest {
 				.bodyJson()
 				.convertTo(cursorModel(AuditRecord.class))
 				.extracting(CursorModel::getContent, InstanceOfAssertFactories.iterable(AuditRecord.class))
-				.hasSize(1)
+				.hasSize(2)
 				.first()
 				.satisfies(record -> {
 					assertThat(record.eventType()).isEqualTo("service.created");

--- a/konfigyr-api/src/test/java/com/konfigyr/audit/controller/AuditControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/audit/controller/AuditControllerTest.java
@@ -125,6 +125,49 @@ class AuditControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@DisplayName("should filter audit events by entity type and entity identifier")
+	void shouldFilterByEntityTypeAndId() {
+		mvc.get().uri("/namespaces/{slug}/audit", "konfigyr")
+				.queryParam("entityType", "service")
+				.queryParam("entityId", EntityId.from(3).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(cursorModel(AuditRecord.class))
+				.extracting(CursorModel::getContent, InstanceOfAssertFactories.iterable(AuditRecord.class))
+				.hasSize(1)
+				.allSatisfy(record -> assertThat(record)
+						.returns(EntityId.from(3), AuditRecord::entityId)
+						.returns("service", AuditRecord::entityType)
+						.returns("service.created", AuditRecord::eventType)
+				);
+	}
+
+	@Test
+	@DisplayName("should filter audit events by entity type and event type")
+	void shouldFilterByEntityTypeAndEventType() {
+		mvc.get().uri("/namespaces/{slug}/audit", "konfigyr")
+				.queryParam("entityType", "service")
+				.queryParam("eventType", "service.created")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(cursorModel(AuditRecord.class))
+				.extracting(CursorModel::getContent, InstanceOfAssertFactories.iterable(AuditRecord.class))
+				.hasSize(2)
+				.allSatisfy(record -> assertThat(record)
+						.returns("service", AuditRecord::entityType)
+						.returns("service.created", AuditRecord::eventType)
+				);
+	}
+
+	@Test
 	@DisplayName("should filter audit events by event type")
 	void shouldFilterByEventType() {
 		mvc.get().uri("/namespaces/{slug}/audit", "konfigyr")

--- a/konfigyr-api/src/test/resources/data/audit.sql
+++ b/konfigyr-api/src/test/resources/data/audit.sql
@@ -12,6 +12,7 @@ INSERT INTO audit_events(id, namespace_id, entity_type, entity_id, event_type, a
 -- Service events for konfigyr namespace
 ('019690a1-b4a0-7000-8000-000000000005', 2, 'service', 2, 'service.created', 'john.doe@konfigyr.com', 'user', 'John Doe', '{"name": "config-service", "@class": "java.util.Collections$UnmodifiableMap"}', now() - interval '20 days'),
 ('019690a1-b4a0-7000-8000-000000000006', 2, 'service', 2, 'service.updated', 'jane.doe@konfigyr.com', 'user', 'Jane Doe', NULL, now() - interval '15 days'),
+('019690a1-b4a0-7000-8000-000000000014', 2, 'service', 3, 'service.created', 'jane.doe@konfigyr.com', 'user', 'Jane Doe', '{"name": "konfigyr-api", "@class": "java.util.Collections$UnmodifiableMap"}', now() - interval '2 days'),
 -- KMS events
 ('019690a1-b4a0-7000-8000-000000000007', 2, 'kms', 1, 'kms.key.rotated', 'system', 'system', 'System', '{"algorithm": "AES-256", "@class": "java.util.Collections$UnmodifiableMap"}', now() - interval '10 days'),
 -- Invitation events

--- a/konfigyr-frontend/src/components/artifactory/groups/group-verification-challenge.tsx
+++ b/konfigyr-frontend/src/components/artifactory/groups/group-verification-challenge.tsx
@@ -30,7 +30,7 @@ export const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
  * @param verification the group verification record to display
  * @param challenge the optional verification challenge used to render the method, challenge state, and activation instructions
  */
-export function GroupVerification ({ verification, challenge }: {
+export function GroupVerificationChallenge ({ verification, challenge }: {
   verification: GroupVerification;
   challenge?: VerificationChallenge | undefined;
 }) {

--- a/konfigyr-frontend/src/components/artifactory/groups/group-verification-details.tsx
+++ b/konfigyr-frontend/src/components/artifactory/groups/group-verification-details.tsx
@@ -1,0 +1,136 @@
+import { useMemo } from 'react';
+import {
+  PackageIcon,
+  RotateCcwIcon,
+  ShieldBanIcon,
+  XIcon,
+} from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import { Button, buttonVariants } from '@konfigyr/components/ui/button';
+import { RequestTransferLabel } from '@konfigyr/components/artifactory/transfers/messages';
+import {
+  ConflictingOwnersAlert,
+  GroupVerificationStateAlert,
+} from '@konfigyr/components/artifactory/groups/group-verification-state';
+import { GroupVerificationChallenge } from '@konfigyr/components/artifactory/groups/group-verification-challenge';
+import {
+  CancelGroupVerificationButton,
+  RevokeGroupVerificationButton,
+} from '@konfigyr/components/artifactory/groups/revoke-group-verification';
+import {
+  CancelClaimLabel,
+  ClaimAgainLabel,
+  RevokeClaimLabel,
+  VerifyClaimLabel,
+} from '@konfigyr/components/artifactory/groups/messages';
+import { VerifyGroupVerificationButton } from '@konfigyr/components/artifactory/groups/verify-group-verification';
+
+import type { GroupVerification, Namespace, VerificationChallenge } from '@konfigyr/hooks/types';
+
+function RequestTransferCta({ namespace, groupId, conflictingOwners }: {
+  namespace: string;
+  groupId: string;
+  conflictingOwners: Array<string>;
+}) {
+  const fromNamespace = conflictingOwners.length === 1 ? conflictingOwners[0] : undefined;
+
+  return (
+    <Link
+      to="/namespace/$namespace/artifactory/transfers/create"
+      params={{ namespace }}
+      search={{ groupId, fromNamespace }}
+      className={buttonVariants({ variant: 'outline', size: 'sm' })}
+    >
+      <RequestTransferLabel/>
+    </Link>
+  );
+}
+
+export function GroupVerificationDetails({ namespace, verification, challenges }: {
+  namespace: Namespace;
+  verification: GroupVerification;
+  challenges: Array<VerificationChallenge>;
+}) {
+  const challenge = useMemo(
+    () => challenges.at(-1),
+    [challenges],
+  );
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border bg-card">
+            <PackageIcon className="size-5 text-muted-foreground" aria-hidden="true"/>
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate font-mono text-2xl font-medium leading-tight">
+              {verification.groupId}
+            </h1>
+          </div>
+        </div>
+      </div>
+
+      <GroupVerificationStateAlert
+        groupId={verification.groupId}
+        verificationChallenge={challenge}
+        verificationState={verification.state}
+      />
+
+      {!!verification.conflictingOwners?.length && (
+        <ConflictingOwnersAlert
+          conflictingOwners={verification.conflictingOwners}
+          action={(
+            <RequestTransferCta
+              namespace={namespace.slug}
+              groupId={verification.groupId}
+              conflictingOwners={verification.conflictingOwners}
+            />
+          )}
+        />
+      )}
+
+      <GroupVerificationChallenge verification={verification} challenge={challenge}/>
+
+      <div className="flex flex-wrap gap-3">
+        {verification.state === 'ACTIVE' && (
+          <RevokeGroupVerificationButton namespace={namespace.slug} verification={verification} >
+            <Button variant="destructive">
+              <ShieldBanIcon />
+              <RevokeClaimLabel/>
+            </Button>
+          </RevokeGroupVerificationButton>
+        )}
+
+        {verification.state === 'PENDING' && (
+          <CancelGroupVerificationButton namespace={namespace.slug} verification={verification} >
+            <Button variant="destructive">
+              <XIcon/>
+              <CancelClaimLabel />
+            </Button>
+          </CancelGroupVerificationButton>
+        )}
+
+        {(verification.state === 'PENDING' || verification.state === 'FAILED') && (
+          <VerifyGroupVerificationButton namespace={namespace.slug} verification={verification}>
+            <Button>
+              <RotateCcwIcon/>
+              <VerifyClaimLabel/>
+            </Button>
+          </VerifyGroupVerificationButton>
+        )}
+
+        {verification.state === 'REVOKED' && (
+          <Link
+            to="/namespace/$namespace/artifactory/groups/$groupId/edit"
+            params={{ namespace: namespace.slug, groupId: verification.groupId }}
+            className={buttonVariants({ variant: 'default' })}
+          >
+            <RotateCcwIcon/>
+            <ClaimAgainLabel/>
+          </Link>
+        )}
+      </div>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/groups/group-verification-state.tsx
+++ b/konfigyr-frontend/src/components/artifactory/groups/group-verification-state.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@konfigyr/components/ui/badge';
 import { SimpleAlert } from '@konfigyr/components/ui/alert';
 import { AlertCircleIcon, CheckCircle2Icon, CircleAlertIcon, Trash2Icon, TriangleAlertIcon } from 'lucide-react';
 import { sourceCodeHostLabel } from '@konfigyr/components/artifactory/groups/group-verification-method';
-import type { ComponentProps } from 'react';
+import type { ComponentProps, ReactNode } from 'react';
 import type { VerificationMethod, VerificationState } from '@konfigyr/hooks/types';
 
 export type GroupVerificationStateAlertProps = {
@@ -184,7 +184,7 @@ function FailedStateAlert () {
   );
 }
 
-export function ConflictingOwnersAlert ({ conflictingOwners }: { conflictingOwners: Array<string> }) {
+export function ConflictingOwnersAlert ({ conflictingOwners, action }: { conflictingOwners: Array<string>; action?: ReactNode }) {
   return (
     <SimpleAlert
       icon={
@@ -207,6 +207,7 @@ export function ConflictingOwnersAlert ({ conflictingOwners }: { conflictingOwne
         />
       }
       variant="warning"
+      action={action}
     />
   );
 }

--- a/konfigyr-frontend/src/components/artifactory/transfers/breadcrumbs.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/breadcrumbs.tsx
@@ -1,0 +1,35 @@
+import { Link } from '@tanstack/react-router';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from '@konfigyr/components/ui/breadcrumb';
+
+import { TransfersLabel } from '@konfigyr/components/artifactory/transfers/messages';
+import type { ReactNode } from 'react';
+import type { Namespace } from '@konfigyr/hooks/types';
+
+export function TransfersBreadcrumbs({ namespace, children }: { namespace: Namespace; children: ReactNode }) {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink
+            render={
+              <Link
+                to="/namespace/$namespace/artifactory/transfers"
+                params={{ namespace: namespace.slug }}
+              >
+                <TransfersLabel />
+              </Link>
+            }
+          />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        {children}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/messages.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/messages.tsx
@@ -1,0 +1,167 @@
+import { FormattedMessage } from 'react-intl';
+
+export const TransfersLabel = () => (
+  <FormattedMessage
+    defaultMessage="Ownership transfers"
+    description="Breadcrumb label for the ownership transfers list page."
+  />
+);
+
+export const GroupIdLabel = () => (
+  <FormattedMessage
+    defaultMessage="Group Id"
+    description="Label for the Maven groupId of an ownership transfer."
+  />
+);
+
+export const StateLabel = () => (
+  <FormattedMessage
+    defaultMessage="State"
+    description="Label for the state of an ownership transfer."
+  />
+);
+
+export const RequestedAtLabel = () => (
+  <FormattedMessage
+    defaultMessage="Requested at"
+    description="Label for the date an ownership transfer was requested."
+  />
+);
+
+export const ResolvedAtLabel = () => (
+  <FormattedMessage
+    defaultMessage="Resolved at"
+    description="Label for the date an ownership transfer was resolved."
+  />
+);
+
+export const IncomingLabel = () => (
+  <FormattedMessage
+    defaultMessage="Incoming"
+    description="Label for the toggle showing ownership transfers where this namespace is asked to release a groupId."
+  />
+);
+
+export const OutgoingLabel = () => (
+  <FormattedMessage
+    defaultMessage="Outgoing"
+    description="Label for the toggle showing ownership transfers this namespace has requested."
+  />
+);
+
+export const RequestTransferLabel = () => (
+  <FormattedMessage
+    defaultMessage="Request transfer"
+    description="Button label that starts a new ownership transfer request."
+  />
+);
+
+export const AcceptTransferLabel = () => (
+  <FormattedMessage
+    defaultMessage="Accept"
+    description="Button label that accepts an ownership transfer request."
+  />
+);
+
+export const RejectTransferLabel = () => (
+  <FormattedMessage
+    defaultMessage="Reject"
+    description="Button label that rejects an ownership transfer request."
+  />
+);
+
+export const CancelTransferLabel = () => (
+  <FormattedMessage
+    defaultMessage="Cancel request"
+    description="Button label that cancels a pending ownership transfer request."
+  />
+);
+
+export const AcceptTransferTitle = () => (
+  <FormattedMessage
+    defaultMessage="Accept ownership transfer"
+    description="Title of the confirmation dialog for accepting an ownership transfer request."
+  />
+);
+
+export const RejectTransferTitle = () => (
+  <FormattedMessage
+    defaultMessage="Reject ownership transfer"
+    description="Title of the confirmation dialog for rejecting an ownership transfer request."
+  />
+);
+
+export const CancelTransferTitle = () => (
+  <FormattedMessage
+    defaultMessage="Cancel ownership transfer"
+    description="Title of the confirmation dialog for canceling an ownership transfer request."
+  />
+);
+
+export const AcceptTransferDescription = ({ groupId, to }: { groupId: string; to: string }) => (
+  <FormattedMessage
+    defaultMessage="Are you sure you want to transfer ownership of <b>{groupId}</b> to <b>{to}</b>?"
+    values={{
+      groupId,
+      to,
+      b: (chunks) => <strong>{chunks}</strong>,
+    }}
+    description="Confirmation text in the dialog for accepting an ownership transfer request."
+  />
+);
+
+export const RejectTransferDescription = ({ groupId, to }: { groupId: string; to: string }) => (
+  <FormattedMessage
+    defaultMessage="Are you sure you want to reject the request from <b>{to}</b> to transfer ownership of <b>{groupId}</b>?"
+    values={{
+      groupId,
+      to,
+      b: (chunks) => <strong>{chunks}</strong>,
+    }}
+    description="Confirmation text in the dialog for rejecting an ownership transfer request."
+  />
+);
+
+export const CancelTransferDescription = ({ groupId, from }: { groupId: string; from: string }) => (
+  <FormattedMessage
+    defaultMessage="Are you sure you want to cancel your request to transfer ownership of <b>{groupId}</b> from <b>{from}</b>?"
+    values={{
+      groupId,
+      from,
+      b: (chunks) => <strong>{chunks}</strong>,
+    }}
+    description="Confirmation text in the dialog for canceling an ownership transfer request."
+  />
+);
+
+export const TransferAcceptedSuccessMessage = ({ groupId }: { groupId: string }) => (
+  <FormattedMessage
+    defaultMessage="Transferred ownership of {groupId}"
+    values={{ groupId }}
+    description="Success message when an ownership transfer request is accepted."
+  />
+);
+
+export const TransferRejectedSuccessMessage = ({ groupId }: { groupId: string }) => (
+  <FormattedMessage
+    defaultMessage="Rejected the ownership transfer request for {groupId}"
+    values={{ groupId }}
+    description="Success message when an ownership transfer request is rejected."
+  />
+);
+
+export const TransferCanceledSuccessMessage = ({ groupId }: { groupId: string }) => (
+  <FormattedMessage
+    defaultMessage="Canceled the ownership transfer request for {groupId}"
+    values={{ groupId }}
+    description="Success message when an ownership transfer request is canceled."
+  />
+);
+
+export const TransferRequestedSuccessMessage = ({ groupId }: { groupId: string }) => (
+  <FormattedMessage
+    defaultMessage="Requested ownership transfer of {groupId}"
+    values={{ groupId }}
+    description="Success message when an ownership transfer request is created."
+  />
+);

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-actions.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-actions.tsx
@@ -1,0 +1,202 @@
+'use client';
+
+import { toast } from 'sonner';
+import { useCallback } from 'react';
+import { CheckCircle2Icon, TriangleAlert } from 'lucide-react';
+import { useAcceptTransfer, useCancelTransfer, useRejectTransfer } from '@konfigyr/hooks';
+import { useErrorNotification } from '@konfigyr/components/error';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@konfigyr/components/ui/alert-dialog';
+import { CancelLabel } from '@konfigyr/components/messages';
+import {
+  AcceptTransferDescription,
+  AcceptTransferLabel,
+  AcceptTransferTitle,
+  CancelTransferDescription,
+  CancelTransferLabel,
+  CancelTransferTitle,
+  RejectTransferDescription,
+  RejectTransferLabel,
+  RejectTransferTitle,
+  TransferAcceptedSuccessMessage,
+  TransferCanceledSuccessMessage,
+  TransferRejectedSuccessMessage,
+} from '@konfigyr/components/artifactory/transfers/messages';
+import type { AriaRole, ReactElement, ReactNode } from 'react';
+import type { ArtifactOwnershipTransfer } from '@konfigyr/hooks/types';
+
+type TransferActionButtonProps = {
+  namespace: string;
+  transfer: ArtifactOwnershipTransfer;
+  children: ReactElement;
+  role?: AriaRole;
+  nativeButton?: boolean;
+  onOpenChange?: (open: boolean) => void;
+};
+
+type ConfirmTransferDialogProps = {
+  children: ReactElement;
+  role?: AriaRole;
+  nativeButton?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  icon: ReactNode;
+  title: ReactNode;
+  description: ReactNode;
+  submitLabel: ReactNode;
+  variant: 'default' | 'destructive';
+  isPending: boolean;
+  onConfirm: () => void;
+};
+
+function ConfirmTransferDialog ({
+  children,
+  role,
+  nativeButton,
+  onOpenChange,
+  icon,
+  title,
+  description,
+  submitLabel,
+  variant,
+  isPending,
+  onConfirm,
+}: ConfirmTransferDialogProps) {
+  return (
+    <AlertDialog onOpenChange={onOpenChange}>
+      <AlertDialogTrigger
+        nativeButton={nativeButton}
+        role={role}
+        render={children}
+      />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            {icon}
+            {title}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {description}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>
+            <CancelLabel/>
+          </AlertDialogCancel>
+          <AlertDialogAction
+            variant={variant}
+            disabled={isPending}
+            loading={isPending}
+            onClick={onConfirm}
+          >
+            {submitLabel}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+
+export function AcceptTransferButton ({ namespace, transfer, children, role, nativeButton, onOpenChange }: TransferActionButtonProps) {
+  const errorNotification = useErrorNotification();
+  const { isPending, mutateAsync: acceptTransfer } = useAcceptTransfer(namespace);
+
+  const onConfirm = useCallback(async () => {
+    try {
+      await acceptTransfer(transfer.id);
+    } catch (error) {
+      return errorNotification(error);
+    }
+
+    toast.success(<TransferAcceptedSuccessMessage groupId={transfer.groupId}/>);
+  }, [transfer, errorNotification, acceptTransfer]);
+
+  return (
+    <ConfirmTransferDialog
+      role={role}
+      nativeButton={nativeButton}
+      onOpenChange={onOpenChange}
+      icon={<CheckCircle2Icon className="h-5 w-5 text-success shrink-0"/>}
+      title={<AcceptTransferTitle/>}
+      description={<AcceptTransferDescription groupId={transfer.groupId} to={transfer.to.slug}/>}
+      submitLabel={<AcceptTransferLabel/>}
+      variant="default"
+      isPending={isPending}
+      onConfirm={onConfirm}
+    >
+      {children}
+    </ConfirmTransferDialog>
+  );
+}
+
+export function RejectTransferButton ({ namespace, transfer, children, role, nativeButton, onOpenChange }: TransferActionButtonProps) {
+  const errorNotification = useErrorNotification();
+  const { isPending, mutateAsync: rejectTransfer } = useRejectTransfer(namespace);
+
+  const onConfirm = useCallback(async () => {
+    try {
+      await rejectTransfer(transfer.id);
+    } catch (error) {
+      return errorNotification(error);
+    }
+
+    toast.success(<TransferRejectedSuccessMessage groupId={transfer.groupId}/>);
+  }, [transfer, errorNotification, rejectTransfer]);
+
+  return (
+    <ConfirmTransferDialog
+      role={role}
+      nativeButton={nativeButton}
+      onOpenChange={onOpenChange}
+      icon={<TriangleAlert className="h-5 w-5 text-destructive shrink-0"/>}
+      title={<RejectTransferTitle/>}
+      description={<RejectTransferDescription groupId={transfer.groupId} to={transfer.to.slug}/>}
+      submitLabel={<RejectTransferLabel/>}
+      variant="destructive"
+      isPending={isPending}
+      onConfirm={onConfirm}
+    >
+      {children}
+    </ConfirmTransferDialog>
+  );
+}
+
+export function CancelTransferButton ({ namespace, transfer, children, role, nativeButton, onOpenChange }: TransferActionButtonProps) {
+  const errorNotification = useErrorNotification();
+  const { isPending, mutateAsync: cancelTransfer } = useCancelTransfer(namespace);
+
+  const onConfirm = useCallback(async () => {
+    try {
+      await cancelTransfer(transfer.id);
+    } catch (error) {
+      return errorNotification(error);
+    }
+
+    toast.success(<TransferCanceledSuccessMessage groupId={transfer.groupId}/>);
+  }, [transfer, errorNotification, cancelTransfer]);
+
+  return (
+    <ConfirmTransferDialog
+      role={role}
+      nativeButton={nativeButton}
+      onOpenChange={onOpenChange}
+      icon={<TriangleAlert className="h-5 w-5 text-destructive shrink-0"/>}
+      title={<CancelTransferTitle/>}
+      description={<CancelTransferDescription groupId={transfer.groupId} from={transfer.from.slug}/>}
+      submitLabel={<CancelTransferLabel/>}
+      variant="destructive"
+      isPending={isPending}
+      onConfirm={onConfirm}
+    >
+      {children}
+    </ConfirmTransferDialog>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-audit-trail.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-audit-trail.tsx
@@ -1,0 +1,25 @@
+import { HistoryLabel } from '@konfigyr/components/messages';
+import { AuditRecordListContent } from '@konfigyr/components/audit/audit-record-list';
+import { useGetAuditRecords } from '@konfigyr/hooks';
+
+import type { Namespace } from '@konfigyr/hooks/types';
+
+export function TransferAuditTrail({ namespace, transferId }: {
+  namespace: Namespace;
+  transferId: string;
+}) {
+  const { data, error, isPending } = useGetAuditRecords(namespace, {
+    entityType: 'artifact-ownership-transfer',
+    entityId: transferId,
+    size: 20,
+  });
+
+  return (
+    <div className="space-y-3">
+      <h2 className="text-sm font-medium text-muted-foreground">
+        <HistoryLabel/>
+      </h2>
+      <AuditRecordListContent data={data} error={error} isPending={isPending}/>
+    </div>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-details.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-details.tsx
@@ -1,0 +1,115 @@
+import {
+  ArrowLeftRightIcon,
+  CheckIcon,
+  XIcon,
+} from 'lucide-react';
+import { FormattedDate } from 'react-intl';
+import { Button } from '@konfigyr/components/ui/button';
+import { TransferStateBadge } from '@konfigyr/components/artifactory/transfers/transfer-state-badge';
+import { NamespaceLabel } from '@konfigyr/components/messages';
+import {
+  AcceptTransferLabel,
+  CancelTransferLabel,
+  RejectTransferLabel,
+  RequestedAtLabel,
+  ResolvedAtLabel,
+} from '@konfigyr/components/artifactory/transfers/messages';
+import {
+  AcceptTransferButton,
+  CancelTransferButton,
+  RejectTransferButton,
+} from '@konfigyr/components/artifactory/transfers/transfer-actions';
+import { TransferAuditTrail } from '@konfigyr/components/artifactory/transfers/transfer-audit-trail';
+
+import type { ArtifactOwnershipTransfer, Namespace } from '@konfigyr/hooks/types';
+
+export function TransferDetails({ namespace, transfer }: {
+  namespace: Namespace;
+  transfer: ArtifactOwnershipTransfer;
+}) {
+  const isFromParty = transfer.from.slug === namespace.slug;
+  const isToParty = transfer.to.slug === namespace.slug;
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border bg-card">
+            <ArrowLeftRightIcon className="size-5 text-muted-foreground" aria-hidden="true"/>
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate font-mono text-2xl font-medium leading-tight">
+              {transfer.groupId}
+            </h1>
+          </div>
+        </div>
+        <TransferStateBadge state={transfer.state}/>
+      </div>
+
+      <dl className="grid grid-cols-3 gap-4 text-sm">
+        <div>
+          <dt className="text-muted-foreground"><NamespaceLabel/></dt>
+          <dd>{isFromParty ? transfer.to.slug : transfer.from.slug}</dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground"><RequestedAtLabel/></dt>
+          <dd>
+            {transfer.requestedAt ? (
+              <time dateTime={transfer.requestedAt}>
+                <FormattedDate value={transfer.requestedAt} day="2-digit" month="short" year="numeric"/>
+              </time>
+            ) : (
+              <span className="text-muted-foreground">&mdash;</span>
+            )}
+          </dd>
+        </div>
+        <div>
+          <dt className="text-muted-foreground"><ResolvedAtLabel/></dt>
+          <dd>
+            {transfer.resolvedAt ? (
+              <time dateTime={transfer.resolvedAt}>
+                <FormattedDate value={transfer.resolvedAt} day="2-digit" month="short" year="numeric"/>
+              </time>
+            ) : (
+              <span className="text-muted-foreground">&mdash;</span>
+            )}
+          </dd>
+        </div>
+      </dl>
+
+      <div className="flex flex-wrap gap-3">
+        {transfer.state === 'PENDING' && isFromParty && (
+          <>
+            <AcceptTransferButton namespace={namespace.slug} transfer={transfer}>
+              <Button>
+                <CheckIcon/>
+                <AcceptTransferLabel/>
+              </Button>
+            </AcceptTransferButton>
+
+            <RejectTransferButton namespace={namespace.slug} transfer={transfer}>
+              <Button variant="destructive">
+                <XIcon/>
+                <RejectTransferLabel/>
+              </Button>
+            </RejectTransferButton>
+          </>
+        )}
+
+        {transfer.state === 'PENDING' && isToParty && (
+          <CancelTransferButton namespace={namespace.slug} transfer={transfer}>
+            <Button variant="destructive">
+              <XIcon/>
+              <CancelTransferLabel/>
+            </Button>
+          </CancelTransferButton>
+        )}
+      </div>
+
+      <TransferAuditTrail
+        namespace={namespace}
+        transferId={transfer.id}
+      />
+    </>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-filters.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-filters.tsx
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { useIntl } from 'react-intl';
+import { SearchIcon } from 'lucide-react';
+import { useDebouncedCallback } from 'use-debounce';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@konfigyr/components/ui/input-group';
+
+import type { ChangeEvent } from 'react';
+import type { ArtifactOwnershipTransferQuery } from '@konfigyr/hooks/types';
+
+export function TransferFilters({ query, onQueryChange }: {
+  query: ArtifactOwnershipTransferQuery,
+  onQueryChange: (query: ArtifactOwnershipTransferQuery) => void,
+}) {
+  const intl = useIntl();
+  const debounced = useDebouncedCallback(
+    (term: string) => onQueryChange({ term: term || undefined }),
+    200,
+  );
+
+  const onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    debounced(event.target.value);
+  }, [debounced]);
+
+  return (
+    <InputGroup className="grow">
+      <InputGroupInput
+        type="search"
+        defaultValue={query.term || ''}
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Search ownership transfers...',
+          description: 'Placeholder text for the ownership transfers search input.',
+        })}
+        aria-label={intl.formatMessage({
+          defaultMessage: 'Search ownership transfers',
+          description: 'Label for the ownership transfers search input.',
+        })}
+        className="text-sm"
+        onChange={onChange}
+      />
+      <InputGroupAddon>
+        <SearchIcon size="1rem" className="text-muted-foreground" />
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-request-form.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-request-form.tsx
@@ -1,0 +1,310 @@
+import { z } from 'zod';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { ArrowLeftRightIcon, CircleQuestionMarkIcon } from 'lucide-react';
+import { useQuery } from '@tanstack/react-query';
+import { useDebouncedCallback } from 'use-debounce';
+import { Link } from '@tanstack/react-router';
+import { Button, buttonVariants } from '@konfigyr/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@konfigyr/components/ui/card';
+import { SimpleAlert } from '@konfigyr/components/ui/alert';
+import { useNormalizeError } from '@konfigyr/components/error/normalize';
+import { CancelLabel } from '@konfigyr/components/messages';
+import { Field, FieldDescription, FieldError, FieldLabel } from '@konfigyr/components/ui/field';
+import { Combobox, ComboboxContent, ComboboxEmpty, ComboboxInput, ComboboxItem, ComboboxList } from '@konfigyr/components/ui/combobox';
+import { Label } from '@konfigyr/components/ui/label';
+import { RadioGroup, RadioGroupItem } from '@konfigyr/components/ui/radio-group';
+import { cn } from '@konfigyr/components/utils';
+import { useForm, useFormSubmit } from '@konfigyr/components/ui/form';
+import { getGroupVerification, useGetGroupVerifications } from '@konfigyr/hooks';
+import { GroupIdLabel, RequestTransferLabel } from '@konfigyr/components/artifactory/transfers/messages';
+
+export const TRANSFER_REQUEST_SCHEMA = z.object({
+  groupId: z.string().min(1, { message: 'Group ID is required' }),
+  fromNamespace: z.string().min(1, { message: 'Namespace is required' }),
+});
+
+export type TransferRequestFormValues = z.infer<typeof TRANSFER_REQUEST_SCHEMA>;
+
+export type TransferRequestFormProps = {
+  namespace: string;
+  defaultValues: TransferRequestFormValues;
+  onSubmit: (args: { value: TransferRequestFormValues }) => Promise<void>;
+  onCancel: () => void;
+  error?: unknown;
+};
+
+function normalizeFieldError(e: unknown): { message?: string } {
+  if (typeof e === 'string') return { message: e };
+  if (e && typeof e === 'object' && 'message' in e) return e as { message?: string };
+  return {};
+}
+
+function GroupIdCombobox({ namespace, value, onChange }: {
+  namespace: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const [input, setInput] = useState(value);
+  const [term, setTerm] = useState<string>();
+  const debouncedSetTerm = useDebouncedCallback((next: string) => setTerm(next || undefined), 200);
+
+  useEffect(() => setInput(value), [value]);
+
+  const { data } = useGetGroupVerifications(namespace, { state: 'ACTIVE', term, size: 20 });
+
+  const groupIds = useMemo(() => {
+    const ids = new Set((data?.data ?? []).map(verification => verification.groupId));
+    if (value) {
+      ids.add(value);
+    }
+    return Array.from(ids);
+  }, [data, value]);
+
+  const onInputValueChange = useCallback((next: string) => {
+    setInput(next);
+    debouncedSetTerm(next);
+  }, [debouncedSetTerm]);
+
+  return (
+    <Combobox
+      items={groupIds}
+      value={value || null}
+      onValueChange={(next) => onChange(next ?? '')}
+      inputValue={input}
+      onInputValueChange={onInputValueChange}
+    >
+      <ComboboxInput
+        aria-label="Group Id"
+        placeholder="com.mycompany"
+        autoComplete="off"
+        className="font-mono"
+      />
+      <ComboboxContent>
+        <ComboboxEmpty className="flex-col gap-2 py-3">
+          <FormattedMessage
+            defaultMessage="No active group claims found."
+            description="Empty state shown in the groupId combobox when this namespace has no matching active claims."
+          />
+          <Link
+            to="/namespace/$namespace/artifactory/groups/create"
+            params={{ namespace }}
+            className={buttonVariants({ variant: 'outline', size: 'sm' })}
+          >
+            <FormattedMessage
+              defaultMessage="Claim a groupId"
+              description="Link shown in the groupId combobox empty state, leading to the group verification claim creation page."
+            />
+          </Link>
+        </ComboboxEmpty>
+        <ComboboxList>
+          {groupIds.map(groupId => (
+            <ComboboxItem key={groupId} value={groupId}>{groupId}</ComboboxItem>
+          ))}
+        </ComboboxList>
+      </ComboboxContent>
+    </Combobox>
+  );
+}
+
+function FromNamespaceRadioGroup({ namespace, groupId, value, onChange }: {
+  namespace: string;
+  groupId: string;
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  const { data: verification, isPending } = useQuery({
+    ...getGroupVerification(namespace, groupId),
+    enabled: !!groupId,
+  });
+
+  const owners = useMemo(() => {
+    const slugs = new Set(verification?.conflictingOwners ?? []);
+    if (value) {
+      slugs.add(value);
+    }
+    return Array.from(slugs);
+  }, [verification, value]);
+
+  if (!groupId) {
+    return (
+      <p className="text-sm text-muted-foreground italic">
+        <FormattedMessage
+          defaultMessage="Select a groupId first."
+          description="Hint shown before a groupId has been chosen on the ownership transfer request creation form."
+        />
+      </p>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <p className="text-sm text-muted-foreground italic">
+        <FormattedMessage
+          defaultMessage="Checking for owners of this groupId, please be patient..."
+          description="Loading state shown when the selected groupId is loading conflicting groupId owners."
+        />
+      </p>
+    );
+  }
+
+  if (owners.length === 0) {
+    return (
+      <p className="text-sm text-muted-foreground italic">
+        <FormattedMessage
+          defaultMessage="No known namespaces own artifacts under this groupId yet."
+          description="Empty state shown when the selected groupId has no conflicting owners."
+        />
+      </p>
+    );
+  }
+
+  return (
+    <RadioGroup value={value || ''} onValueChange={onChange} aria-label="From namespace">
+      {owners.map((slug) => {
+        const selected = value === slug;
+        return (
+          <Label
+            key={slug}
+            className={cn(
+              'cursor-pointer border gap-4 rounded-xl p-4 transition-colors',
+              selected ? 'border-primary bg-primary/5 dark:bg-primary/10' : 'border-transparent hover:bg-muted/50',
+            )}
+          >
+            <RadioGroupItem value={slug}/>
+            <span className="font-medium font-mono leading-none">{slug}</span>
+          </Label>
+        );
+      })}
+    </RadioGroup>
+  );
+}
+
+export function TransferRequestForm ({
+  namespace,
+  defaultValues,
+  onSubmit,
+  onCancel,
+  error,
+}: TransferRequestFormProps) {
+  const form = useForm({
+    defaultValues,
+    validators: { onSubmit: TRANSFER_REQUEST_SCHEMA },
+    onSubmit,
+  });
+
+  const handleSubmit = useFormSubmit(form);
+  const problem = useNormalizeError(error);
+
+  return (
+    <Card className="border">
+      <CardHeader>
+        <CardTitle className="flex flex-col items-center gap-6 my-2">
+          <ArrowLeftRightIcon size={64} strokeWidth="1" className="text-secondary"/>
+          <p className="text-center text-lg lg:text-xl">
+            <FormattedMessage
+              defaultMessage="Request an ownership transfer"
+              description="Heading on the ownership transfer request creation form"
+            />
+          </p>
+        </CardTitle>
+        <CardDescription>
+          <FormattedMessage
+            defaultMessage="Ask another namespace to release a Maven groupId so this namespace can take over publishing under it."
+            description="Description text shown when user tries to create a new ownership transfer request"
+          />
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        <SimpleAlert
+          icon={<CircleQuestionMarkIcon />}
+          title={
+            <FormattedMessage
+              defaultMessage="How ownership transfer works"
+              description="Title for the explanation of the ownership transfer preconditions shown above the request form."
+            />
+          }
+          description={
+            <FormattedMessage
+              defaultMessage="You can only request a transfer for a groupId your own namespace already holds an active, verified claim on. That's only possible once any previous claim on it has been revoked (or none ever existed). Meaning, if the previous owner still had one, it's already gone. Pick the namespace below that already publishes artifacts under this groupId; submitting sends them an accept/reject decision."
+              description="Explanation of the ownership transfer preconditions shown above the request form."
+            />
+          }
+        />
+
+        {problem && (
+          <SimpleAlert
+            variant="destructive"
+            title={problem.title}
+            description={problem.detail}
+          />
+        )}
+
+        <form.AppForm>
+          <form name="request-transfer" className="grid gap-6" onSubmit={handleSubmit}>
+            <form.AppField name="groupId" children={(field) => (
+              <Field>
+                <FieldLabel>
+                  <GroupIdLabel/>
+                </FieldLabel>
+                <FieldDescription>
+                  <FormattedMessage
+                    defaultMessage="The Maven groupId this namespace has verified and wants to take over."
+                    description="Hint text for the groupId combobox field on the ownership transfer request creation form."
+                  />
+                </FieldDescription>
+                <GroupIdCombobox
+                  namespace={namespace}
+                  value={field.state.value}
+                  onChange={(next) => {
+                    field.handleChange(next);
+                    form.setFieldValue('fromNamespace', '');
+                  }}
+                />
+                <FieldError errors={field.state.meta.errors.map(normalizeFieldError)} />
+              </Field>
+            )}/>
+
+            <form.AppField name="fromNamespace" children={(field) => (
+              <Field>
+                <FieldLabel>
+                  <FormattedMessage
+                    defaultMessage="From namespace"
+                    description="Label for the from-namespace radio field on the ownership transfer request creation form."
+                  />
+                </FieldLabel>
+                <FieldDescription>
+                  <FormattedMessage
+                    defaultMessage="The namespace that currently owns artifacts under this groupId and is being asked to release them."
+                    description="Hint text for the from-namespace radio field on the ownership transfer request creation form."
+                  />
+                </FieldDescription>
+                <form.Subscribe
+                  selector={(state) => state.values.groupId}
+                  children={(groupId) => (
+                    <FromNamespaceRadioGroup
+                      namespace={namespace}
+                      groupId={groupId}
+                      value={field.state.value}
+                      onChange={field.handleChange}
+                    />
+                  )}
+                />
+                <FieldError errors={field.state.meta.errors.map(normalizeFieldError)} />
+              </Field>
+            )}/>
+
+            <div className="flex gap-3">
+              <form.Submit>
+                <RequestTransferLabel/>
+              </form.Submit>
+              <Button type="button" variant="ghost" onClick={onCancel}>
+                <CancelLabel/>
+              </Button>
+            </div>
+          </form>
+        </form.AppForm>
+      </CardContent>
+    </Card>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-state-badge.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-state-badge.tsx
@@ -1,0 +1,70 @@
+import { FormattedMessage } from 'react-intl';
+import { Badge } from '@konfigyr/components/ui/badge';
+
+import type { ComponentProps } from 'react';
+import type { TransferState } from '@konfigyr/hooks/types';
+
+export function TransferStateLabel ({ state }: { state?: string | TransferState }) {
+  switch (state) {
+    case 'PENDING':
+      return <FormattedMessage
+        defaultMessage="Pending"
+        description="Name or label of the PENDING ownership transfer state."
+      />;
+    case 'ACCEPTED':
+      return <FormattedMessage
+        defaultMessage="Accepted"
+        description="Name or label of the ACCEPTED ownership transfer state."
+      />;
+    case 'REJECTED':
+      return <FormattedMessage
+        defaultMessage="Rejected"
+        description="Name or label of the REJECTED ownership transfer state."
+      />;
+    case 'CANCELLED':
+      return <FormattedMessage
+        defaultMessage="Cancelled"
+        description="Name or label of the CANCELLED ownership transfer state."
+      />;
+    default:
+      return null;
+  }
+}
+
+export function TransferStateBadge ({ state, ...props }: {
+  state?: string | TransferState;
+} & Omit<ComponentProps<typeof Badge>, 'variant'>) {
+  const label = <TransferStateLabel state={state}/>;
+  const icon = (
+    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 4" width="4" height="4">
+      <circle cx="2" cy="2" r="1" fill="currentColor"/>
+    </svg>
+  );
+
+  switch (state) {
+    case 'PENDING':
+      return (
+        <Badge variant="warning" {...props}>
+          {icon} {label}
+        </Badge>
+      );
+    case 'ACCEPTED':
+      return (
+        <Badge variant="success" {...props}>
+          {icon} {label}
+        </Badge>
+      );
+    case 'REJECTED':
+      return (
+        <Badge variant="destructive" {...props}>
+          {icon} {label}
+        </Badge>
+      );
+    case 'CANCELLED':
+      return (
+        <Badge variant="secondary" {...props}>
+          {icon} {label}
+        </Badge>
+      );
+  }
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-table.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-table.tsx
@@ -1,0 +1,217 @@
+import { ArrowLeftRightIcon, Package } from 'lucide-react';
+import { FormattedDate, FormattedMessage } from 'react-intl';
+import { Link } from '@tanstack/react-router';
+import {
+  ActionsLabel,
+  CreatedAtLabel,
+  NamespaceLabel,
+  ViewLabel,
+} from '@konfigyr/components/messages';
+import { ErrorState } from '@konfigyr/components/error';
+import { buttonVariants } from '@konfigyr/components/ui/button';
+import { Card, CardContent } from '@konfigyr/components/ui/card';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationRange,
+} from '@konfigyr/components/ui/pagination';
+import { Skeleton } from '@konfigyr/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@konfigyr/components/ui/table';
+import { GroupIdLabel, StateLabel } from '@konfigyr/components/artifactory/transfers/messages';
+import { TransferStateBadge } from '@konfigyr/components/artifactory/transfers/transfer-state-badge';
+
+import type { ArtifactOwnershipTransfer, PageResponse } from '@konfigyr/hooks/types';
+
+export type TransferDirection = 'incoming' | 'outgoing';
+
+function TransferRow ({ namespace, direction, transfer }: {
+  namespace: string;
+  direction: TransferDirection;
+  transfer: ArtifactOwnershipTransfer;
+}) {
+  const counterpart = direction === 'incoming' ? transfer.to : transfer.from;
+
+  return (
+    <TableRow>
+      <TableCell className="font-mono font-bold">
+        <div className="flex items-center gap-2">
+          <Package className="size-4 text-muted-foreground" aria-hidden="true"/>
+          {transfer.groupId}
+        </div>
+      </TableCell>
+      <TableCell>
+        {counterpart.slug}
+      </TableCell>
+      <TableCell>
+        <TransferStateBadge state={transfer.state}/>
+      </TableCell>
+      <TableCell>
+        {transfer.requestedAt ? (
+          <time dateTime={transfer.requestedAt}>
+            <FormattedDate value={transfer.requestedAt} day="2-digit" month="short" year="numeric"/>
+          </time>
+        ) : (
+          <span className="text-muted-foreground">&mdash;</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        <Link
+          to="/namespace/$namespace/artifactory/transfers/$transferId"
+          params={{ namespace, transferId: transfer.id }}
+          className={buttonVariants({ variant: 'ghost' })}
+        >
+          <ViewLabel/>
+        </Link>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function TransferSkeleton () {
+  return (
+    <TableRow data-slot="transfer-skeleton">
+      <TableCell><Skeleton className="h-5 w-48"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-24"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-20 rounded-xl"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-24"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-24 ml-auto"/></TableCell>
+    </TableRow>
+  );
+}
+
+function TransferPagination ({ page = 1, size = 20, data }: {
+  page?: number;
+  size?: number;
+  data?: PageResponse<ArtifactOwnershipTransfer>;
+}) {
+  const pages = data?.metadata.pages || 1;
+  const total = data?.metadata.total || 0;
+
+  if (pages < 2) {
+    return null;
+  }
+
+  return (
+    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            render={(
+              <Link to="." search={search => ({ ...search, page: page - 1 })}/>
+            )}
+          />
+        </PaginationItem>
+        <PaginationRange>
+          {(state) => (
+            <PaginationLink
+              isActive={state.active}
+              render={(
+                <Link to="." search={search => ({ ...search, page: state.page })}>
+                  {state.page}
+                </Link>
+              )}
+            />
+          )}
+        </PaginationRange>
+        <PaginationItem>
+          <PaginationNext
+            render={(
+              <Link to="." search={search => ({ ...search, page: page + 1 })}/>
+            )}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}
+
+export function TransferTable ({ namespace, direction, data, error, isPending, page, size }: {
+  namespace: string;
+  direction: TransferDirection;
+  data?: PageResponse<ArtifactOwnershipTransfer>;
+  error?: Error | null;
+  isPending?: boolean;
+  page?: number;
+  size?: number;
+}) {
+  return (
+    <>
+      <Card className="border">
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-64">
+                  <GroupIdLabel/>
+                </TableHead>
+                <TableHead className="w-40">
+                  <NamespaceLabel/>
+                </TableHead>
+                <TableHead className="w-32">
+                  <StateLabel/>
+                </TableHead>
+                <TableHead className="w-32">
+                  <CreatedAtLabel/>
+                </TableHead>
+                <TableHead className="w-48 text-right">
+                  <ActionsLabel/>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isPending && (
+                <>
+                  <TransferSkeleton/>
+                  <TransferSkeleton/>
+                  <TransferSkeleton/>
+                </>
+              )}
+
+              {data?.data.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={5}>
+                    <EmptyState
+                      icon={<ArrowLeftRightIcon size="2rem"/>}
+                      title={
+                        <FormattedMessage
+                          defaultMessage="No ownership transfers found"
+                          description="Empty state title when no ownership transfers are found."
+                        />
+                      }
+                      description={
+                        direction === 'incoming' ? (
+                          <FormattedMessage
+                            defaultMessage="No other namespace has asked this namespace to transfer ownership of a groupId."
+                            description="Empty state description when no incoming ownership transfers are found."
+                          />
+                        ) : (
+                          <FormattedMessage
+                            defaultMessage="This namespace has not requested ownership of a groupId from another namespace."
+                            description="Empty state description when no outgoing ownership transfers are found."
+                          />
+                        )
+                      }
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {data?.data.map((transfer) => (
+                <TransferRow key={transfer.id} namespace={namespace} direction={direction} transfer={transfer}/>
+              ))}
+            </TableBody>
+          </Table>
+
+          {error && <ErrorState error={error}/>}
+        </CardContent>
+      </Card>
+
+      <TransferPagination page={page} size={size} data={data}/>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/components/audit/audit-record-list.tsx
+++ b/konfigyr-frontend/src/components/audit/audit-record-list.tsx
@@ -99,7 +99,7 @@ function AuditRecordSkeleton() {
   );
 }
 
-function AuditRecordListContent({ data, error, isPending = false }: {
+export function AuditRecordListContent({ data, error, isPending = false }: {
   data?: CursorResponse<AuditRecord>;
   error?: Error | null;
   isPending?: boolean;

--- a/konfigyr-frontend/src/components/error/normalize.tsx
+++ b/konfigyr-frontend/src/components/error/normalize.tsx
@@ -1,4 +1,5 @@
 import { HTTPError } from 'ky';
+import { useMemo } from 'react';
 import {
   GeneralErrorDetail,
   GeneralErrorTitle,
@@ -10,6 +11,15 @@ export interface NormalizedError {
   title: string | ReactNode,
   detail: string | ReactNode;
 }
+
+export const useNormalizeError = (error?: any): NormalizedError | null => useMemo(
+  () => {
+    if (error === undefined || error === null) {
+      return null;
+    }
+    return normalizeError(error);
+  }, [error],
+);
 
 export const normalizeError = (error: any): NormalizedError => {
   let title, detail;

--- a/konfigyr-frontend/src/components/messages/globals.tsx
+++ b/konfigyr-frontend/src/components/messages/globals.tsx
@@ -54,6 +54,13 @@ export const OAuthErrorDetail = () => (
   />
 );
 
+export const NamespaceLabel = () => (
+  <FormattedMessage
+    defaultMessage="Namespace"
+    description="Simple namespace label text."
+  />
+);
+
 export const HomeLabel = () => (
   <FormattedMessage
     defaultMessage="Home"

--- a/konfigyr-frontend/src/components/namespace/navigation/artifactory.tsx
+++ b/konfigyr-frontend/src/components/namespace/navigation/artifactory.tsx
@@ -34,9 +34,19 @@ export function NamespaceArtifactoryNavigationMenu({ namespace }: { namespace: N
                 />
               </Link>
             } />
-            <SidebarMenuButton disabled>
-              <span className="truncate">Ownership transfers</span>
-            </SidebarMenuButton>
+            <SidebarMenuButton render={
+              <Link
+                to="/namespace/$namespace/artifactory/transfers"
+                params={{ namespace: namespace.slug }}
+                className="truncate"
+                activeProps={{ 'data-active': true }}
+              >
+                <FormattedMessage
+                  defaultMessage="Ownership transfers"
+                  description="Label for the Ownership transfers page"
+                />
+              </Link>
+            } />
             <SidebarMenuButton disabled>
               <span className="truncate">Artifact registry</span>
             </SidebarMenuButton>

--- a/konfigyr-frontend/src/hooks/audit/query.tsx
+++ b/konfigyr-frontend/src/hooks/audit/query.tsx
@@ -23,7 +23,7 @@ export const getAuditRecordsQuery = (namespace: Namespace, query: AuditRecordQue
         .json<CursorResponse<AuditRecord>>();
     },
     placeholderData: previousData => previousData,
-    staleTime: Infinity,
+    staleTime: 5000,
   });
 };
 

--- a/konfigyr-frontend/src/hooks/audit/types.ts
+++ b/konfigyr-frontend/src/hooks/audit/types.ts
@@ -17,6 +17,7 @@ export interface AuditRecord {
 
 export interface AuditRecordQuery {
   entityType?: string;
+  entityId?: string;
   from?: string;
   to?: string;
   token?: string;

--- a/konfigyr-frontend/src/hooks/index.ts
+++ b/konfigyr-frontend/src/hooks/index.ts
@@ -6,6 +6,7 @@ export * from './kms/query';
 export * from './memberships/query';
 export * from './namespace/context';
 export * from './namespace/query';
+export * from './transfers/query';
 export * from './vault/change-requests';
 export * from './vault/config-file-parser';
 export * from './vault/changeset';

--- a/konfigyr-frontend/src/hooks/transfers/query.tsx
+++ b/konfigyr-frontend/src/hooks/transfers/query.tsx
@@ -1,0 +1,128 @@
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import request from '@konfigyr/lib/http';
+
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+import type {
+  ArtifactOwnershipTransfer,
+  ArtifactOwnershipTransferQuery,
+  RequestTransferPayload,
+} from './types';
+
+export const transferKeys = {
+  getTransfer: (namespace: string, id: string) => ['namespace', namespace, 'artifact-transfers', id],
+  getIncomingTransfers: (namespace: string, query: ArtifactOwnershipTransferQuery) => ['namespace', namespace, 'artifact-transfers', 'incoming', query],
+  getOutgoingTransfers: (namespace: string, query: ArtifactOwnershipTransferQuery) => ['namespace', namespace, 'artifact-transfers', 'outgoing', query],
+};
+
+export const getIncomingTransfers = (namespace: string, query: ArtifactOwnershipTransferQuery = {}) => {
+  return queryOptions({
+    queryKey: transferKeys.getIncomingTransfers(namespace, query),
+    queryFn: async ({ signal }): Promise<PageResponse<ArtifactOwnershipTransfer>> => {
+      return await request
+        .get(`api/namespaces/${namespace}/artifact-transfers/incoming`, { signal, searchParams: { ...query } })
+        .json();
+    },
+    placeholderData: previousData => previousData,
+  });
+};
+
+export const getOutgoingTransfers = (namespace: string, query: ArtifactOwnershipTransferQuery = {}) => {
+  return queryOptions({
+    queryKey: transferKeys.getOutgoingTransfers(namespace, query),
+    queryFn: async ({ signal }): Promise<PageResponse<ArtifactOwnershipTransfer>> => {
+      return await request
+        .get(`api/namespaces/${namespace}/artifact-transfers/outgoing`, { signal, searchParams: { ...query } })
+        .json();
+    },
+    placeholderData: previousData => previousData,
+  });
+};
+
+export const getTransfer = (namespace: string, id: string) => {
+  return queryOptions({
+    queryKey: transferKeys.getTransfer(namespace, id),
+    queryFn: async ({ signal }): Promise<ArtifactOwnershipTransfer> => {
+      return await request
+        .get(`api/namespaces/${namespace}/artifact-transfers/${id}`, { signal })
+        .json();
+    },
+  });
+};
+
+export const useGetIncomingTransfers = (namespace: string, query?: ArtifactOwnershipTransferQuery) => {
+  return useQuery(getIncomingTransfers(namespace, query));
+};
+
+export const useGetOutgoingTransfers = (namespace: string, query?: ArtifactOwnershipTransferQuery) => {
+  return useQuery(getOutgoingTransfers(namespace, query));
+};
+
+export const useGetTransfer = (namespace: string, id: string) => {
+  return useQuery(getTransfer(namespace, id));
+};
+
+export const useRequestTransfer = (namespace: string) => {
+  const client = useQueryClient();
+
+  return useMutation({
+    mutationFn: (payload: RequestTransferPayload): Promise<ArtifactOwnershipTransfer> => {
+      return request.post(`api/namespaces/${namespace}/artifact-transfers`, {
+        json: payload,
+      }).json<ArtifactOwnershipTransfer>();
+    },
+    onSuccess: async (transfer) => {
+      client.setQueryData(transferKeys.getTransfer(namespace, transfer.id), transfer);
+      await client.invalidateQueries({
+        queryKey: ['namespace', namespace, 'artifact-transfers'],
+      });
+    },
+  });
+};
+
+export const useAcceptTransfer = (namespace: string) => {
+  const client = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string): Promise<ArtifactOwnershipTransfer> => {
+      return request.post(`api/namespaces/${namespace}/artifact-transfers/${id}/accept`).json<ArtifactOwnershipTransfer>();
+    },
+    onSuccess: async (transfer) => {
+      client.setQueryData(transferKeys.getTransfer(namespace, transfer.id), transfer);
+      await client.invalidateQueries({
+        queryKey: ['namespace', namespace, 'artifact-transfers'],
+      });
+    },
+  });
+};
+
+export const useRejectTransfer = (namespace: string) => {
+  const client = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string): Promise<ArtifactOwnershipTransfer> => {
+      return request.post(`api/namespaces/${namespace}/artifact-transfers/${id}/reject`).json<ArtifactOwnershipTransfer>();
+    },
+    onSuccess: async (transfer) => {
+      client.setQueryData(transferKeys.getTransfer(namespace, transfer.id), transfer);
+      await client.invalidateQueries({
+        queryKey: ['namespace', namespace, 'artifact-transfers'],
+      });
+    },
+  });
+};
+
+export const useCancelTransfer = (namespace: string) => {
+  const client = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string): Promise<ArtifactOwnershipTransfer> => {
+      return request.delete(`api/namespaces/${namespace}/artifact-transfers/${id}`).json<ArtifactOwnershipTransfer>();
+    },
+    onSuccess: async (transfer) => {
+      client.setQueryData(transferKeys.getTransfer(namespace, transfer.id), transfer);
+      await client.invalidateQueries({
+        queryKey: ['namespace', namespace, 'artifact-transfers'],
+      });
+    },
+  });
+};

--- a/konfigyr-frontend/src/hooks/transfers/types.ts
+++ b/konfigyr-frontend/src/hooks/transfers/types.ts
@@ -1,0 +1,27 @@
+import type { Pageable } from '@konfigyr/hooks/hateoas/types';
+
+export type TransferState = 'PENDING' | 'ACCEPTED' | 'REJECTED' | 'CANCELLED';
+
+export interface TransferParty {
+  id: string;
+  slug: string;
+}
+
+export interface ArtifactOwnershipTransfer {
+  id: string;
+  groupId: string;
+  from: TransferParty;
+  to: TransferParty;
+  state: TransferState;
+  requestedAt: string | null;
+  resolvedAt: string | null;
+}
+
+export interface ArtifactOwnershipTransferQuery extends Pageable {
+  term?: string;
+}
+
+export interface RequestTransferPayload {
+  groupId: string;
+  fromNamespace: string;
+}

--- a/konfigyr-frontend/src/hooks/types.ts
+++ b/konfigyr-frontend/src/hooks/types.ts
@@ -6,4 +6,5 @@ export type * from './hateoas/types';
 export type * from './kms/types';
 export type * from './memberships/types';
 export type * from './namespace/types';
+export type * from './transfers/types';
 export type * from './vault/types';

--- a/konfigyr-frontend/src/routeTree.gen.ts
+++ b/konfigyr-frontend/src/routeTree.gen.ts
@@ -34,14 +34,18 @@ import { Route as AuthenticatedNamespaceNamespaceApplicationsCreateRouteImport }
 import { Route as AuthenticatedNamespaceNamespaceApplicationsIdRouteImport } from './routes/_authenticated/namespace/$namespace/applications/$id'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceRouteRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/route'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceIndexRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/index'
+import { Route as AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/transfers/index'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/groups/index'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceSettingsRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/settings'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/create-profile'
+import { Route as AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/transfers/create'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/groups/create'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceManifestRouteRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/manifest/route'
+import { Route as AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/route'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/groups/$groupId/route'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceRequestsIndexRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/requests/index'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/manifest/index'
+import { Route as AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/index'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/groups/$groupId/index'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceManifestArtifactsRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/manifest/artifacts'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/groups/$groupId/edit'
@@ -193,6 +197,12 @@ const AuthenticatedNamespaceNamespaceServicesServiceIndexRoute =
     getParentRoute: () =>
       AuthenticatedNamespaceNamespaceServicesServiceRouteRoute,
   } as any)
+const AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute =
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRouteImport.update({
+    id: '/artifactory/transfers/',
+    path: '/artifactory/transfers/',
+    getParentRoute: () => AuthenticatedNamespaceNamespaceRouteRoute,
+  } as any)
 const AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute =
   AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRouteImport.update({
     id: '/artifactory/groups/',
@@ -215,6 +225,12 @@ const AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRoute =
         AuthenticatedNamespaceNamespaceServicesServiceRouteRoute,
     } as any,
   )
+const AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute =
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRouteImport.update({
+    id: '/artifactory/transfers/create',
+    path: '/artifactory/transfers/create',
+    getParentRoute: () => AuthenticatedNamespaceNamespaceRouteRoute,
+  } as any)
 const AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute =
   AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRouteImport.update({
     id: '/artifactory/groups/create',
@@ -228,6 +244,14 @@ const AuthenticatedNamespaceNamespaceServicesServiceManifestRouteRoute =
       path: '/manifest',
       getParentRoute: () =>
         AuthenticatedNamespaceNamespaceServicesServiceRouteRoute,
+    } as any,
+  )
+const AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRoute =
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteImport.update(
+    {
+      id: '/artifactory/transfers/$transferId',
+      path: '/artifactory/transfers/$transferId',
+      getParentRoute: () => AuthenticatedNamespaceNamespaceRouteRoute,
     } as any,
   )
 const AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRoute =
@@ -254,6 +278,15 @@ const AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRoute =
       path: '/',
       getParentRoute: () =>
         AuthenticatedNamespaceNamespaceServicesServiceManifestRouteRoute,
+    } as any,
+  )
+const AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRoute =
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRouteImport.update(
+    {
+      id: '/',
+      path: '/',
+      getParentRoute: () =>
+        AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRoute,
     } as any,
   )
 const AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdIndexRoute =
@@ -345,16 +378,20 @@ export interface FileRoutesByFullPath {
   '/namespace/$namespace/kms/': typeof AuthenticatedNamespaceNamespaceKmsIndexRoute
   '/namespace/$namespace/settings/': typeof AuthenticatedNamespaceNamespaceSettingsIndexRoute
   '/namespace/$namespace/artifactory/groups/$groupId': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRouteWithChildren
+  '/namespace/$namespace/artifactory/transfers/$transferId': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteWithChildren
   '/namespace/$namespace/services/$service/manifest': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestRouteRouteWithChildren
   '/namespace/$namespace/artifactory/groups/create': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute
+  '/namespace/$namespace/artifactory/transfers/create': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute
   '/namespace/$namespace/services/$service/create-profile': typeof AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRoute
   '/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/namespace/$namespace/artifactory/groups/': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
+  '/namespace/$namespace/artifactory/transfers/': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/namespace/$namespace/services/$service/': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
   '/namespace/$namespace/services/$service/profiles/$profile': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRouteWithChildren
   '/namespace/$namespace/artifactory/groups/$groupId/edit': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRoute
   '/namespace/$namespace/services/$service/manifest/artifacts': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestArtifactsRoute
   '/namespace/$namespace/artifactory/groups/$groupId/': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdIndexRoute
+  '/namespace/$namespace/artifactory/transfers/$transferId/': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRoute
   '/namespace/$namespace/services/$service/manifest/': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRoute
   '/namespace/$namespace/services/$service/requests/': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsIndexRoute
   '/namespace/$namespace/services/$service/profiles/$profile/history': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRoute
@@ -382,13 +419,16 @@ export interface FileRoutesByTo {
   '/namespace/$namespace/kms': typeof AuthenticatedNamespaceNamespaceKmsIndexRoute
   '/namespace/$namespace/settings': typeof AuthenticatedNamespaceNamespaceSettingsIndexRoute
   '/namespace/$namespace/artifactory/groups/create': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute
+  '/namespace/$namespace/artifactory/transfers/create': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute
   '/namespace/$namespace/services/$service/create-profile': typeof AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRoute
   '/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/namespace/$namespace/artifactory/groups': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
+  '/namespace/$namespace/artifactory/transfers': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/namespace/$namespace/services/$service': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
   '/namespace/$namespace/artifactory/groups/$groupId/edit': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRoute
   '/namespace/$namespace/services/$service/manifest/artifacts': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestArtifactsRoute
   '/namespace/$namespace/artifactory/groups/$groupId': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdIndexRoute
+  '/namespace/$namespace/artifactory/transfers/$transferId': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRoute
   '/namespace/$namespace/services/$service/manifest': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRoute
   '/namespace/$namespace/services/$service/requests': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsIndexRoute
   '/namespace/$namespace/services/$service/profiles/$profile/history': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRoute
@@ -422,16 +462,20 @@ export interface FileRoutesById {
   '/_authenticated/namespace/$namespace/kms/': typeof AuthenticatedNamespaceNamespaceKmsIndexRoute
   '/_authenticated/namespace/$namespace/settings/': typeof AuthenticatedNamespaceNamespaceSettingsIndexRoute
   '/_authenticated/namespace/$namespace/artifactory/groups/$groupId': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRouteWithChildren
+  '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteWithChildren
   '/_authenticated/namespace/$namespace/services/$service/manifest': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestRouteRouteWithChildren
   '/_authenticated/namespace/$namespace/artifactory/groups/create': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute
+  '/_authenticated/namespace/$namespace/artifactory/transfers/create': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute
   '/_authenticated/namespace/$namespace/services/$service/create-profile': typeof AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRoute
   '/_authenticated/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/_authenticated/namespace/$namespace/artifactory/groups/': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
+  '/_authenticated/namespace/$namespace/artifactory/transfers/': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/profiles/$profile': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRouteWithChildren
   '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/edit': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRoute
   '/_authenticated/namespace/$namespace/services/$service/manifest/artifacts': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestArtifactsRoute
   '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdIndexRoute
+  '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/manifest/': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/requests/': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/profiles/$profile/history': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRoute
@@ -465,16 +509,20 @@ export interface FileRouteTypes {
     | '/namespace/$namespace/kms/'
     | '/namespace/$namespace/settings/'
     | '/namespace/$namespace/artifactory/groups/$groupId'
+    | '/namespace/$namespace/artifactory/transfers/$transferId'
     | '/namespace/$namespace/services/$service/manifest'
     | '/namespace/$namespace/artifactory/groups/create'
+    | '/namespace/$namespace/artifactory/transfers/create'
     | '/namespace/$namespace/services/$service/create-profile'
     | '/namespace/$namespace/services/$service/settings'
     | '/namespace/$namespace/artifactory/groups/'
+    | '/namespace/$namespace/artifactory/transfers/'
     | '/namespace/$namespace/services/$service/'
     | '/namespace/$namespace/services/$service/profiles/$profile'
     | '/namespace/$namespace/artifactory/groups/$groupId/edit'
     | '/namespace/$namespace/services/$service/manifest/artifacts'
     | '/namespace/$namespace/artifactory/groups/$groupId/'
+    | '/namespace/$namespace/artifactory/transfers/$transferId/'
     | '/namespace/$namespace/services/$service/manifest/'
     | '/namespace/$namespace/services/$service/requests/'
     | '/namespace/$namespace/services/$service/profiles/$profile/history'
@@ -502,13 +550,16 @@ export interface FileRouteTypes {
     | '/namespace/$namespace/kms'
     | '/namespace/$namespace/settings'
     | '/namespace/$namespace/artifactory/groups/create'
+    | '/namespace/$namespace/artifactory/transfers/create'
     | '/namespace/$namespace/services/$service/create-profile'
     | '/namespace/$namespace/services/$service/settings'
     | '/namespace/$namespace/artifactory/groups'
+    | '/namespace/$namespace/artifactory/transfers'
     | '/namespace/$namespace/services/$service'
     | '/namespace/$namespace/artifactory/groups/$groupId/edit'
     | '/namespace/$namespace/services/$service/manifest/artifacts'
     | '/namespace/$namespace/artifactory/groups/$groupId'
+    | '/namespace/$namespace/artifactory/transfers/$transferId'
     | '/namespace/$namespace/services/$service/manifest'
     | '/namespace/$namespace/services/$service/requests'
     | '/namespace/$namespace/services/$service/profiles/$profile/history'
@@ -541,16 +592,20 @@ export interface FileRouteTypes {
     | '/_authenticated/namespace/$namespace/kms/'
     | '/_authenticated/namespace/$namespace/settings/'
     | '/_authenticated/namespace/$namespace/artifactory/groups/$groupId'
+    | '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId'
     | '/_authenticated/namespace/$namespace/services/$service/manifest'
     | '/_authenticated/namespace/$namespace/artifactory/groups/create'
+    | '/_authenticated/namespace/$namespace/artifactory/transfers/create'
     | '/_authenticated/namespace/$namespace/services/$service/create-profile'
     | '/_authenticated/namespace/$namespace/services/$service/settings'
     | '/_authenticated/namespace/$namespace/artifactory/groups/'
+    | '/_authenticated/namespace/$namespace/artifactory/transfers/'
     | '/_authenticated/namespace/$namespace/services/$service/'
     | '/_authenticated/namespace/$namespace/services/$service/profiles/$profile'
     | '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/edit'
     | '/_authenticated/namespace/$namespace/services/$service/manifest/artifacts'
     | '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/'
+    | '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/'
     | '/_authenticated/namespace/$namespace/services/$service/manifest/'
     | '/_authenticated/namespace/$namespace/services/$service/requests/'
     | '/_authenticated/namespace/$namespace/services/$service/profiles/$profile/history'
@@ -743,6 +798,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceRouteRoute
     }
+    '/_authenticated/namespace/$namespace/artifactory/transfers/': {
+      id: '/_authenticated/namespace/$namespace/artifactory/transfers/'
+      path: '/artifactory/transfers'
+      fullPath: '/namespace/$namespace/artifactory/transfers/'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceRouteRoute
+    }
     '/_authenticated/namespace/$namespace/artifactory/groups/': {
       id: '/_authenticated/namespace/$namespace/artifactory/groups/'
       path: '/artifactory/groups'
@@ -764,6 +826,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceRouteRoute
     }
+    '/_authenticated/namespace/$namespace/artifactory/transfers/create': {
+      id: '/_authenticated/namespace/$namespace/artifactory/transfers/create'
+      path: '/artifactory/transfers/create'
+      fullPath: '/namespace/$namespace/artifactory/transfers/create'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceRouteRoute
+    }
     '/_authenticated/namespace/$namespace/artifactory/groups/create': {
       id: '/_authenticated/namespace/$namespace/artifactory/groups/create'
       path: '/artifactory/groups/create'
@@ -777,6 +846,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/namespace/$namespace/services/$service/manifest'
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceManifestRouteRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceRouteRoute
+    }
+    '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId': {
+      id: '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId'
+      path: '/artifactory/transfers/$transferId'
+      fullPath: '/namespace/$namespace/artifactory/transfers/$transferId'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceRouteRoute
     }
     '/_authenticated/namespace/$namespace/artifactory/groups/$groupId': {
       id: '/_authenticated/namespace/$namespace/artifactory/groups/$groupId'
@@ -798,6 +874,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/namespace/$namespace/services/$service/manifest/'
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceManifestRouteRoute
+    }
+    '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/': {
+      id: '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/'
+      path: '/'
+      fullPath: '/namespace/$namespace/artifactory/transfers/$transferId/'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRoute
     }
     '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/': {
       id: '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/'
@@ -980,6 +1063,21 @@ const AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRouteWithChild
     AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRouteChildren,
   )
 
+interface AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteChildren {
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRoute
+}
+
+const AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteChildren: AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteChildren =
+  {
+    AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRoute:
+      AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdIndexRoute,
+  }
+
+const AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteWithChildren =
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRoute._addFileChildren(
+    AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteChildren,
+  )
+
 interface AuthenticatedNamespaceNamespaceRouteRouteChildren {
   AuthenticatedNamespaceNamespaceApplicationsRouteRoute: typeof AuthenticatedNamespaceNamespaceApplicationsRouteRouteWithChildren
   AuthenticatedNamespaceNamespaceKmsRouteRoute: typeof AuthenticatedNamespaceNamespaceKmsRouteRouteWithChildren
@@ -990,8 +1088,11 @@ interface AuthenticatedNamespaceNamespaceRouteRouteChildren {
   AuthenticatedNamespaceNamespaceAuditIndexRoute: typeof AuthenticatedNamespaceNamespaceAuditIndexRoute
   AuthenticatedNamespaceNamespaceSettingsIndexRoute: typeof AuthenticatedNamespaceNamespaceSettingsIndexRoute
   AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRouteWithChildren
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteWithChildren
   AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute
   AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
+  AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
 }
 
 const AuthenticatedNamespaceNamespaceRouteRouteChildren: AuthenticatedNamespaceNamespaceRouteRouteChildren =
@@ -1014,10 +1115,16 @@ const AuthenticatedNamespaceNamespaceRouteRouteChildren: AuthenticatedNamespaceN
       AuthenticatedNamespaceNamespaceSettingsIndexRoute,
     AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRoute:
       AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdRouteRouteWithChildren,
+    AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRoute:
+      AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteWithChildren,
     AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute:
       AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute,
+    AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute:
+      AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute,
     AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute:
       AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute,
+    AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute:
+      AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute,
   }
 
 const AuthenticatedNamespaceNamespaceRouteRouteWithChildren =

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/groups/$groupId/edit.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/groups/$groupId/edit.tsx
@@ -48,6 +48,11 @@ function RouteComponent () {
     verificationMethod: challenge?.method ?? 'DNS',
   };
 
+  const onCancel = () => navigate({
+    to: '/namespace/$namespace/artifactory/groups/$groupId',
+    params: { namespace: namespace.slug, groupId },
+  });
+
   const onSubmit = async ({ value }: { value: typeof defaultValues }) => {
     try {
       const updated = await claimGroupVerification(value);
@@ -87,7 +92,7 @@ function RouteComponent () {
         <GroupVerificationForm
           defaultValues={defaultValues}
           onSubmit={onSubmit}
-          onCancel={() => navigate({ to: '/namespace/$namespace/artifactory/groups/$groupId', params: { namespace: namespace.slug, groupId } })}
+          onCancel={onCancel}
         />
       </div>
     </>

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/groups/$groupId/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/groups/$groupId/index.tsx
@@ -1,7 +1,6 @@
-import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { PackageIcon, RotateCcwIcon, ShieldBanIcon, ShieldCheckIcon, XIcon } from 'lucide-react';
-import { Link, createFileRoute } from '@tanstack/react-router';
+import { ShieldCheckIcon } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
 import {
   useGetGroupVerification,
   useGetVerificationChallenges,
@@ -9,21 +8,8 @@ import {
 } from '@konfigyr/hooks';
 import { ErrorState } from '@konfigyr/components/error';
 import { GroupsBreadcrumbs } from '@konfigyr/components/artifactory/groups/breadcrumbs';
-import { ConflictingOwnersAlert, GroupVerificationStateAlert } from '@konfigyr/components/artifactory/groups/group-verification-state';
-import { Button, buttonVariants } from '@konfigyr/components/ui/button';
 import { EmptyState } from '@konfigyr/components/ui/empty';
-import { GroupVerification } from '@konfigyr/components/artifactory/groups/group-verification-challenge';
-import {
-  CancelClaimLabel,
-  ClaimAgainLabel,
-  RevokeClaimLabel,
-  VerifyClaimLabel,
-} from '@konfigyr/components/artifactory/groups/messages';
-import {
-  CancelGroupVerificationButton,
-  RevokeGroupVerificationButton,
-} from '@konfigyr/components/artifactory/groups/revoke-group-verification';
-import { VerifyGroupVerificationButton } from '@konfigyr/components/artifactory/groups/verify-group-verification';
+import { GroupVerificationDetails } from '@konfigyr/components/artifactory/groups/group-verification-details';
 
 export const Route = createFileRoute(
   '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/',
@@ -52,16 +38,6 @@ function RouteComponent () {
   const loading = isVerificationPending || isChallengesPending;
   const error = verificationError || challengesError;
   const isError = isVerificationError || isChallengesError;
-
-  const challenge = useMemo(() => {
-    const items = challenges?.data ?? [];
-    // items already ordered on the backend by createdAt.asc(),
-    return items.at(-1);
-  }, [challenges]);
-
-  const banner = verification
-    ? <GroupVerificationStateAlert groupId={verification.groupId} verificationChallenge={challenge} verificationState={verification.state}/>
-    : null;
 
   return (
     <>
@@ -93,68 +69,11 @@ function RouteComponent () {
         )}
 
         {verification && (
-          <>
-            <div className="flex items-start justify-between gap-4">
-              <div className="flex min-w-0 items-center gap-3">
-                <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border bg-card">
-                  <PackageIcon className="size-5 text-muted-foreground" aria-hidden="true"/>
-                </div>
-                <div className="min-w-0">
-                  <h1 className="truncate font-mono text-2xl font-medium leading-tight">
-                    {verification.groupId}
-                  </h1>
-                </div>
-              </div>
-            </div>
-
-            {banner}
-
-            {!!verification.conflictingOwners?.length && (
-              <ConflictingOwnersAlert conflictingOwners={verification.conflictingOwners}/>
-            )}
-
-            <GroupVerification verification={verification} challenge={challenge}/>
-
-            <div className="flex flex-wrap gap-3">
-              {verification.state === 'ACTIVE' && (
-                <RevokeGroupVerificationButton namespace={namespace.slug} verification={verification} >
-                  <Button variant="destructive">
-                    <ShieldBanIcon />
-                    <RevokeClaimLabel/>
-                  </Button>
-                </RevokeGroupVerificationButton>
-              )}
-
-              {verification.state === 'PENDING' && (
-                <CancelGroupVerificationButton namespace={namespace.slug} verification={verification} >
-                  <Button variant="destructive">
-                    <XIcon/>
-                    <CancelClaimLabel />
-                  </Button>
-                </CancelGroupVerificationButton>
-              )}
-
-              {(verification.state === 'PENDING' || verification.state === 'FAILED') && (
-                <VerifyGroupVerificationButton namespace={namespace.slug} verification={verification}>
-                  <Button>
-                    <RotateCcwIcon/>
-                    <VerifyClaimLabel/>
-                  </Button>
-                </VerifyGroupVerificationButton>
-              )}
-
-              {verification.state === 'REVOKED' && (
-                <Link
-                  to="/namespace/$namespace/artifactory/groups/$groupId/edit"
-                  params={{ namespace: namespace.slug, groupId }}
-                  className={buttonVariants({ variant: 'default' })}
-                >
-                  <RotateCcwIcon/>
-                  <ClaimAgainLabel/>
-                </Link>
-              )}
-            </div>
-          </>
+          <GroupVerificationDetails
+            namespace={namespace}
+            verification={verification}
+            challenges={challenges?.data || []}
+          />
         )}
       </div>
     </>

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/index.tsx
@@ -1,0 +1,57 @@
+import { FormattedMessage } from 'react-intl';
+import { ArrowLeftRightIcon } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
+import { useGetTransfer, useNamespace } from '@konfigyr/hooks';
+import { ErrorState } from '@konfigyr/components/error';
+import { TransfersBreadcrumbs } from '@konfigyr/components/artifactory/transfers/breadcrumbs';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import { TransferDetails } from '@konfigyr/components/artifactory/transfers/transfer-details';
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/',
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent () {
+  const namespace = useNamespace();
+  const { transferId } = Route.useParams();
+
+  const { data: transfer, error, isError, isPending } = useGetTransfer(namespace.slug, transferId);
+
+  return (
+    <>
+      <TransfersBreadcrumbs namespace={namespace}>
+        {transferId}
+      </TransfersBreadcrumbs>
+
+      <div className="mx-auto w-full space-y-6 lg:w-2/3 xl:w-3/5">
+        {isPending && (
+          <EmptyState
+            icon={<ArrowLeftRightIcon/>}
+            title={(
+              <FormattedMessage
+                defaultMessage="Loading ownership transfer"
+                description="Loading state title for an ownership transfer detail page."
+              />
+            )}
+            description={(
+              <FormattedMessage
+                defaultMessage="Fetching the current transfer request."
+                description="Loading state description for an ownership transfer detail page."
+              />
+            )}
+          />
+        )}
+
+        {isError && (
+          <ErrorState error={error} className="border-none"/>
+        )}
+
+        {transfer && (
+          <TransferDetails transfer={transfer} namespace={namespace} />
+        )}
+      </div>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/route.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/$transferId/route.tsx
@@ -1,0 +1,20 @@
+import { Outlet, createFileRoute } from '@tanstack/react-router';
+import { LayoutContent, LayoutNavbar } from '@konfigyr/components/layout';
+import { TransfersLabel } from '@konfigyr/components/artifactory/transfers/messages';
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/transfers/$transferId',
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent () {
+  return (
+    <LayoutContent>
+      <LayoutNavbar title={( <TransfersLabel /> )} />
+      <div className="mx-4 space-y-6">
+        <Outlet />
+      </div>
+    </LayoutContent>
+  );
+}

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/create.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/create.tsx
@@ -1,0 +1,86 @@
+import { z } from 'zod';
+import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { toast } from 'sonner';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useNamespace, useRequestTransfer } from '@konfigyr/hooks';
+import { TransfersBreadcrumbs } from '@konfigyr/components/artifactory/transfers/breadcrumbs';
+import { TransferRequestForm } from '@konfigyr/components/artifactory/transfers/transfer-request-form';
+import { LayoutContent, LayoutNavbar } from '@konfigyr/components/layout';
+import { TransferRequestedSuccessMessage, TransfersLabel } from '@konfigyr/components/artifactory/transfers/messages';
+import type { TransferRequestFormValues } from '@konfigyr/components/artifactory/transfers/transfer-request-form';
+
+const searchQuerySchema = z.object({
+  groupId: z.string().optional().catch(undefined),
+  fromNamespace: z.string().optional().catch(undefined),
+});
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/transfers/create',
+)({
+  validateSearch: searchQuerySchema,
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const namespace = useNamespace();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const search = Route.useSearch();
+  const [error, setError] = useState<unknown>();
+  const { mutateAsync: requestTransfer } = useRequestTransfer(namespace.slug);
+
+  const defaultValues: TransferRequestFormValues = {
+    groupId: search.groupId ?? '',
+    fromNamespace: search.fromNamespace ?? '',
+  };
+
+  const onCancel = async () => navigate({
+    to: '/namespace/$namespace/artifactory/transfers',
+    params: { namespace: namespace.slug },
+  });
+
+  const onSubmit = async ({ value }: { value: typeof defaultValues }) => {
+    setError(undefined);
+
+    let created;
+    try {
+      created = await requestTransfer(value);
+    } catch (err) {
+      setError(err);
+      return;
+    }
+
+    toast.success((
+      <TransferRequestedSuccessMessage groupId={created.groupId}/>
+    ));
+
+    await navigate({
+      to: '/namespace/$namespace/artifactory/transfers/$transferId',
+      params: { namespace: namespace.slug, transferId: created.id },
+    });
+  };
+
+  return (
+    <LayoutContent>
+      <LayoutNavbar title={( <TransfersLabel/> )}/>
+      <div className="mx-4 space-y-6">
+        <TransfersBreadcrumbs namespace={namespace}>
+          <FormattedMessage
+            defaultMessage="Request a transfer"
+            description="Breadcrumb label for the ownership transfer request creation page."
+          />
+        </TransfersBreadcrumbs>
+
+        <div className="lg:w-2/3 xl:w-3/5 px-4 mx-auto">
+          <TransferRequestForm
+            namespace={namespace.slug}
+            defaultValues={defaultValues}
+            onSubmit={onSubmit}
+            onCancel={onCancel}
+            error={error}
+          />
+        </div>
+      </div>
+    </LayoutContent>
+  );
+}

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/index.tsx
@@ -1,0 +1,107 @@
+import { z } from 'zod';
+import { useCallback } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useGetIncomingTransfers, useGetOutgoingTransfers, useNamespace } from '@konfigyr/hooks';
+import { LayoutContent, LayoutNavbar } from '@konfigyr/components/layout';
+import { buttonVariants } from '@konfigyr/components/ui/button';
+import { TransferFilters } from '@konfigyr/components/artifactory/transfers/transfer-filters';
+import { TransferTable } from '@konfigyr/components/artifactory/transfers/transfer-table';
+import { IncomingLabel, OutgoingLabel, RequestTransferLabel, TransfersLabel } from '@konfigyr/components/artifactory/transfers/messages';
+
+import type { ArtifactOwnershipTransferQuery } from '@konfigyr/hooks/types';
+
+const searchQuerySchema = z.object({
+  term: z.string().min(2).optional().catch(undefined),
+  page: z.number().optional().catch(undefined),
+  size: z.number().optional().catch(undefined),
+  direction: z.enum(['incoming', 'outgoing']).optional().catch('incoming'),
+});
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/transfers/',
+)({
+  validateSearch: searchQuerySchema,
+  component: RouteComponent,
+});
+
+function DirectionToggle ({ direction }: { direction: 'incoming' | 'outgoing' }) {
+  return (
+    <div className="flex gap-1">
+      <Link
+        to="."
+        search={search => ({ ...search, direction: 'incoming', page: 1 })}
+        className={buttonVariants({ variant: direction === 'incoming' ? 'secondary' : 'ghost' })}
+      >
+        <IncomingLabel/>
+      </Link>
+      <Link
+        to="."
+        search={search => ({ ...search, direction: 'outgoing', page: 1 })}
+        className={buttonVariants({ variant: direction === 'outgoing' ? 'secondary' : 'ghost' })}
+      >
+        <OutgoingLabel/>
+      </Link>
+    </div>
+  );
+}
+
+function RouteComponent() {
+  const namespace = useNamespace();
+  const search = Route.useSearch();
+  const query: ArtifactOwnershipTransferQuery = search;
+  const direction = search.direction ?? 'incoming';
+  const navigate = useNavigate({ from: Route.fullPath });
+
+  const incoming = useGetIncomingTransfers(namespace.slug, query);
+  const outgoing = useGetOutgoingTransfers(namespace.slug, query);
+  const { data, isPending, error } = direction === 'incoming' ? incoming : outgoing;
+
+  const onQueryChange = useCallback(async (value: ArtifactOwnershipTransferQuery) => {
+    await navigate({
+      search: current => ({ ...current, ...value, page: 1 }),
+      viewTransition: false,
+    });
+  }, []);
+
+  return (
+    <LayoutContent>
+      <LayoutNavbar title={( <TransfersLabel/> )}/>
+      <div className="w-full lg:w-4/5 xl:w-2/3 space-y-6 px-4 mx-auto">
+        <p className="text-sm text-muted-foreground max-w-2xl">
+          <FormattedMessage
+            defaultMessage="Request, accept, reject, or cancel ownership transfers of Maven groupId coordinates between namespaces."
+            description="Description of the ownership transfers page."
+          />
+        </p>
+
+        <DirectionToggle direction={direction}/>
+
+        <div className="flex justify-between items-center gap-4">
+          <TransferFilters
+            query={query}
+            onQueryChange={onQueryChange}
+          />
+
+          <Link
+            to="/namespace/$namespace/artifactory/transfers/create"
+            params={{ namespace: namespace.slug }}
+            className={buttonVariants({ variant: 'default' })}
+          >
+            <RequestTransferLabel/>
+          </Link>
+        </div>
+
+        <TransferTable
+          namespace={namespace.slug}
+          direction={direction}
+          data={data}
+          isPending={isPending}
+          error={error}
+          page={query.page}
+          size={query.size}
+        />
+      </div>
+    </LayoutContent>
+  );
+}

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/provision.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/provision.tsx
@@ -27,7 +27,7 @@ export const Route = createFileRoute('/_authenticated/namespace/provision')({
   preload: false,
 });
 
-export function RouteComponent({ debounceMs = 300 }: { debounceMs?: number } = {}) {
+function RouteComponent() {
   const navigate = useNavigate();
 
   const onNamespaceCreate = useCallback(async (namespace: Namespace) => {
@@ -56,7 +56,7 @@ export function RouteComponent({ debounceMs = 300 }: { debounceMs?: number } = {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <CreateNamespaceForm onCreate={onNamespaceCreate} debounceMs={debounceMs} />
+          <CreateNamespaceForm onCreate={onNamespaceCreate} />
         </CardContent>
       </Card>
     </LayoutContent>

--- a/konfigyr-frontend/test/components/artifactory/groups/group-verification-challenge.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/groups/group-verification-challenge.test.tsx
@@ -1,13 +1,13 @@
 import { afterEach, describe, expect, test } from 'vitest';
 import { cleanup } from '@testing-library/react';
 import { renderWithMessageProvider } from '@konfigyr/test/helpers/messages';
-import { DATE_FORMAT_OPTIONS, GroupVerification } from '@konfigyr/components/artifactory/groups/group-verification-challenge';
+import { DATE_FORMAT_OPTIONS, GroupVerificationChallenge } from '@konfigyr/components/artifactory/groups/group-verification-challenge';
 
 import type { GroupVerification as GroupVerificationType, VerificationChallenge } from '@konfigyr/hooks/types';
 
 const dateFormat = new Intl.DateTimeFormat('en', DATE_FORMAT_OPTIONS );
 
-describe('components | groups | <GroupVerification/>', () => {
+describe('components | groups | <GroupVerificationChallenge/>', () => {
   afterEach(() => cleanup());
 
   test('should render the verification details card', () => {
@@ -32,7 +32,7 @@ describe('components | groups | <GroupVerification/>', () => {
     };
 
     const { getByText } = renderWithMessageProvider(
-      <GroupVerification verification={verification} challenge={challenge} />,
+      <GroupVerificationChallenge verification={verification} challenge={challenge} />,
     );
 
     expect(getByText('Group verification details')).toBeInTheDocument();
@@ -81,7 +81,7 @@ describe('components | groups | <GroupVerification/>', () => {
     };
 
     const { getByText } = renderWithMessageProvider(
-      <GroupVerification verification={verification} challenge={challenge} />,
+      <GroupVerificationChallenge verification={verification} challenge={challenge} />,
     );
 
     expect(getByText('Add a DNS TXT record')).toBeInTheDocument();
@@ -111,7 +111,7 @@ describe('components | groups | <GroupVerification/>', () => {
     };
 
     const { getByText } = renderWithMessageProvider(
-      <GroupVerification verification={verification} challenge={challenge} />,
+      <GroupVerificationChallenge verification={verification} challenge={challenge} />,
     );
 
     expect(getByText('Create a public repository on GitHub')).toBeInTheDocument();
@@ -141,7 +141,7 @@ describe('components | groups | <GroupVerification/>', () => {
     };
 
     const { queryByText } = renderWithMessageProvider(
-      <GroupVerification verification={verification} challenge={challenge} />,
+      <GroupVerificationChallenge verification={verification} challenge={challenge} />,
     );
 
     expect(queryByText('Add a DNS TXT record')).not.toBeInTheDocument();

--- a/konfigyr-frontend/test/components/artifactory/groups/group-verification-details.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/groups/group-verification-details.test.tsx
@@ -1,0 +1,186 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
+import { GroupVerificationDetails } from '@konfigyr/components/artifactory/groups/group-verification-details';
+
+import type { GroupVerification, Namespace, VerificationChallenge } from '@konfigyr/hooks/types';
+
+const revokeGroupVerification = vi.hoisted(() => vi.fn());
+const verifyGroupVerification = vi.hoisted(() => vi.fn());
+const errorNotification = vi.hoisted(() => vi.fn());
+
+vi.mock('@konfigyr/hooks', () => ({
+  useRevokeGroupVerification: () => ({ isPending: false, mutateAsync: revokeGroupVerification }),
+  useVerifyGroupVerification: () => ({ isPending: false, mutateAsync: verifyGroupVerification }),
+}));
+
+vi.mock('@konfigyr/components/error', () => ({
+  useErrorNotification: () => errorNotification,
+}));
+
+const namespace: Namespace = {
+  id: '2',
+  slug: 'konfigyr',
+  name: 'Konfigyr',
+  description: 'Konfigyr namespace',
+};
+
+const activeVerification: GroupVerification = {
+  id: 'verification-active',
+  groupId: 'com.example.group',
+  state: 'ACTIVE',
+  createdAt: '2026-07-07T00:00:00Z',
+  verifiedAt: '2026-07-08T00:00:00Z',
+  revokedAt: null,
+};
+
+const pendingVerification: GroupVerification = {
+  id: 'verification-pending',
+  groupId: 'io.github.acme',
+  state: 'PENDING',
+  createdAt: '2026-07-09T00:00:00Z',
+  verifiedAt: null,
+  revokedAt: null,
+};
+
+const pendingChallenge: VerificationChallenge = {
+  id: 'challenge-pending',
+  verificationId: pendingVerification.id,
+  method: 'SOURCE_CODE',
+  token: 'token-123',
+  state: 'UNVERIFIED',
+  createdAt: '2026-07-09T00:00:00Z',
+  verifiedAt: null,
+  expiresAt: null,
+};
+
+const conflictedVerification: GroupVerification = {
+  id: 'verification-conflicted',
+  groupId: 'com.acme.widgets',
+  state: 'PENDING',
+  createdAt: '2026-07-09T00:00:00Z',
+  verifiedAt: null,
+  revokedAt: null,
+  conflictingOwners: ['ebf'],
+};
+
+const multiConflictedVerification: GroupVerification = {
+  ...conflictedVerification,
+  id: 'verification-multi-conflicted',
+  groupId: 'com.acme.multi',
+  conflictingOwners: ['ebf', 'acme-legacy'],
+};
+
+const failedVerification: GroupVerification = {
+  id: 'verification-failed',
+  groupId: 'com.acme.failed',
+  state: 'FAILED',
+  createdAt: '2026-07-09T00:00:00Z',
+  verifiedAt: null,
+  revokedAt: null,
+};
+
+const revokedVerification: GroupVerification = {
+  id: 'verification-revoked',
+  groupId: 'com.acme.revoked',
+  state: 'REVOKED',
+  createdAt: '2026-07-09T00:00:00Z',
+  verifiedAt: '2026-07-09T00:00:00Z',
+  revokedAt: '2026-07-10T00:00:00Z',
+};
+
+describe('components | groups | <GroupVerificationDetails/>', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('should render an active group claim', () => {
+    const { getByRole, getByText } = renderComponentWithRouter(
+      <GroupVerificationDetails namespace={namespace} verification={activeVerification} challenges={[]}/>,
+    );
+
+    expect(getByRole('heading', { name: 'com.example.group' })).toBeInTheDocument();
+    expect(getByText('Ownership verified')).toBeInTheDocument();
+    expect(getByText('Group verification details')).toBeInTheDocument();
+    expect(getByText('Active')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Revoke claim' })).toBeInTheDocument();
+  });
+
+  test('should render a pending group claim with a source-code challenge', () => {
+    const { getByRole, getByText } = renderComponentWithRouter(
+      <GroupVerificationDetails namespace={namespace} verification={pendingVerification} challenges={[pendingChallenge]}/>,
+    );
+
+    expect(getByRole('heading', { name: 'io.github.acme' })).toBeInTheDocument();
+    expect(getByText('Claim pending')).toBeInTheDocument();
+    expect(getByText('Create the marker repository for io.github.acme on GitHub, then re-check this claim.')).toBeInTheDocument();
+    expect(getByText('Pending')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Cancel claim' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Verify claim' })).toBeInTheDocument();
+  });
+
+  test('should not render a conflict banner when there are no conflicting owners', () => {
+    const { getByText, queryByText } = renderComponentWithRouter(
+      <GroupVerificationDetails namespace={namespace} verification={activeVerification} challenges={[]}/>,
+    );
+
+    expect(getByText('Ownership verified')).toBeInTheDocument();
+    expect(queryByText('Other namespaces already own artifacts here')).not.toBeInTheDocument();
+  });
+
+  test('should surface conflicting owners', () => {
+    const { getAllByRole, getByText } = renderComponentWithRouter(
+      <GroupVerificationDetails namespace={namespace} verification={conflictedVerification} challenges={[]}/>,
+    );
+
+    expect(getByText('Other namespaces already own artifacts here')).toBeInTheDocument();
+    expect(getByText(
+      'Namespace ebf already publishes artifacts under this groupId. You may need to request an ownership transfer before you can publish.',
+    )).toBeInTheDocument();
+    expect(getAllByRole('alert')).toHaveLength(2);
+  });
+
+  test('should link to a pre-filled transfer request when there is a single conflicting owner', () => {
+    const { getByRole } = renderComponentWithRouter(
+      <GroupVerificationDetails namespace={namespace} verification={conflictedVerification} challenges={[]}/>,
+    );
+
+    expect(getByRole('link', { name: 'Request transfer' })).toHaveAttribute(
+      'href',
+      '/namespace/konfigyr/artifactory/transfers/create?groupId=com.acme.widgets&fromNamespace=ebf',
+    );
+  });
+
+  test('should link to a transfer request without a pre-filled namespace when there are multiple conflicting owners', () => {
+    const { getByRole } = renderComponentWithRouter(
+      <GroupVerificationDetails namespace={namespace} verification={multiConflictedVerification} challenges={[]}/>,
+    );
+
+    expect(getByRole('link', { name: 'Request transfer' })).toHaveAttribute(
+      'href',
+      '/namespace/konfigyr/artifactory/transfers/create?groupId=com.acme.multi',
+    );
+  });
+
+  test('should only show Verify claim for a failed group claim', () => {
+    const { getByRole, queryByRole } = renderComponentWithRouter(
+      <GroupVerificationDetails namespace={namespace} verification={failedVerification} challenges={[]}/>,
+    );
+
+    expect(getByRole('button', { name: 'Verify claim' })).toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Revoke claim' })).not.toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Cancel claim' })).not.toBeInTheDocument();
+  });
+
+  test('should only show Claim again for a revoked group claim', () => {
+    const { getByRole, queryByRole } = renderComponentWithRouter(
+      <GroupVerificationDetails namespace={namespace} verification={revokedVerification} challenges={[]}/>,
+    );
+
+    expect(getByRole('link', { name: 'Claim again' })).toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Revoke claim' })).not.toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Cancel claim' })).not.toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Verify claim' })).not.toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/groups/group-verification-state.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/groups/group-verification-state.test.tsx
@@ -196,4 +196,24 @@ describe('components | groups | <ConflictingOwnersAlert/>', () => {
       'Namespaces ebf, acme-legacy already publish artifacts under this groupId. You may need to request an ownership transfer before you can publish.',
     );
   });
+
+  test('should render the action slot when provided', () => {
+    const { getByRole } = renderWithMessageProvider(
+      <ConflictingOwnersAlert
+        conflictingOwners={['ebf']}
+        action={<button type="button">Request transfer</button>}
+      />,
+    );
+
+    expect(getByRole('alert')).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Request transfer' })).toBeInTheDocument();
+  });
+
+  test('should render nothing in the action slot by default', () => {
+    const { queryByRole } = renderWithMessageProvider(
+      <ConflictingOwnersAlert conflictingOwners={['ebf']} />,
+    );
+
+    expect(queryByRole('button')).not.toBeInTheDocument();
+  });
 });

--- a/konfigyr-frontend/test/components/artifactory/transfers/transfer-actions.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/transfers/transfer-actions.test.tsx
@@ -1,0 +1,210 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import userEvents from '@testing-library/user-event';
+import { renderWithQueryClient } from '@konfigyr/test/helpers/query-client';
+import {
+  AcceptTransferButton,
+  CancelTransferButton,
+  RejectTransferButton,
+} from '@konfigyr/components/artifactory/transfers/transfer-actions';
+import {
+  TransferAcceptedSuccessMessage,
+  TransferCanceledSuccessMessage,
+  TransferRejectedSuccessMessage,
+} from '@konfigyr/components/artifactory/transfers/messages';
+
+import type { ArtifactOwnershipTransfer } from '@konfigyr/hooks/types';
+
+const toast = vi.hoisted(() => ({ success: vi.fn() }));
+
+const acceptTransfer = vi.hoisted(() => vi.fn());
+const rejectTransfer = vi.hoisted(() => vi.fn());
+const cancelTransfer = vi.hoisted(() => vi.fn());
+const errorNotification = vi.hoisted(() => vi.fn());
+
+vi.mock('sonner', () => ({ toast }));
+vi.mock('@konfigyr/hooks', () => ({
+  useAcceptTransfer: () => ({ isPending: false, mutateAsync: acceptTransfer }),
+  useRejectTransfer: () => ({ isPending: false, mutateAsync: rejectTransfer }),
+  useCancelTransfer: () => ({ isPending: false, mutateAsync: cancelTransfer }),
+}));
+
+vi.mock('@konfigyr/components/error', () => ({
+  useErrorNotification: () => errorNotification,
+}));
+
+describe('components | transfers | <AcceptTransferButton/>', () => {
+  const transfer: ArtifactOwnershipTransfer = {
+    id: 'transfer-1',
+    groupId: 'com.example.group',
+    from: { id: '1', slug: 'konfigyr' },
+    to: { id: '2', slug: 'ebf' },
+    state: 'PENDING',
+    requestedAt: '2026-07-10T00:00:00Z',
+    resolvedAt: null,
+  };
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('should open the accept confirmation dialog', async () => {
+    const user = userEvents.setup();
+
+    const { getByRole } = renderWithQueryClient((
+      <AcceptTransferButton namespace="ebf" transfer={transfer}>
+        <button type="button">Accept transfer</button>
+      </AcceptTransferButton>
+    ));
+
+    await user.click(getByRole('button', { name: 'Accept transfer' }));
+
+    const dialog = await waitFor(() => getByRole('alertdialog'));
+
+    expect(dialog).toHaveAccessibleName('Accept ownership transfer');
+    expect(dialog).toHaveAccessibleDescription(
+      'Are you sure you want to transfer ownership of com.example.group to ebf?',
+    );
+  });
+
+  test('should submit the accept action successfully', async () => {
+    acceptTransfer.mockResolvedValueOnce(undefined);
+
+    const user = userEvents.setup();
+
+    const { getByRole } = renderWithQueryClient((
+      <AcceptTransferButton namespace="konfigyr" transfer={transfer}>
+        <button type="button">Accept transfer</button>
+      </AcceptTransferButton>
+    ));
+
+    await user.click(getByRole('button', { name: 'Accept transfer' }));
+
+    const submitButton = await waitFor(() => getByRole('button', { name: 'Accept' }));
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(acceptTransfer).toHaveBeenCalledExactlyOnceWith(transfer.id);
+      expect(toast.success).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          type: TransferAcceptedSuccessMessage,
+          props: expect.objectContaining({ groupId: transfer.groupId }),
+        }),
+      );
+    });
+  });
+
+  test('should report a forbidden error clearly', async () => {
+    const error = new Error('Only the \'konfigyr\' namespace may accept this transfer');
+    acceptTransfer.mockRejectedValueOnce(error);
+
+    const user = userEvents.setup();
+
+    const { getByRole } = renderWithQueryClient((
+      <AcceptTransferButton namespace="ebf" transfer={transfer}>
+        <button type="button">Accept transfer</button>
+      </AcceptTransferButton>
+    ));
+
+    await user.click(getByRole('button', { name: 'Accept transfer' }));
+
+    const submitButton = await waitFor(() => getByRole('button', { name: 'Accept' }));
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(acceptTransfer).toHaveBeenCalledExactlyOnceWith(transfer.id);
+      expect(errorNotification).toHaveBeenCalledExactlyOnceWith(error);
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});
+
+describe('components | transfers | <RejectTransferButton/>', () => {
+  const transfer: ArtifactOwnershipTransfer = {
+    id: 'transfer-1',
+    groupId: 'com.example.group',
+    from: { id: '1', slug: 'konfigyr' },
+    to: { id: '2', slug: 'ebf' },
+    state: 'PENDING',
+    requestedAt: '2026-07-10T00:00:00Z',
+    resolvedAt: null,
+  };
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('should submit the reject action successfully', async () => {
+    rejectTransfer.mockResolvedValueOnce(undefined);
+
+    const user = userEvents.setup();
+
+    const { getByRole } = renderWithQueryClient((
+      <RejectTransferButton namespace="konfigyr" transfer={transfer}>
+        <button type="button">Reject transfer</button>
+      </RejectTransferButton>
+    ));
+
+    await user.click(getByRole('button', { name: 'Reject transfer' }));
+
+    const submitButton = await waitFor(() => getByRole('button', { name: 'Reject' }));
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(rejectTransfer).toHaveBeenCalledExactlyOnceWith(transfer.id);
+      expect(toast.success).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          type: TransferRejectedSuccessMessage,
+          props: expect.objectContaining({ groupId: transfer.groupId }),
+        }),
+      );
+    });
+  });
+});
+
+describe('components | transfers | <CancelTransferButton/>', () => {
+  const transfer: ArtifactOwnershipTransfer = {
+    id: 'transfer-1',
+    groupId: 'com.example.group',
+    from: { id: '1', slug: 'konfigyr' },
+    to: { id: '2', slug: 'ebf' },
+    state: 'PENDING',
+    requestedAt: '2026-07-10T00:00:00Z',
+    resolvedAt: null,
+  };
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('should submit the cancel action successfully', async () => {
+    cancelTransfer.mockResolvedValueOnce(undefined);
+
+    const user = userEvents.setup();
+
+    const { getByRole } = renderWithQueryClient((
+      <CancelTransferButton namespace="ebf" transfer={transfer}>
+        <button type="button">Cancel transfer</button>
+      </CancelTransferButton>
+    ));
+
+    await user.click(getByRole('button', { name: 'Cancel transfer' }));
+
+    const submitButton = await waitFor(() => getByRole('button', { name: 'Cancel request' }));
+    await user.click(submitButton);
+
+    await waitFor(() => {
+      expect(cancelTransfer).toHaveBeenCalledExactlyOnceWith(transfer.id);
+      expect(toast.success).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          type: TransferCanceledSuccessMessage,
+          props: expect.objectContaining({ groupId: transfer.groupId }),
+        }),
+      );
+    });
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/transfers/transfer-details.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/transfers/transfer-details.test.tsx
@@ -1,0 +1,137 @@
+import { afterEach,beforeEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import { renderWithQueryClient } from '@konfigyr/test/helpers/query-client';
+import { TransferDetails } from '@konfigyr/components/artifactory/transfers/transfer-details';
+
+import type { ArtifactOwnershipTransfer, AuditRecord, CursorResponse, Namespace } from '@konfigyr/hooks/types';
+
+const acceptTransfer = vi.hoisted(() => vi.fn());
+const rejectTransfer = vi.hoisted(() => vi.fn());
+const cancelTransfer = vi.hoisted(() => vi.fn());
+const errorNotification = vi.hoisted(() => vi.fn());
+const useGetAuditRecords = vi.hoisted(() => vi.fn());
+
+vi.mock('@konfigyr/hooks', () => ({
+  useAcceptTransfer: () => ({ isPending: false, mutateAsync: acceptTransfer }),
+  useRejectTransfer: () => ({ isPending: false, mutateAsync: rejectTransfer }),
+  useCancelTransfer: () => ({ isPending: false, mutateAsync: cancelTransfer }),
+  useGetAuditRecords,
+}));
+
+vi.mock('@konfigyr/components/error', () => ({
+  useErrorNotification: () => errorNotification,
+  ErrorState: () => null,
+}));
+
+const namespace: Namespace = {
+  id: '2',
+  slug: 'konfigyr',
+  name: 'Konfigyr',
+  description: 'Konfigyr namespace',
+};
+
+const baseTransfer: ArtifactOwnershipTransfer = {
+  id: 'transfer-1',
+  groupId: 'com.example.group',
+  from: { id: '1', slug: namespace.slug },
+  to: { id: '2', slug: 'ebf' },
+  state: 'PENDING',
+  requestedAt: '2026-07-10T00:00:00Z',
+  resolvedAt: null,
+};
+
+const emptyAuditRecords: CursorResponse<AuditRecord> = { data: [], metadata: { size: 20 } };
+
+describe('components | transfers | <TransferDetails/>', () => {
+  beforeEach(() => {
+    useGetAuditRecords.mockReturnValue({ data: emptyAuditRecords, error: null, isPending: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('should show Accept/Reject and not Cancel when this namespace is the from party', () => {
+    const transfer: ArtifactOwnershipTransfer = { ...baseTransfer, from: { id: '1', slug: namespace.slug }, to: { id: '2', slug: 'ebf' } };
+
+    const { getByRole, queryByRole } = renderWithQueryClient(
+      <TransferDetails namespace={namespace} transfer={transfer}/>,
+    );
+
+    expect(getByRole('button', { name: 'Accept' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Reject' })).toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Cancel request' })).not.toBeInTheDocument();
+  });
+
+  test('should show Cancel and not Accept/Reject when this namespace is the to party', () => {
+    const transfer: ArtifactOwnershipTransfer = { ...baseTransfer, from: { id: '1', slug: 'ebf' }, to: { id: '2', slug: namespace.slug } };
+
+    const { getByRole, queryByRole } = renderWithQueryClient(
+      <TransferDetails namespace={namespace} transfer={transfer}/>,
+    );
+
+    expect(getByRole('button', { name: 'Cancel request' })).toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Reject' })).not.toBeInTheDocument();
+  });
+
+  test('should not show any actions for a resolved transfer', () => {
+    const transfer: ArtifactOwnershipTransfer = {
+      ...baseTransfer,
+      state: 'ACCEPTED',
+      resolvedAt: '2026-07-11T00:00:00Z',
+    };
+
+    const { queryByRole } = renderWithQueryClient(
+      <TransferDetails namespace={namespace} transfer={transfer}/>,
+    );
+
+    expect(queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Reject' })).not.toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Cancel request' })).not.toBeInTheDocument();
+  });
+
+  test('should not show any actions when this namespace is neither party', () => {
+    const transfer: ArtifactOwnershipTransfer = {
+      ...baseTransfer,
+      from: { id: '1', slug: 'ebf' },
+      to: { id: '2', slug: 'other-namespace' },
+    };
+
+    const { queryByRole } = renderWithQueryClient(
+      <TransferDetails namespace={namespace} transfer={transfer}/>,
+    );
+
+    expect(queryByRole('button', { name: 'Accept' })).not.toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Reject' })).not.toBeInTheDocument();
+    expect(queryByRole('button', { name: 'Cancel request' })).not.toBeInTheDocument();
+  });
+
+  test('should show the audit trail scoped to this transfer', async () => {
+    const records: CursorResponse<AuditRecord> = {
+      data: [{
+        id: 'transfer-requested-audit-record',
+        entityType: 'artifact-ownership-transfer',
+        entityId: baseTransfer.id,
+        eventType: 'artifact-ownership-transfer.requested',
+        message: 'Ownership transfer for com.example.group was requested from ebf',
+        actor: { id: 'john-doe', type: 'USER_ACCOUNT', name: 'John Doe' },
+        createdAt: '2026-07-10T00:00:00Z',
+      }],
+      metadata: { size: 20 },
+    };
+
+    useGetAuditRecords.mockReturnValue({ data: records, error: null, isPending: false });
+
+    const { getByRole, getByText } = renderWithQueryClient(
+      <TransferDetails namespace={namespace} transfer={baseTransfer}/>,
+    );
+
+    await waitFor(() => {
+      expect(getByRole('heading', { name: 'History' })).toBeInTheDocument();
+      expect(getByText('Ownership transfer for com.example.group was requested from ebf')).toBeInTheDocument();
+      expect(getByText(/John Doe/)).toBeInTheDocument();
+    });
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/transfers/transfer-request-form.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/transfers/transfer-request-form.test.tsx
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
+import { TransferRequestForm } from '@konfigyr/components/artifactory/transfers/transfer-request-form';
+
+import type { GroupVerification, PageResponse } from '@konfigyr/hooks/types';
+
+const useGetGroupVerifications = vi.hoisted(() => vi.fn());
+const getGroupVerification = vi.hoisted(() => vi.fn());
+
+vi.mock('@konfigyr/hooks', () => ({
+  useGetGroupVerifications,
+  getGroupVerification,
+}));
+
+const activeVerifications: PageResponse<GroupVerification> = {
+  data: [
+    {
+      id: 'verification-1',
+      groupId: 'com.example.group',
+      state: 'ACTIVE',
+      createdAt: '2026-07-01T00:00:00Z',
+      verifiedAt: '2026-07-02T00:00:00Z',
+      revokedAt: null,
+    },
+    {
+      id: 'verification-2',
+      groupId: 'com.acme.transfer-ready',
+      state: 'ACTIVE',
+      createdAt: '2026-07-01T00:00:00Z',
+      verifiedAt: '2026-07-02T00:00:00Z',
+      revokedAt: null,
+      conflictingOwners: ['ebf'],
+    },
+  ],
+  metadata: { number: 1, size: 20, total: 2, pages: 1 },
+};
+
+const defaultValues = { groupId: '', fromNamespace: '' };
+
+describe('components | transfers | <TransferRequestForm/>', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  function setup () {
+    useGetGroupVerifications.mockReturnValue({ data: activeVerifications, isPending: false });
+    getGroupVerification.mockImplementation((_namespace: string, groupId: string) => ({
+      queryKey: ['test-group-verification', groupId],
+      queryFn: () => activeVerifications.data.find(verification => verification.groupId === groupId),
+    }));
+  }
+
+  test('should show a hint before a groupId is chosen', () => {
+    setup();
+
+    const { getByRole, getByText } = renderComponentWithRouter(
+      <TransferRequestForm namespace="konfigyr" defaultValues={defaultValues} onSubmit={vi.fn()} onCancel={vi.fn()}/>,
+    );
+
+    expect(getByRole('combobox', { name: 'Group Id' })).toBeInTheDocument();
+    expect(getByText('Select a groupId first.')).toBeInTheDocument();
+  });
+
+  test('should only list active group claims in the combobox', async () => {
+    setup();
+
+    const user = userEvent.setup();
+    const { getByRole } = renderComponentWithRouter(
+      <TransferRequestForm namespace="konfigyr" defaultValues={defaultValues} onSubmit={vi.fn()} onCancel={vi.fn()}/>,
+    );
+
+    await user.click(getByRole('combobox', { name: 'Group Id' }));
+
+    await waitFor(() => {
+      expect(getByRole('option', { name: 'com.example.group' })).toBeInTheDocument();
+      expect(getByRole('option', { name: 'com.acme.transfer-ready' })).toBeInTheDocument();
+    });
+  });
+
+  test('should populate from-namespace radio options once a groupId is selected', async () => {
+    setup();
+
+    const user = userEvent.setup();
+    const { getByRole } = renderComponentWithRouter(
+      <TransferRequestForm namespace="konfigyr" defaultValues={defaultValues} onSubmit={vi.fn()} onCancel={vi.fn()}/>,
+    );
+
+    await user.click(getByRole('combobox', { name: 'Group Id' }));
+    await user.click(await waitFor(() => getByRole('option', { name: 'com.acme.transfer-ready' })));
+
+    await waitFor(() => {
+      expect(getByRole('radio', { name: 'ebf' })).toBeInTheDocument();
+    });
+  });
+
+  test('should show an empty state when the selected groupId has no known owners', async () => {
+    setup();
+
+    const user = userEvent.setup();
+    const { getByRole, getByText } = renderComponentWithRouter(
+      <TransferRequestForm namespace="konfigyr" defaultValues={defaultValues} onSubmit={vi.fn()} onCancel={vi.fn()}/>,
+    );
+
+    await user.click(getByRole('combobox', { name: 'Group Id' }));
+    await user.click(await waitFor(() => getByRole('option', { name: 'com.example.group' })));
+
+    await waitFor(() => {
+      expect(getByText('No known namespaces own artifacts under this groupId yet.')).toBeInTheDocument();
+    });
+  });
+
+  test('should reset the from-namespace choice when the groupId changes', async () => {
+    setup();
+
+    const user = userEvent.setup();
+    const { getByRole, getByText, queryByRole } = renderComponentWithRouter(
+      <TransferRequestForm namespace="konfigyr" defaultValues={defaultValues} onSubmit={vi.fn()} onCancel={vi.fn()}/>,
+    );
+
+    await user.click(getByRole('combobox', { name: 'Group Id' }));
+    await user.click(await waitFor(() => getByRole('option', { name: 'com.acme.transfer-ready' })));
+    await user.click(await waitFor(() => getByRole('radio', { name: 'ebf' })));
+
+    await user.click(getByRole('combobox', { name: 'Group Id' }));
+    await user.click(await waitFor(() => getByRole('option', { name: 'com.example.group' })));
+
+    await waitFor(() => {
+      expect(getByRole('combobox', { name: 'Group Id' })).toHaveValue('com.example.group');
+      expect(getByText('No known namespaces own artifacts under this groupId yet.')).toBeInTheDocument();
+    });
+
+    expect(queryByRole('radio', { name: 'ebf' })).not.toBeInTheDocument();
+  });
+
+  test('should show a link to claim a groupId when there are no active claims', async () => {
+    useGetGroupVerifications.mockReturnValue({
+      data: { data: [], metadata: { number: 1, size: 20, total: 0, pages: 0 } },
+      isPending: false,
+    });
+    getGroupVerification.mockImplementation((_namespace: string, groupId: string) => ({
+      queryKey: ['test-group-verification', groupId],
+      queryFn: () => undefined,
+    }));
+
+    const user = userEvent.setup();
+    const { getByRole } = renderComponentWithRouter(
+      <TransferRequestForm namespace="konfigyr" defaultValues={defaultValues} onSubmit={vi.fn()} onCancel={vi.fn()}/>,
+    );
+
+    await user.click(getByRole('combobox', { name: 'Group Id' }));
+
+    await waitFor(() => {
+      expect(getByRole('link', { name: 'Claim a groupId' })).toBeInTheDocument();
+    });
+
+    expect(getByRole('link', { name: 'Claim a groupId' })).toHaveAttribute('href', '/namespace/konfigyr/artifactory/groups/create');
+  });
+
+  test('should submit the selected groupId and fromNamespace', async () => {
+    setup();
+
+    const onSubmit = vi.fn();
+    const user = userEvent.setup();
+    const { getByRole } = renderComponentWithRouter(
+      <TransferRequestForm namespace="konfigyr" defaultValues={defaultValues} onSubmit={onSubmit} onCancel={vi.fn()}/>,
+    );
+
+    await user.click(getByRole('combobox', { name: 'Group Id' }));
+    await user.click(await waitFor(() => getByRole('option', { name: 'com.acme.transfer-ready' })));
+    await user.click(await waitFor(() => getByRole('radio', { name: 'ebf' })));
+
+    await user.click(getByRole('button', { name: 'Request transfer' }));
+
+    await waitFor(() => {
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        value: { groupId: 'com.acme.transfer-ready', fromNamespace: 'ebf' },
+      }));
+    });
+  });
+
+  test('should render the passed-in error inline', () => {
+    setup();
+
+    const { getByText } = renderComponentWithRouter(
+      <TransferRequestForm
+        namespace="konfigyr"
+        defaultValues={defaultValues}
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+        error={{ title: 'Bad request', detail: 'GroupId \'unverified.group\' is not verified for publishing' }}
+      />,
+    );
+
+    expect(getByText('GroupId \'unverified.group\' is not verified for publishing')).toBeInTheDocument();
+  });
+
+  test('should call onCancel when the cancel button is clicked', async () => {
+    setup();
+
+    const onCancel = vi.fn();
+    const user = userEvent.setup();
+    const { getByRole } = renderComponentWithRouter(
+      <TransferRequestForm namespace="konfigyr" defaultValues={defaultValues} onSubmit={vi.fn()} onCancel={onCancel}/>,
+    );
+
+    await user.click(getByRole('button', { name: 'Cancel' }));
+
+    expect(onCancel).toHaveBeenCalledOnce();
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/transfers/transfer-state-badge.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/transfers/transfer-state-badge.test.tsx
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { renderWithMessageProvider } from '@konfigyr/test/helpers/messages';
+import { TransferStateBadge, TransferStateLabel } from '@konfigyr/components/artifactory/transfers/transfer-state-badge';
+
+describe('components | transfers | <TransferStateLabel/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render a label for a pending transfer', () => {
+    const { getByText } = renderWithMessageProvider(
+      <TransferStateLabel state="PENDING" />,
+    );
+
+    expect(getByText('Pending')).toBeInTheDocument();
+  });
+
+  test('should render a label for an accepted transfer', () => {
+    const { getByText } = renderWithMessageProvider(
+      <TransferStateLabel state="ACCEPTED" />,
+    );
+
+    expect(getByText('Accepted')).toBeInTheDocument();
+  });
+
+  test('should render a label for a rejected transfer', () => {
+    const { getByText } = renderWithMessageProvider(
+      <TransferStateLabel state="REJECTED" />,
+    );
+
+    expect(getByText('Rejected')).toBeInTheDocument();
+  });
+
+  test('should render a label for a cancelled transfer', () => {
+    const { getByText } = renderWithMessageProvider(
+      <TransferStateLabel state="CANCELLED" />,
+    );
+
+    expect(getByText('Cancelled')).toBeInTheDocument();
+  });
+
+  test('should render nothing for an unknown state', () => {
+    const { container } = renderWithMessageProvider(
+      <TransferStateLabel state="UNKNOWN" />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe('components | transfers | <TransferStateBadge/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render a pending transfer badge', () => {
+    const { getByText } = renderWithMessageProvider(
+      <TransferStateBadge state="PENDING" data-testid="badge" />,
+    );
+
+    expect(getByText('Pending')).toBeInTheDocument();
+    expect(getByText('Pending').closest('[data-testid="badge"]')).toHaveClass('bg-warning/10');
+  });
+
+  test('should render an accepted transfer badge', () => {
+    const { getByText } = renderWithMessageProvider(
+      <TransferStateBadge state="ACCEPTED" data-testid="badge" />,
+    );
+
+    expect(getByText('Accepted')).toBeInTheDocument();
+    expect(getByText('Accepted').closest('[data-testid="badge"]')).toHaveClass('bg-success/10');
+  });
+
+  test('should render a rejected transfer badge', () => {
+    const { getByText } = renderWithMessageProvider(
+      <TransferStateBadge state="REJECTED" data-testid="badge" />,
+    );
+
+    expect(getByText('Rejected')).toBeInTheDocument();
+    expect(getByText('Rejected').closest('[data-testid="badge"]')).toHaveClass('bg-destructive/10');
+  });
+
+  test('should render a cancelled transfer badge', () => {
+    const { getByText } = renderWithMessageProvider(
+      <TransferStateBadge state="CANCELLED" data-testid="badge" />,
+    );
+
+    expect(getByText('Cancelled')).toBeInTheDocument();
+    expect(getByText('Cancelled').closest('[data-testid="badge"]')).toHaveClass('bg-secondary');
+  });
+
+  test('should render nothing for an unknown state', () => {
+    const { queryByTestId } = renderWithMessageProvider(
+      <TransferStateBadge state="UNKNOWN" data-testid="badge" />,
+    );
+
+    expect(queryByTestId('badge')).not.toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/namespace/namespace-form.test.tsx
+++ b/konfigyr-frontend/test/components/namespace/namespace-form.test.tsx
@@ -1,0 +1,117 @@
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import userEvents from '@testing-library/user-event';
+import { renderWithQueryClient } from '@konfigyr/test/helpers/query-client';
+import { CreateNamespaceForm } from '@konfigyr/components/namespace/form/create';
+
+import type { RenderResult } from '@testing-library/react';
+import type { UserEvent } from '@testing-library/user-event';
+
+describe('components | namespace | <CreateNamespaceForm/>', () => {
+  let result: RenderResult;
+  let user: UserEvent;
+  const onCreate = vi.fn();
+
+  beforeAll(() => {
+    user = userEvents.setup();
+    result = renderWithQueryClient(
+      <CreateNamespaceForm onCreate={onCreate} debounceMs={0} />,
+    );
+  });
+
+  afterAll(() => cleanup());
+
+  test('should render the namespace form fields', async () => {
+    await waitFor(() => {
+      expect(result.getByRole('textbox', { name: 'Name' }))
+        .toBeInTheDocument();
+
+      expect(result.getByRole('textbox', { name: 'URL' }))
+        .toBeInTheDocument();
+
+      expect(result.getByRole('textbox', { name: 'Description' }))
+        .toBeInTheDocument();
+    });
+  });
+
+  test('should validate initial form data', async () => {
+    await user.click(
+      result.getByRole('button', { name: 'Create namespace' }),
+    );
+
+    expect(result.getByRole('button', { name: 'Create namespace' }))
+      .toBeDisabled();
+
+    expect(result.getByRole('textbox', { name: 'Name' }))
+      .toBeInvalid();
+
+    expect(result.getByRole('textbox', { name: 'URL' }))
+      .toBeInvalid();
+  });
+
+  test('should connect name with URL slug input field', async () => {
+    await user.type(
+      result.getByRole('textbox', { name: 'Name' }),
+      'some Namespace name',
+    );
+
+    expect(result.getByRole('textbox', { name: 'URL' })).toHaveValue('some-namespace-name');
+  });
+
+  test('should disconnect name when URL slug input field is made dirty and invalid', async () => {
+    await user.clear(
+      result.getByRole('textbox', { name: 'URL' }),
+    );
+
+    await user.type(
+      result.getByRole('textbox', { name: 'URL' }),
+      'updated-namespace-slug',
+    );
+
+    await user.clear(
+      result.getByRole('textbox', { name: 'Name' }),
+    );
+
+    await user.type(
+      result.getByRole('textbox', { name: 'Name' }),
+      'Namespace name',
+    );
+
+    expect(result.getByRole('textbox', { name: 'URL' }))
+      .toHaveValue('updated-namespace-slug');
+
+    await waitFor(() => {
+      expect(result.getByRole('textbox', { name: 'URL' })).toBeInvalid();
+    });
+  });
+
+  test('should validate URL slug availability', async () => {
+    await user.clear(
+      result.getByRole('textbox', { name: 'URL' }),
+    );
+
+    await user.type(
+      result.getByRole('textbox', { name: 'URL' }),
+      'available-namespace',
+    );
+
+    await waitFor(() => {
+      expect(result.getByRole('textbox', { name: 'URL' })).toBeValid();
+    });
+
+    expect(result.getByRole('textbox', { name: 'URL' }))
+      .toHaveValue('available-namespace');
+  });
+
+  test('should submit the form and invoke onCreate with the created namespace', async () => {
+    await user.click(
+      result.getByRole('button', { name: 'Create namespace' }),
+    );
+
+    await waitFor(() => {
+      expect(onCreate).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ slug: 'available-namespace' }),
+      );
+    });
+  });
+});

--- a/konfigyr-frontend/test/helpers/server.ts
+++ b/konfigyr-frontend/test/helpers/server.ts
@@ -7,6 +7,7 @@ import namespaces from './server/namespaces';
 import applications from './server/namespace/applications';
 import groups from './server/namespace/groups';
 import invitations from './server/namespace/invitations';
+import transfers from './server/namespace/transfers';
 import audit from './server/audit';
 import oidc from './server/oidc';
 import proxy from './server/proxy';
@@ -22,6 +23,7 @@ export const handlers = [
   ...applications,
   ...groups,
   ...invitations,
+  ...transfers,
   ...audit,
   ...oidc,
   ...proxy,

--- a/konfigyr-frontend/test/helpers/server/audit.ts
+++ b/konfigyr-frontend/test/helpers/server/audit.ts
@@ -4,7 +4,57 @@ import * as namespaces from '../mocks/namespace';
 
 import type { AuditRecord, CursorResponse } from '@konfigyr/hooks/types';
 
-const search = http.get('http://localhost/api/namespaces/:slug/audit', ({ params }) => {
+const allRecords: Array<AuditRecord> = [{
+  id: 'fourth-audit-record',
+  entityType: 'keyset',
+  entityId: 'kms-keyset',
+  eventType: 'keyset.created',
+  message: 'Keyset was created',
+  actor: {
+    id: janeDoe.id,
+    type: 'USER_ACCOUNT',
+    name: janeDoe.fullName ?? janeDoe.email,
+  },
+  createdAt: '2026-04-28T20:51:56.341973+02:00',
+}, {
+  id: 'third-audit-record',
+  entityType: 'profile',
+  entityId: 'development',
+  eventType: 'profile.created',
+  message: 'Profile was created',
+  actor: {
+    id: johnDoe.id,
+    type: 'USER_ACCOUNT',
+    name: johnDoe.fullName ?? johnDoe.email,
+  },
+  createdAt: '2026-04-28T20:51:56.341973+02:00',
+}, {
+  id: 'second-audit-record',
+  entityType: 'service',
+  entityId: 'konfgyr-api',
+  eventType: 'service.created',
+  message: 'Service was created',
+  actor: {
+    id: johnDoe.id,
+    type: 'USER_ACCOUNT',
+    name: johnDoe.fullName ?? johnDoe.email,
+  },
+  createdAt: '2026-04-28T20:51:56.341973+02:00',
+}, {
+  id: 'first-audit-record',
+  entityType: 'namespace',
+  entityId: namespaces.konfigyr.id,
+  eventType: 'namespace.created',
+  message: 'Namespace was created',
+  actor: {
+    id: johnDoe.id,
+    type: 'USER_ACCOUNT',
+    name: johnDoe.fullName ?? johnDoe.email,
+  },
+  createdAt: '2026-04-28T20:51:39.399083+02:00',
+}];
+
+const search = http.get('http://localhost/api/namespaces/:slug/audit', ({ params, request }) => {
   if (params.slug === namespaces.unknown.slug) {
     return HttpResponse.json({
       status: 404,
@@ -17,59 +67,25 @@ const search = http.get('http://localhost/api/namespaces/:slug/audit', ({ params
     return HttpResponse.json({ data: [] });
   }
 
+  const url = new URL(request.url);
+  const entityType = url.searchParams.get('entityType');
+  const entityId = url.searchParams.get('entityId');
+
+  let data = allRecords;
+
+  if (entityType) {
+    data = data.filter(record => record.entityType === entityType);
+  }
+
+  if (entityId) {
+    data = data.filter(record => record.entityId === entityId);
+  }
+
   const response: CursorResponse<AuditRecord> = {
-    data: [{
-      id: 'fourth-audit-record',
-      entityType: 'keyset',
-      entityId: 'kms-keyset',
-      eventType: 'keyset.created',
-      message: 'Keyset was created',
-      actor: {
-        id: janeDoe.id,
-        type: 'USER_ACCOUNT',
-        name: janeDoe.fullName ?? janeDoe.email,
-      },
-      createdAt: '2026-04-28T20:51:56.341973+02:00',
-    }, {
-      id: 'third-audit-record',
-      entityType: 'profile',
-      entityId: 'development',
-      eventType: 'profile.created',
-      message: 'Profile was created',
-      actor: {
-        id: johnDoe.id,
-        type: 'USER_ACCOUNT',
-        name: johnDoe.fullName ?? johnDoe.email,
-      },
-      createdAt: '2026-04-28T20:51:56.341973+02:00',
-    }, {
-      id: 'second-audit-record',
-      entityType: 'service',
-      entityId: 'konfgyr-api',
-      eventType: 'service.created',
-      message: 'Service was created',
-      actor: {
-        id: johnDoe.id,
-        type: 'USER_ACCOUNT',
-        name: johnDoe.fullName ?? johnDoe.email,
-      },
-      createdAt: '2026-04-28T20:51:56.341973+02:00',
-    }, {
-      id: 'first-audit-record',
-      entityType: 'namespace',
-      entityId: namespaces.konfigyr.id,
-      eventType: 'namespace.created',
-      message: 'Namespace was created',
-      actor: {
-        id: johnDoe.id,
-        type: 'USER_ACCOUNT',
-        name: johnDoe.fullName ?? johnDoe.email,
-      },
-      createdAt: '2026-04-28T20:51:39.399083+02:00',
-    }],
+    data,
     metadata: {
       size: 20,
-      next: 'next-token',
+      ...(data.length === allRecords.length ? { next: 'next-token' } : {}),
     },
   };
 

--- a/konfigyr-frontend/test/helpers/server/namespace/groups.ts
+++ b/konfigyr-frontend/test/helpers/server/namespace/groups.ts
@@ -32,6 +32,16 @@ const conflictedVerification: GroupVerification = {
   conflictingOwners: ['ebf'],
 };
 
+const activeConflictedVerification: GroupVerification = {
+  id: 'verification-active-conflicted',
+  groupId: 'com.acme.transfer-ready',
+  state: 'ACTIVE',
+  createdAt: '2026-07-05T00:00:00Z',
+  verifiedAt: '2026-07-06T00:00:00Z',
+  revokedAt: null,
+  conflictingOwners: ['ebf'],
+};
+
 const verificationChallenge: VerificationChallenge = {
   id: 'challenge-pending',
   verificationId: pendingVerification.id,
@@ -54,11 +64,17 @@ const conflictedChallenge: VerificationChallenge = {
   expiresAt: null,
 };
 
-const list = http.get('http://localhost/api/namespaces/:slug/group-verifications', ({ params }) => {
+const list = http.get('http://localhost/api/namespaces/:slug/group-verifications', ({ params, request }) => {
   const { slug } = params;
-  const data = slug === namespaces.konfigyr.slug
-    ? [activeVerification, pendingVerification]
+  const state = new URL(request.url).searchParams.get('state');
+
+  let data = slug === namespaces.konfigyr.slug
+    ? [activeVerification, pendingVerification, activeConflictedVerification]
     : [];
+
+  if (state) {
+    data = data.filter(verification => verification.state === state);
+  }
 
   const response: PageResponse<GroupVerification> = {
     data,
@@ -94,6 +110,10 @@ const get = http.get('http://localhost/api/namespaces/:slug/group-verifications/
 
   if (groupId === conflictedVerification.groupId) {
     return HttpResponse.json(conflictedVerification);
+  }
+
+  if (groupId === activeConflictedVerification.groupId) {
+    return HttpResponse.json(activeConflictedVerification);
   }
 
   return HttpResponse.json({

--- a/konfigyr-frontend/test/helpers/server/namespace/transfers.ts
+++ b/konfigyr-frontend/test/helpers/server/namespace/transfers.ts
@@ -1,0 +1,183 @@
+import { HttpResponse, http } from 'msw';
+import { namespaces } from '../../mocks';
+
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+import type { ArtifactOwnershipTransfer } from '@konfigyr/hooks/transfers/types';
+
+const incomingPending: ArtifactOwnershipTransfer = {
+  id: 'transfer-incoming-pending',
+  groupId: 'com.example.group',
+  from: { id: '2', slug: namespaces.konfigyr.slug },
+  to: { id: '99', slug: 'ebf' },
+  state: 'PENDING',
+  requestedAt: '2026-07-10T00:00:00Z',
+  resolvedAt: null,
+};
+
+const outgoingPending: ArtifactOwnershipTransfer = {
+  id: 'transfer-outgoing-pending',
+  groupId: 'io.github.acme',
+  from: { id: '99', slug: 'ebf' },
+  to: { id: '2', slug: namespaces.konfigyr.slug },
+  state: 'PENDING',
+  requestedAt: '2026-07-11T00:00:00Z',
+  resolvedAt: null,
+};
+
+const resolvedTransfer: ArtifactOwnershipTransfer = {
+  id: 'transfer-resolved',
+  groupId: 'com.acme.widgets',
+  from: { id: '2', slug: namespaces.konfigyr.slug },
+  to: { id: '99', slug: 'ebf' },
+  state: 'ACCEPTED',
+  requestedAt: '2026-07-05T00:00:00Z',
+  resolvedAt: '2026-07-06T00:00:00Z',
+};
+
+const forbiddenTransfer: ArtifactOwnershipTransfer = {
+  id: 'transfer-forbidden',
+  groupId: 'com.forbidden.group',
+  from: { id: '99', slug: 'ebf' },
+  to: { id: '100', slug: 'other-namespace' },
+  state: 'PENDING',
+  requestedAt: '2026-07-12T00:00:00Z',
+  resolvedAt: null,
+};
+
+const transfersById = new Map<string, ArtifactOwnershipTransfer>([
+  [incomingPending.id, incomingPending],
+  [outgoingPending.id, outgoingPending],
+  [resolvedTransfer.id, resolvedTransfer],
+  [forbiddenTransfer.id, forbiddenTransfer],
+]);
+
+const incoming = http.get('http://localhost/api/namespaces/:slug/artifact-transfers/incoming', ({ params }) => {
+  const { slug } = params;
+  const data = slug === namespaces.konfigyr.slug ? [incomingPending] : [];
+
+  const response: PageResponse<ArtifactOwnershipTransfer> = {
+    data,
+    metadata: { number: 1, size: 20, total: data.length, pages: 1 },
+  };
+
+  return HttpResponse.json(response);
+});
+
+const outgoing = http.get('http://localhost/api/namespaces/:slug/artifact-transfers/outgoing', ({ params }) => {
+  const { slug } = params;
+  const data = slug === namespaces.konfigyr.slug ? [outgoingPending] : [];
+
+  const response: PageResponse<ArtifactOwnershipTransfer> = {
+    data,
+    metadata: { number: 1, size: 20, total: data.length, pages: 1 },
+  };
+
+  return HttpResponse.json(response);
+});
+
+const get = http.get('http://localhost/api/namespaces/:slug/artifact-transfers/:id', ({ params }) => {
+  const { id } = params;
+  const transfer = transfersById.get(id as string);
+
+  if (!transfer) {
+    return HttpResponse.json({
+      status: 404,
+      title: 'Not found',
+      detail: `Could not find an artifact ownership transfer '${id}'.`,
+    }, { status: 404 });
+  }
+
+  return HttpResponse.json(transfer);
+});
+
+const create = http.post('http://localhost/api/namespaces/:slug/artifact-transfers', async ({ request }) => {
+  const body = await request.clone().json() as { groupId?: string; fromNamespace?: string };
+
+  if (body.groupId === 'unverified.group') {
+    return HttpResponse.json({
+      status: 400,
+      title: 'Bad request',
+      detail: `GroupId '${body.groupId}' is not verified for publishing`,
+    }, { status: 400 });
+  }
+
+  const response: ArtifactOwnershipTransfer = {
+    id: `${body.groupId}-transfer`,
+    groupId: body.groupId!,
+    from: { id: '99', slug: body.fromNamespace! },
+    to: { id: '2', slug: namespaces.konfigyr.slug },
+    state: 'PENDING',
+    requestedAt: '2026-07-13T00:00:00Z',
+    resolvedAt: null,
+  };
+
+  return HttpResponse.json(response, { status: 201 });
+});
+
+const accept = http.post('http://localhost/api/namespaces/:slug/artifact-transfers/:id/accept', ({ params }) => {
+  const { id } = params;
+  const transfer = transfersById.get(id as string);
+
+  if (!transfer) {
+    return HttpResponse.json({ status: 404, title: 'Not found', detail: `Could not find transfer '${id}'.` }, { status: 404 });
+  }
+
+  if (id === forbiddenTransfer.id) {
+    return HttpResponse.json({
+      status: 403,
+      title: 'Access Denied',
+      detail: `Only the '${transfer.from.slug}' namespace may accept this transfer`,
+    }, { status: 403 });
+  }
+
+  if (transfer.state !== 'PENDING') {
+    return HttpResponse.json({
+      status: 409,
+      title: 'Conflict',
+      detail: `Artifact ownership transfer '${id}' has already been resolved with state '${transfer.state}'`,
+    }, { status: 409 });
+  }
+
+  const updated: ArtifactOwnershipTransfer = { ...transfer, state: 'ACCEPTED', resolvedAt: '2026-07-14T00:00:00Z' };
+  transfersById.set(updated.id, updated);
+
+  return HttpResponse.json(updated);
+});
+
+const reject = http.post('http://localhost/api/namespaces/:slug/artifact-transfers/:id/reject', ({ params }) => {
+  const { id } = params;
+  const transfer = transfersById.get(id as string);
+
+  if (!transfer) {
+    return HttpResponse.json({ status: 404, title: 'Not found', detail: `Could not find transfer '${id}'.` }, { status: 404 });
+  }
+
+  const updated: ArtifactOwnershipTransfer = { ...transfer, state: 'REJECTED', resolvedAt: '2026-07-14T00:00:00Z' };
+  transfersById.set(updated.id, updated);
+
+  return HttpResponse.json(updated);
+});
+
+const cancel = http.delete('http://localhost/api/namespaces/:slug/artifact-transfers/:id', ({ params }) => {
+  const { id } = params;
+  const transfer = transfersById.get(id as string);
+
+  if (!transfer) {
+    return HttpResponse.json({ status: 404, title: 'Not found', detail: `Could not find transfer '${id}'.` }, { status: 404 });
+  }
+
+  const updated: ArtifactOwnershipTransfer = { ...transfer, state: 'CANCELLED', resolvedAt: '2026-07-14T00:00:00Z' };
+  transfersById.set(updated.id, updated);
+
+  return HttpResponse.json(updated);
+});
+
+export default [
+  incoming,
+  outgoing,
+  get,
+  create,
+  accept,
+  reject,
+  cancel,
+];

--- a/konfigyr-frontend/test/routes/namespace/artifactory/groups/$groupId/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/groups/$groupId/index.test.tsx
@@ -5,51 +5,12 @@ import { renderWithRouter } from '@konfigyr/test/helpers/router';
 describe('routes | namespace | groups | detail', () => {
   afterEach(() => cleanup());
 
-  test('should render an active group claim detail page', async () => {
+  test('should render the group claim detail page', async () => {
     const { getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/groups/com.example.group/');
 
     await waitFor(() => {
       expect(getByRole('heading', { name: 'com.example.group' })).toBeInTheDocument();
-      expect(getByText('Ownership verified')).toBeInTheDocument();
-      expect(getByText('Group verification details')).toBeInTheDocument();
       expect(getByText('Active')).toBeInTheDocument();
-      expect(getByRole('button', { name: 'Revoke claim' })).toBeInTheDocument();
     });
-  });
-
-  test('should render a pending group claim detail page', async () => {
-    const { getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/groups/io.github.acme/');
-
-    await waitFor(() => {
-      expect(getByRole('heading', { name: 'io.github.acme' })).toBeInTheDocument();
-      expect(getByText('Claim pending')).toBeInTheDocument();
-      expect(getByText('Create the marker repository for io.github.acme on GitHub, then re-check this claim.')).toBeInTheDocument();
-      expect(getByText('Pending')).toBeInTheDocument();
-      expect(getByRole('button', { name: 'Cancel claim' })).toBeInTheDocument();
-      expect(getByRole('button', { name: 'Verify claim' })).toBeInTheDocument();
-    });
-  });
-
-  test('should not render a conflict banner when there are no conflicting owners', async () => {
-    const { getByText, queryByText } = renderWithRouter('/namespace/konfigyr/artifactory/groups/com.example.group/');
-
-    await waitFor(() => {
-      expect(getByText('Ownership verified')).toBeInTheDocument();
-    });
-
-    expect(queryByText('Other namespaces already own artifacts here')).not.toBeInTheDocument();
-  });
-
-  test('should surface conflicting owners on the detail page', async () => {
-    const { getAllByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/groups/com.acme.widgets/');
-
-    await waitFor(() => {
-      expect(getByText('Other namespaces already own artifacts here')).toBeInTheDocument();
-      expect(getByText(
-        'Namespace ebf already publishes artifacts under this groupId. You may need to request an ownership transfer before you can publish.',
-      )).toBeInTheDocument();
-    });
-
-    expect(getAllByRole('alert')).toHaveLength(2);
   });
 });

--- a/konfigyr-frontend/test/routes/namespace/artifactory/groups/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/groups/index.test.tsx
@@ -6,13 +6,14 @@ describe('routes | namespace | groups', () => {
   afterEach(() => cleanup());
 
   test('should render the group claims list for a populated namespace', async () => {
-    const { getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/groups');
+    const { getAllByText, getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/groups');
 
     await waitFor(() => {
       expect(getByRole('link', { name: 'Claim a groupId' })).toBeInTheDocument();
       expect(getByText('com.example.group')).toBeInTheDocument();
       expect(getByText('io.github.acme')).toBeInTheDocument();
-      expect(getByText('Active')).toBeInTheDocument();
+      expect(getByText('com.acme.transfer-ready')).toBeInTheDocument();
+      expect(getAllByText('Active')).toHaveLength(2);
       expect(getByText('Pending')).toBeInTheDocument();
     });
   });

--- a/konfigyr-frontend/test/routes/namespace/artifactory/transfers/$transferId/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/transfers/$transferId/index.test.tsx
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '@konfigyr/test/helpers/router';
+
+describe('routes | namespace | transfers | detail', () => {
+  afterEach(() => cleanup());
+
+  test('should render the transfer detail page', async () => {
+    const { getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/transfers/transfer-incoming-pending/');
+
+    await waitFor(() => {
+      expect(getByRole('heading', { name: 'com.example.group' })).toBeInTheDocument();
+      expect(getByText('Pending')).toBeInTheDocument();
+    });
+  });
+
+});

--- a/konfigyr-frontend/test/routes/namespace/artifactory/transfers/create.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/transfers/create.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithRouter } from '@konfigyr/test/helpers/router';
+
+describe('routes | namespace | transfers | create', () => {
+  afterEach(() => cleanup());
+
+  test('should render the request form', async () => {
+    const { getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/transfers/create');
+
+    await waitFor(() => {
+      expect(getByRole('combobox', { name: 'Group Id' })).toBeInTheDocument();
+      expect(getByText('Select a groupId first.')).toBeInTheDocument();
+    });
+  });
+
+  test('should pre-fill the form from search params', async () => {
+    const { findByRole, getByRole } = renderWithRouter(
+      '/namespace/konfigyr/artifactory/transfers/create?groupId=com.acme.transfer-ready&fromNamespace=ebf',
+    );
+
+    expect(await findByRole('combobox', { name: 'Group Id' })).toHaveValue('com.acme.transfer-ready');
+
+    await waitFor(() => {
+      expect(getByRole('radio', { name: 'ebf' })).toBeChecked();
+    });
+  });
+
+  test('should show a clear inline error when the backend rejects the request', async () => {
+    const user = userEvent.setup();
+    const { getByRole, getByText, router } = renderWithRouter(
+      '/namespace/konfigyr/artifactory/transfers/create?groupId=unverified.group&fromNamespace=ebf',
+    );
+
+    await waitFor(() => {
+      expect(getByRole('combobox', { name: 'Group Id' })).toHaveValue('unverified.group');
+      expect(getByRole('radio', { name: 'ebf' })).toBeChecked();
+    });
+
+    await user.click(getByRole('button', { name: 'Request transfer' }));
+
+    await waitFor(() => {
+      expect(getByText('GroupId \'unverified.group\' is not verified for publishing')).toBeInTheDocument();
+    });
+
+    expect(router.state.location.pathname).toBe('/namespace/konfigyr/artifactory/transfers/create');
+  });
+});

--- a/konfigyr-frontend/test/routes/namespace/artifactory/transfers/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/transfers/index.test.tsx
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '@konfigyr/test/helpers/router';
+
+describe('routes | namespace | transfers', () => {
+  afterEach(() => cleanup());
+
+  test('should render the incoming transfers list by default', async () => {
+    const { getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/transfers');
+
+    await waitFor(() => {
+      expect(getByRole('link', { name: 'Request transfer' })).toBeInTheDocument();
+      expect(getByText('com.example.group')).toBeInTheDocument();
+      expect(getByText('ebf')).toBeInTheDocument();
+      expect(getByText('Pending')).toBeInTheDocument();
+    });
+  });
+
+  test('should toggle to the outgoing transfers list', async () => {
+    const { getByRole, getByText, queryByText } = renderWithRouter('/namespace/konfigyr/artifactory/transfers');
+
+    await waitFor(() => {
+      expect(getByText('com.example.group')).toBeInTheDocument();
+    });
+
+    const outgoingToggle = getByRole('link', { name: 'Outgoing' });
+    outgoingToggle.click();
+
+    await waitFor(() => {
+      expect(getByText('io.github.acme')).toBeInTheDocument();
+    });
+
+    expect(queryByText('com.example.group')).not.toBeInTheDocument();
+  });
+
+  test('should render an empty state when no transfers exist', async () => {
+    const { getByRole, getByText } = renderWithRouter('/namespace/john-doe/artifactory/transfers');
+
+    await waitFor(() => {
+      expect(getByRole('link', { name: 'Request transfer' })).toBeInTheDocument();
+      expect(getByText('No ownership transfers found')).toBeInTheDocument();
+    });
+  });
+});

--- a/konfigyr-frontend/test/routes/namespace/provision.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/provision.test.tsx
@@ -1,122 +1,48 @@
-import { afterAll, beforeAll, describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test } from 'vitest';
 import { cleanup, waitFor } from '@testing-library/react';
 import userEvents from '@testing-library/user-event';
-import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
-import { RouteComponent } from '@konfigyr/routes/_authenticated/namespace/provision';
-
-import type { RenderResult } from '@testing-library/react';
-import type { UserEvent } from '@testing-library/user-event';
+import { renderWithRouter } from '@konfigyr/test/helpers/router';
 
 describe('routes | namespace | provision', () => {
-  let result: RenderResult & { router: { state: { location: { pathname: string } } } };
-  let user: UserEvent;
-
-  beforeAll(() => {
-    user = userEvents.setup();
-    result = renderComponentWithRouter(
-      <RouteComponent debounceMs={0} />,
-    ) as RenderResult & { router: { state: { location: { pathname: string } } } };
-  });
-
-  afterAll(() => cleanup());
+  afterEach(() => cleanup());
 
   test('should render Namespace provisioning card', async () => {
-    await waitFor(() => {
-      expect(result.getByText('Tell us more about your organization or team that would be the owner of this namespace.'))
-        .toBeInTheDocument();
-
-      expect(result.getByRole('textbox', { name: 'Name' }))
-        .toBeInTheDocument();
-
-      expect(result.getByRole('textbox', { name: 'URL' }))
-        .toBeInTheDocument();
-
-      expect(result.getByRole('textbox', { name: 'Description' }))
-        .toBeInTheDocument();
-    });
-  });
-
-  test('should validate initial form data', async () => {
-    await user.click(
-      result.getByRole('button'),
-    );
-
-    expect(result.getByRole('button'))
-      .toBeDisabled();
-
-    expect(result.getByRole('textbox', { name: 'Name' }))
-      .toBeInvalid();
-
-    expect(result.getByRole('textbox', { name: 'URL' }))
-      .toBeInvalid();
-  });
-
-  test('should connect name with URL slug input field', async () => {
-    await user.type(
-      result.getByRole('textbox', { name: 'Name' }),
-      'some Namespace name',
-    );
-
-    expect(result.getByRole('textbox', { name: 'URL' })).toHaveValue('some-namespace-name');
-  });
-
-  test('should disconnect name when URL slug input field is made dirty and invalid', async () => {
-    await user.clear(
-      result.getByRole('textbox', { name: 'URL' }),
-    );
-
-    await user.type(
-      result.getByRole('textbox', { name: 'URL' }),
-      'updated-namespace-slug',
-    );
-
-    await user.clear(
-      result.getByRole('textbox', { name: 'Name' }),
-    );
-
-    await user.type(
-      result.getByRole('textbox', { name: 'Name' }),
-      'Namespace name',
-    );
-
-    expect(result.getByRole('textbox', { name: 'URL' }))
-      .toHaveValue('updated-namespace-slug');
+    const { getByText, getByRole } = renderWithRouter('/namespace/provision');
 
     await waitFor(() => {
-      expect(result.getByRole('textbox', { name: 'URL' })).toBeInvalid();
+      expect(getByText('Tell us more about your organization or team that would be the owner of this namespace.'))
+        .toBeInTheDocument();
+
+      expect(getByRole('textbox', { name: 'Name' }))
+        .toBeInTheDocument();
+
+      expect(getByRole('textbox', { name: 'URL' }))
+        .toBeInTheDocument();
+
+      expect(getByRole('textbox', { name: 'Description' }))
+        .toBeInTheDocument();
     });
-  });
-
-  test('should validate URL slug availability', async () => {
-    await user.clear(
-      result.getByRole('textbox', { name: 'URL' }),
-    );
-
-    await user.type(
-      result.getByRole('textbox', { name: 'URL' }),
-      'available-namespace',
-    );
-
-    // wait for the debounce period to be over to avoid race conditions when validating the URL slug
-    await new Promise((resolve) => setTimeout(resolve, 25));
-
-    await waitFor(() => {
-      expect(result.getByRole('textbox', { name: 'URL' })).toBeValid();
-    });
-
-    expect(result.getByRole('textbox', { name: 'URL' }))
-      .toHaveValue('available-namespace');
   });
 
   test('should create namespace and redirect to namespace overview page', async () => {
-    expect(result.getByRole('button')).not.toBeDisabled();
+    const user = userEvents.setup();
+    const { getByRole, router } = renderWithRouter('/namespace/provision');
+
+    await user.type(
+      await waitFor(() => getByRole('textbox', { name: 'Name' })),
+      'Available Namespace',
+    );
+
+    // wait for the debounced async slug validation to fully settle before submitting,
+    // otherwise the form can reject the submission as invalid despite no visible errors.
+    await new Promise(resolve => setTimeout(resolve, 300));
 
     await user.click(
-      result.getByRole('button'),
+      getByRole('button', { name: 'Create namespace' }),
     );
 
     await waitFor(() => {
-      expect(result.router.state.location.pathname).toBe('/namespace/available-namespace');
+      expect(router.state.location.pathname).toBe('/namespace/available-namespace');
     });
   });
 });


### PR DESCRIPTION
Adds a full ownership-transfer workflow to the Artifactory UI. Namespace admins can now request, accept, reject, or cancel the transfer of a Maven `groupId`'s ownership from another namespace directly from the frontend, instead of driving the existing REST API (`ArtifactOwnershipTransfersController`, already shipped) by hand.

- **List page** (`/artifactory/transfers`) toggles between incoming and outgoing transfers, with search.
- **Detail page** shows state, counterpart namespace, requested/resolved dates, role-gated Accept/Reject/Cancel actions, and a **new audit trail** (who accepted/rejected/cancelled and when).
- **Request form** only offers `groupId`s this namespace already holds an active verified claim on (combobox, searchable), then derives the "from namespace" options from that claim's known conflicting owners (radio group) — so the two required preconditions (active claim + a real existing owner) are encoded directly in the UI instead of relying on trial and error against backend validation.
- The group verification detail page's `ConflictingOwnersAlert` banner now links straight into a pre-filled transfer request (pre-selecting the counterpart namespace when there's exactly one conflicting owner).
- Sidebar: "Ownership transfers" is no longer a disabled placeholder.

## Backend changes

- New `ArtifactoryEvent.OwnershipTransferRequested` domain event, published when a transfer request is created, with a matching audit listener (previously only accept/reject/cancel were audited, a freshly-requested transfer had no audit trail entry at all until it was resolved).
- `AuditController`'s list endpoint now accepts an `entityId` filter (the repository/query layer already supported it; it just wasn't exposed as a request param).
- Rewrote the `artifact-ownership-transfer.*` audit message templates in `audit.properties`. They previously addressed the reader directly ("You have transferred...", "You are now the owner..."), which is wrong for anyone reading the log who wasn't the actor. Now phrased objectively, matching every other audit message in the file. Also fixed `.requested`'s text, which had been copy-pasted from `.received`/`.transferred` and claimed ownership had already moved before the request was even accepted.

## Frontend structure

- `src/hooks/transfers/{types,query}.ts(x)`: mirrors the existing `hooks/groups` conventions (query-key factory, `queryOptions`, mutation hooks with `setQueryData`/`invalidateQueries`).
- `src/components/artifactory/transfers/*`: table, filters, state badge, action buttons (confirm-dialog pattern matching the existing group-verification revoke/cancel buttons), request form, audit trail.
- `src/routes/.../artifactory/transfers/*`: list, create, detail routes.
- Extracted `TransferDetails` and `GroupVerificationDetails` as dedicated presentational components (previously inlined in their route files), so their state/role-gating logic is unit-testable without spinning up a router or MSW.
