### PR TITLE
Artifact registry UI

### DIFF
--- a/konfigyr-frontend/src/components/artifactory/registry/artifact-filters.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/artifact-filters.tsx
@@ -1,0 +1,45 @@
+import { useCallback } from 'react';
+import { useIntl } from 'react-intl';
+import { SearchIcon } from 'lucide-react';
+import { useDebouncedCallback } from 'use-debounce';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@konfigyr/components/ui/input-group';
+
+import type { ChangeEvent } from 'react';
+import type { ArtifactQuery } from '@konfigyr/hooks/artifactory/types';
+
+export function ArtifactFilters({ query, onQueryChange }: {
+  query: ArtifactQuery,
+  onQueryChange: (query: ArtifactQuery) => void,
+}) {
+  const intl = useIntl();
+  const debounced = useDebouncedCallback(
+    (term: string) => onQueryChange({ term: term || undefined }),
+    200,
+  );
+
+  const onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    debounced(event.target.value);
+  }, [debounced]);
+
+  return (
+    <InputGroup className="grow">
+      <InputGroupInput
+        type="search"
+        defaultValue={query.term || ''}
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Search artifacts...',
+          description: 'Placeholder text for the artifact registry search input.',
+        })}
+        aria-label={intl.formatMessage({
+          defaultMessage: 'Search artifacts',
+          description: 'Label for the artifact registry search input.',
+        })}
+        className="text-sm"
+        onChange={onChange}
+      />
+      <InputGroupAddon>
+        <SearchIcon size="1rem" className="text-muted-foreground" />
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/registry/artifact-overview.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/artifact-overview.tsx
@@ -1,0 +1,98 @@
+import { FormattedMessage } from 'react-intl';
+import { PackageIcon } from 'lucide-react';
+import { useIsNamespaceAdmin } from '@konfigyr/hooks';
+import { Card, CardContent, CardFooter, CardHeader } from '@konfigyr/components/ui/card';
+import { ArtifactVisibilityBadge } from '@konfigyr/components/artifactory/registry/visibility-badge';
+import { ChangeVisibilityButton } from '@konfigyr/components/artifactory/registry/change-visibility-button';
+import { RepositoryLabel, WebsiteLabel } from '@konfigyr/components/artifactory/registry/messages';
+
+import type { ArtifactDefinition } from '@konfigyr/hooks/artifactory/types';
+import type { Namespace } from '@konfigyr/hooks/types';
+
+export function ArtifactOverview({ namespace, artifact }: { namespace: Namespace; artifact: ArtifactDefinition }) {
+  const isAdmin = useIsNamespaceAdmin(namespace);
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border bg-card">
+            <PackageIcon className="size-5 text-muted-foreground" aria-hidden="true"/>
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate font-mono text-2xl font-medium leading-tight">
+              {artifact.groupId}:{artifact.artifactId}
+            </h1>
+            {artifact.name && (
+              <p className="text-sm text-muted-foreground truncate">{artifact.name}</p>
+            )}
+          </div>
+        </div>
+        <ArtifactVisibilityBadge
+          size="lg"
+          visibility={artifact.visibility}
+        />
+      </div>
+
+      <Card className="border">
+        <CardHeader title="Details"/>
+        <CardContent>
+          <dl className="grid grid-cols-2 gap-4 text-sm">
+            {artifact.description && (
+              <div className="col-span-2">
+                <dt className="text-muted-foreground">Description</dt>
+                <dd>{artifact.description}</dd>
+              </div>
+            )}
+            <div>
+              <dt className="text-muted-foreground"><WebsiteLabel/></dt>
+              <dd>
+                {artifact.website ? (
+                  <a href={artifact.website} target="_blank" rel="noreferrer" className="underline text-primary">
+                    {artifact.website}
+                  </a>
+                ) : (
+                  <span className="text-muted-foreground">&mdash;</span>
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground"><RepositoryLabel/></dt>
+              <dd>
+                {artifact.repository ? (
+                  <a href={artifact.repository} target="_blank" rel="noreferrer" className="underline text-primary">
+                    {artifact.repository}
+                  </a>
+                ) : (
+                  <span className="text-muted-foreground">&mdash;</span>
+                )}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+        <CardFooter className="justify-between">
+          {artifact.visibility === 'PUBLIC' && (
+            <FormattedMessage
+              defaultMessage="Visible to every namespace."
+              description="Label used to describe the public artifact visibility."
+              tagName="p"
+            />
+          )}
+
+          {artifact.visibility === 'PRIVATE' && (
+            <FormattedMessage
+              defaultMessage="Visible to everyone in the {namespace} namespace."
+              description="Label used to describe the private artifact visibility."
+              values={{ namespace: <strong>{namespace.slug}</strong> }}
+              tagName="p"
+            />
+          )}
+
+          {isAdmin && (
+            <ChangeVisibilityButton namespace={namespace.slug} artifact={artifact}/>
+          )}
+        </CardFooter>
+      </Card>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/registry/artifact-table.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/artifact-table.tsx
@@ -1,0 +1,191 @@
+import { PackageIcon } from 'lucide-react';
+import { FormattedDate } from 'react-intl';
+import { Link } from '@tanstack/react-router';
+import { ActionsLabel, UpdatedAtLabel, ViewLabel } from '@konfigyr/components/messages';
+import { ErrorState } from '@konfigyr/components/error';
+import { buttonVariants } from '@konfigyr/components/ui/button';
+import { Card, CardContent } from '@konfigyr/components/ui/card';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationRange,
+} from '@konfigyr/components/ui/pagination';
+import { Skeleton } from '@konfigyr/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@konfigyr/components/ui/table';
+import { ArtifactVisibilityBadge } from '@konfigyr/components/artifactory/registry/visibility-badge';
+import {
+  NoArtifactsFoundDescription,
+  NoArtifactsFoundTitle,
+  VisibilityLabel,
+} from '@konfigyr/components/artifactory/registry/messages';
+
+import type { ArtifactDefinition } from '@konfigyr/hooks/artifactory/types';
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+
+function ArtifactRow({ namespace, artifact }: { namespace: string; artifact: ArtifactDefinition }) {
+  return (
+    <TableRow>
+      <TableCell className="font-mono font-bold">
+        <div className="flex items-center gap-2">
+          <PackageIcon className="size-4 text-muted-foreground" aria-hidden="true"/>
+          {artifact.groupId}:{artifact.artifactId}
+        </div>
+      </TableCell>
+      <TableCell>
+        {artifact.name || <span className="text-muted-foreground">&mdash;</span>}
+      </TableCell>
+      <TableCell>
+        <ArtifactVisibilityBadge visibility={artifact.visibility}/>
+      </TableCell>
+      <TableCell>
+        {artifact.updatedAt ? (
+          <time dateTime={artifact.updatedAt}>
+            <FormattedDate value={artifact.updatedAt} day="2-digit" month="short" year="numeric"/>
+          </time>
+        ) : (
+          <span className="text-muted-foreground">&mdash;</span>
+        )}
+      </TableCell>
+      <TableCell className="text-right">
+        <Link
+          to="/namespace/$namespace/artifactory/registry/$groupId/$artifactId"
+          params={{ namespace, groupId: artifact.groupId, artifactId: artifact.artifactId }}
+          className={buttonVariants({ variant: 'ghost' })}
+        >
+          <ViewLabel/>
+        </Link>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function ArtifactSkeleton() {
+  return (
+    <TableRow data-slot="artifact-skeleton">
+      <TableCell><Skeleton className="h-5 w-48"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-32"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-20 rounded-xl"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-24"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-24 ml-auto"/></TableCell>
+    </TableRow>
+  );
+}
+
+function ArtifactPagination({ page = 1, size = 20, data }: {
+  page?: number;
+  size?: number;
+  data?: PageResponse<ArtifactDefinition>;
+}) {
+  const pages = data?.metadata.pages || 1;
+  const total = data?.metadata.total || 0;
+
+  if (pages < 2) {
+    return null;
+  }
+
+  return (
+    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            render={(
+              <Link to="." search={search => ({ ...search, page: page - 1 })}/>
+            )}
+          />
+        </PaginationItem>
+        <PaginationRange>
+          {(state) => (
+            <PaginationLink
+              isActive={state.active}
+              render={(
+                <Link to="." search={search => ({ ...search, page: state.page })}>
+                  {state.page}
+                </Link>
+              )}
+            />
+          )}
+        </PaginationRange>
+        <PaginationItem>
+          <PaginationNext
+            render={(
+              <Link to="." search={search => ({ ...search, page: page + 1 })}/>
+            )}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}
+
+export function ArtifactTable({ namespace, data, error, isPending, page, size }: {
+  namespace: string;
+  data?: PageResponse<ArtifactDefinition>;
+  error?: Error | null;
+  isPending?: boolean;
+  page?: number;
+  size?: number;
+}) {
+  return (
+    <>
+      <Card className="border">
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-64">
+                  Coordinates
+                </TableHead>
+                <TableHead className="w-48">
+                  Name
+                </TableHead>
+                <TableHead className="w-32">
+                  <VisibilityLabel/>
+                </TableHead>
+                <TableHead className="w-32">
+                  <UpdatedAtLabel/>
+                </TableHead>
+                <TableHead className="w-48 text-right">
+                  <ActionsLabel/>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isPending && (
+                <>
+                  <ArtifactSkeleton/>
+                  <ArtifactSkeleton/>
+                  <ArtifactSkeleton/>
+                </>
+              )}
+
+              {data?.data.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={5}>
+                    <EmptyState
+                      icon={<PackageIcon size="2rem"/>}
+                      title={<NoArtifactsFoundTitle/>}
+                      description={<NoArtifactsFoundDescription/>}
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {data?.data.map((artifact) => (
+                <ArtifactRow key={artifact.id} namespace={namespace} artifact={artifact}/>
+              ))}
+            </TableBody>
+          </Table>
+
+          {error && <ErrorState error={error}/>}
+        </CardContent>
+      </Card>
+
+      <ArtifactPagination page={page} size={size} data={data}/>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/registry/breadcrumbs.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/breadcrumbs.tsx
@@ -1,0 +1,35 @@
+import { Link } from '@tanstack/react-router';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbSeparator,
+} from '@konfigyr/components/ui/breadcrumb';
+
+import { RegistryLabel } from '@konfigyr/components/artifactory/registry/messages';
+import type { ReactNode } from 'react';
+import type { Namespace } from '@konfigyr/hooks/types';
+
+export function RegistryBreadcrumbs({ namespace, children }: { namespace: Namespace; children: ReactNode }) {
+  return (
+    <Breadcrumb>
+      <BreadcrumbList>
+        <BreadcrumbItem>
+          <BreadcrumbLink
+            render={
+              <Link
+                to="/namespace/$namespace/artifactory/registry"
+                params={{ namespace: namespace.slug }}
+              >
+                <RegistryLabel />
+              </Link>
+            }
+          />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator />
+        {children}
+      </BreadcrumbList>
+    </Breadcrumb>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/registry/change-visibility-button.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/change-visibility-button.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { toast } from 'sonner';
+import { useCallback } from 'react';
+import { EyeIcon, EyeOffIcon } from 'lucide-react';
+import { useChangeArtifactVisibility } from '@konfigyr/hooks';
+import { useErrorNotification } from '@konfigyr/components/error';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@konfigyr/components/ui/alert-dialog';
+import { Button } from '@konfigyr/components/ui/button';
+import { CancelLabel } from '@konfigyr/components/messages';
+import {
+  ChangeVisibilityTitle,
+  MakePrivateDescription,
+  MakePrivateLabel,
+  MakePublicDescription,
+  MakePublicLabel,
+  VisibilityChangedSuccessMessage,
+} from '@konfigyr/components/artifactory/registry/messages';
+
+import type { ArtifactDefinition } from '@konfigyr/hooks/artifactory/types';
+
+export function ChangeVisibilityButton({ namespace, artifact }: {
+  namespace: string;
+  artifact: ArtifactDefinition;
+}) {
+  const errorNotification = useErrorNotification();
+  const { isPending, mutateAsync: changeVisibility } = useChangeArtifactVisibility(namespace);
+
+  const nextVisibility = artifact.visibility === 'PUBLIC' ? 'PRIVATE' : 'PUBLIC';
+  const coordinates = `${artifact.groupId}:${artifact.artifactId}`;
+
+  const onConfirm = useCallback(async () => {
+    try {
+      await changeVisibility({
+        groupId: artifact.groupId,
+        artifactId: artifact.artifactId,
+        visibility: nextVisibility,
+      });
+    } catch (error) {
+      return errorNotification(error);
+    }
+
+    toast.success(<VisibilityChangedSuccessMessage artifact={coordinates}/>);
+  }, [artifact, nextVisibility, coordinates, errorNotification, changeVisibility]);
+
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger
+        render={
+          <Button variant="outline">
+            {nextVisibility === 'PUBLIC' ? <EyeIcon/> : <EyeOffIcon/>}
+            {nextVisibility === 'PUBLIC' ? <MakePublicLabel/> : <MakePrivateLabel/>}
+          </Button>
+        }
+      />
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            <ChangeVisibilityTitle/>
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {nextVisibility === 'PUBLIC' ? (
+              <MakePublicDescription artifact={coordinates}/>
+            ) : (
+              <MakePrivateDescription artifact={coordinates}/>
+            )}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>
+            <CancelLabel/>
+          </AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isPending}
+            loading={isPending}
+            onClick={onConfirm}
+          >
+            {nextVisibility === 'PUBLIC' ? <MakePublicLabel/> : <MakePrivateLabel/>}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/registry/messages.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/messages.tsx
@@ -1,0 +1,144 @@
+import { FormattedMessage } from 'react-intl';
+
+export const RegistryLabel = () => (
+  <FormattedMessage
+    defaultMessage="Artifact registry"
+    description="Breadcrumb and sidebar label for the artifact registry list page."
+  />
+);
+
+export const VisibilityLabel = () => (
+  <FormattedMessage
+    defaultMessage="Visibility"
+    description="Label for the visibility of an artifact."
+  />
+);
+
+export const PublicLabel = () => (
+  <FormattedMessage
+    defaultMessage="Public"
+    description="Label for a PUBLIC artifact visibility."
+  />
+);
+
+export const PrivateLabel = () => (
+  <FormattedMessage
+    defaultMessage="Private"
+    description="Label for a PRIVATE artifact visibility."
+  />
+);
+
+export const VersionsLabel = () => (
+  <FormattedMessage
+    defaultMessage="Versions"
+    description="Label for the list of published versions of an artifact."
+  />
+);
+
+export const PublishedAtLabel = () => (
+  <FormattedMessage
+    defaultMessage="Published at"
+    description="Label for the date an artifact version was published."
+  />
+);
+
+export const WebsiteLabel = () => (
+  <FormattedMessage
+    defaultMessage="Website"
+    description="Label for the website URL of an artifact."
+  />
+);
+
+export const RepositoryLabel = () => (
+  <FormattedMessage
+    defaultMessage="Repository"
+    description="Label for the source control repository URL of an artifact."
+  />
+);
+
+export const MakePublicLabel = () => (
+  <FormattedMessage
+    defaultMessage="Make public"
+    description="Button label that changes an artifact's visibility to PUBLIC."
+  />
+);
+
+export const MakePrivateLabel = () => (
+  <FormattedMessage
+    defaultMessage="Make private"
+    description="Button label that changes an artifact's visibility to PRIVATE."
+  />
+);
+
+export const ChangeVisibilityTitle = () => (
+  <FormattedMessage
+    defaultMessage="Change artifact visibility"
+    description="Title of the confirmation dialog for changing an artifact's visibility."
+  />
+);
+
+export const MakePublicDescription = ({ artifact }: { artifact: string }) => (
+  <FormattedMessage
+    defaultMessage="Are you sure you want to make <b>{artifact}</b> public? Every namespace will be able to read its metadata and property definitions."
+    values={{ artifact, b: (chunks) => <strong>{chunks}</strong> }}
+    description="Confirmation text in the dialog for making an artifact PUBLIC."
+  />
+);
+
+export const MakePrivateDescription = ({ artifact }: { artifact: string }) => (
+  <FormattedMessage
+    defaultMessage="Are you sure you want to make <b>{artifact}</b> private? Only this namespace will be able to read its metadata and property definitions."
+    values={{ artifact, b: (chunks) => <strong>{chunks}</strong> }}
+    description="Confirmation text in the dialog for making an artifact PRIVATE."
+  />
+);
+
+export const VisibilityChangedSuccessMessage = ({ artifact }: { artifact: string }) => (
+  <FormattedMessage
+    defaultMessage="Updated the visibility of {artifact}"
+    values={{ artifact }}
+    description="Success message shown after an artifact's visibility was changed."
+  />
+);
+
+export const NoArtifactsFoundTitle = () => (
+  <FormattedMessage
+    defaultMessage="No artifacts found"
+    description="Empty state title when no artifacts are found in the registry list."
+  />
+);
+
+export const NoArtifactsFoundDescription = () => (
+  <FormattedMessage
+    defaultMessage="This namespace has not published any artifact metadata yet."
+    description="Empty state description when no artifacts are found in the registry list."
+  />
+);
+
+export const NoVersionsFoundTitle = () => (
+  <FormattedMessage
+    defaultMessage="No versions found"
+    description="Empty state title when an artifact has no published versions."
+  />
+);
+
+export const SearchPropertiesPromptTitle = () => (
+  <FormattedMessage
+    defaultMessage="Search this version's properties"
+    description="Empty state title shown before a property search term has been entered on the version detail page."
+  />
+);
+
+export const SearchPropertiesPromptDescription = () => (
+  <FormattedMessage
+    defaultMessage="Type a property name or description to see matching configuration properties published with this version."
+    description="Empty state description shown before a property search term has been entered on the version detail page."
+  />
+);
+
+export const NoMatchingPropertiesTitle = () => (
+  <FormattedMessage
+    defaultMessage="No matching properties found"
+    description="Empty state title when no properties match the search term on the version detail page."
+  />
+);

--- a/konfigyr-frontend/src/components/artifactory/registry/version-detail.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/version-detail.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useState } from 'react';
+import { FormattedDate, useIntl } from 'react-intl';
+import { SearchIcon, TagIcon } from 'lucide-react';
+import { useDebouncedCallback } from 'use-debounce';
+import { useSearchArtifactProperties } from '@konfigyr/hooks';
+import { ErrorState } from '@konfigyr/components/error';
+import { PropertyDeprecation } from '@konfigyr/components/artifactory/property-deprecation';
+import { PropertyDescription } from '@konfigyr/components/artifactory/property-description';
+import { PropertyName } from '@konfigyr/components/artifactory/property-name';
+import { PropertySchema } from '@konfigyr/components/artifactory/property-schema';
+import { PropertyDefaultValue } from '@konfigyr/components/artifactory/property-default-value';
+import { PropertyTypeName } from '@konfigyr/components/artifactory/property-type-name';
+import { Card, CardContent } from '@konfigyr/components/ui/card';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@konfigyr/components/ui/input-group';
+import { Item, ItemContent, ItemGroup, ItemTitle } from '@konfigyr/components/ui/item';
+import { Skeleton } from '@konfigyr/components/ui/skeleton';
+import { ArtifactVisibilityBadge } from '@konfigyr/components/artifactory/registry/visibility-badge';
+import {
+  NoMatchingPropertiesTitle,
+  PublishedAtLabel,
+  SearchPropertiesPromptDescription,
+  SearchPropertiesPromptTitle,
+} from '@konfigyr/components/artifactory/registry/messages';
+
+import type { ChangeEvent } from 'react';
+import type { PropertyDescriptor, VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
+
+function PropertyItem({ property }: { property: PropertyDescriptor }) {
+  return (
+    <Item variant="list">
+      <ItemContent>
+        <ItemTitle>
+          <PropertyName value={property.name}/>
+          <PropertyTypeName value={property.typeName}/>
+          <PropertyDeprecation deprecation={property.deprecation}/>
+        </ItemTitle>
+        <PropertyDescription value={property.description}/>
+        <div className="text-xs mt-2 space-y-1">
+          <PropertyDefaultValue variant="labeled" value={property.defaultValue}/>
+          <p>
+            <span className="text-muted-foreground mr-1">JSON Schema type:</span>
+            <PropertySchema value={property.schema}/>
+          </p>
+        </div>
+      </ItemContent>
+    </Item>
+  );
+}
+
+function PropertySearchForm({ term, onTermChange }: { term: string; onTermChange: (term: string) => void }) {
+  const intl = useIntl();
+  const debounced = useDebouncedCallback((value: string) => onTermChange(value), 260);
+
+  const onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    debounced(event.target.value);
+  }, [debounced]);
+
+  return (
+    <InputGroup className="max-w-sm">
+      <InputGroupInput
+        type="search"
+        defaultValue={term}
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Search properties...',
+          description: 'Placeholder for the version property search input.',
+        })}
+        aria-label={intl.formatMessage({
+          defaultMessage: 'Search properties in this version',
+          description: 'Aria label for the version property search input.',
+        })}
+        onChange={onChange}
+      />
+      <InputGroupAddon>
+        <SearchIcon size="1rem" className="text-muted-foreground"/>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}
+
+export function VersionDetail({ namespace, version }: { namespace: string; version: VersionedArtifact }) {
+  const [term, setTerm] = useState('');
+
+  const { data, error, isPending, isError } = useSearchArtifactProperties(namespace, {
+    groupId: version.groupId,
+    artifactId: version.artifactId,
+    version: version.version,
+    term,
+  });
+
+  return (
+    <>
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl border bg-card">
+            <TagIcon className="size-5 text-muted-foreground" aria-hidden="true"/>
+          </div>
+          <div className="min-w-0">
+            <h1 className="truncate font-mono text-2xl font-medium leading-tight">
+              {version.groupId}:{version.artifactId}:{version.version}
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              <PublishedAtLabel/>:{' '}
+              <time dateTime={version.publishedAt}>
+                <FormattedDate value={version.publishedAt} day="2-digit" month="short" year="numeric"/>
+              </time>
+            </p>
+          </div>
+        </div>
+        <ArtifactVisibilityBadge
+          size="lg"
+          visibility={version.visibility}
+        />
+      </div>
+
+      <PropertySearchForm term={term} onTermChange={setTerm}/>
+
+      <Card className="border">
+        <CardContent>
+          {term.trim().length === 0 && (
+            <EmptyState
+              icon={<SearchIcon size="2rem"/>}
+              title={<SearchPropertiesPromptTitle/>}
+              description={<SearchPropertiesPromptDescription/>}
+            />
+          )}
+
+          {term.trim().length > 0 && isPending && (
+            <div data-slot="property-search-skeleton" className="space-y-3">
+              <Skeleton className="h-4 w-64"/>
+              <Skeleton className="h-4 w-48"/>
+              <Skeleton className="h-4 w-56"/>
+            </div>
+          )}
+
+          {isError && (
+            <ErrorState error={error} className="border-none"/>
+          )}
+
+          {term.trim().length > 0 && data?.data.length === 0 && (
+            <EmptyState
+              icon={<SearchIcon size="2rem"/>}
+              title={<NoMatchingPropertiesTitle/>}
+            />
+          )}
+
+          {data && data.data.length > 0 && (
+            <ItemGroup>
+              {data.data.map(property => (
+                <PropertyItem key={property.name} property={property}/>
+              ))}
+            </ItemGroup>
+          )}
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/registry/version-table.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/version-table.tsx
@@ -1,0 +1,175 @@
+import { TagIcon } from 'lucide-react';
+import { FormattedDate } from 'react-intl';
+import { Link } from '@tanstack/react-router';
+import { ActionsLabel, ViewLabel } from '@konfigyr/components/messages';
+import { ErrorState } from '@konfigyr/components/error';
+import { buttonVariants } from '@konfigyr/components/ui/button';
+import { Card, CardContent } from '@konfigyr/components/ui/card';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+  PaginationRange,
+} from '@konfigyr/components/ui/pagination';
+import { Skeleton } from '@konfigyr/components/ui/skeleton';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@konfigyr/components/ui/table';
+import { ArtifactVisibilityBadge } from '@konfigyr/components/artifactory/registry/visibility-badge';
+import {
+  NoVersionsFoundTitle,
+  PublishedAtLabel,
+  VisibilityLabel,
+} from '@konfigyr/components/artifactory/registry/messages';
+
+import type { VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+
+function VersionRow({ namespace, version }: { namespace: string; version: VersionedArtifact }) {
+  return (
+    <TableRow>
+      <TableCell className="font-mono font-bold">
+        {version.version}
+      </TableCell>
+      <TableCell>
+        <ArtifactVisibilityBadge visibility={version.visibility}/>
+      </TableCell>
+      <TableCell>
+        <time dateTime={version.publishedAt}>
+          <FormattedDate value={version.publishedAt} day="2-digit" month="short" year="numeric"/>
+        </time>
+      </TableCell>
+      <TableCell className="text-right">
+        <Link
+          to="/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version"
+          params={{ namespace, groupId: version.groupId, artifactId: version.artifactId, version: version.version }}
+          className={buttonVariants({ variant: 'ghost' })}
+        >
+          <ViewLabel/>
+        </Link>
+      </TableCell>
+    </TableRow>
+  );
+}
+
+function VersionSkeleton() {
+  return (
+    <TableRow data-slot="version-skeleton">
+      <TableCell><Skeleton className="h-5 w-24"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-20 rounded-xl"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-24"/></TableCell>
+      <TableCell><Skeleton className="h-5 w-24 ml-auto"/></TableCell>
+    </TableRow>
+  );
+}
+
+function VersionPagination({ page = 1, size = 20, data }: {
+  page?: number;
+  size?: number;
+  data?: PageResponse<VersionedArtifact>;
+}) {
+  const pages = data?.metadata.pages || 1;
+  const total = data?.metadata.total || 0;
+
+  if (pages < 2) {
+    return null;
+  }
+
+  return (
+    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            render={(
+              <Link to="." search={search => ({ ...search, page: page - 1 })}/>
+            )}
+          />
+        </PaginationItem>
+        <PaginationRange>
+          {(state) => (
+            <PaginationLink
+              isActive={state.active}
+              render={(
+                <Link to="." search={search => ({ ...search, page: state.page })}>
+                  {state.page}
+                </Link>
+              )}
+            />
+          )}
+        </PaginationRange>
+        <PaginationItem>
+          <PaginationNext
+            render={(
+              <Link to="." search={search => ({ ...search, page: page + 1 })}/>
+            )}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
+  );
+}
+
+export function VersionTable({ namespace, data, error, isPending, page, size }: {
+  namespace: string;
+  data?: PageResponse<VersionedArtifact>;
+  error?: Error | null;
+  isPending?: boolean;
+  page?: number;
+  size?: number;
+}) {
+  return (
+    <>
+      <Card className="border">
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead className="min-w-32">
+                  Version
+                </TableHead>
+                <TableHead className="w-32">
+                  <VisibilityLabel/>
+                </TableHead>
+                <TableHead className="w-32">
+                  <PublishedAtLabel/>
+                </TableHead>
+                <TableHead className="w-48 text-right">
+                  <ActionsLabel/>
+                </TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {isPending && (
+                <>
+                  <VersionSkeleton/>
+                  <VersionSkeleton/>
+                </>
+              )}
+
+              {data?.data.length === 0 && (
+                <TableRow>
+                  <TableCell colSpan={4}>
+                    <EmptyState
+                      icon={<TagIcon size="2rem"/>}
+                      title={<NoVersionsFoundTitle/>}
+                    />
+                  </TableCell>
+                </TableRow>
+              )}
+
+              {data?.data.map((version) => (
+                <VersionRow key={version.id} namespace={namespace} version={version}/>
+              ))}
+            </TableBody>
+          </Table>
+
+          {error && <ErrorState error={error}/>}
+        </CardContent>
+      </Card>
+
+      <VersionPagination page={page} size={size} data={data}/>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/registry/visibility-badge.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/visibility-badge.tsx
@@ -1,0 +1,27 @@
+import {
+  GlobeIcon,
+  LockIcon,
+} from 'lucide-react';
+import { Badge } from '@konfigyr/components/ui/badge';
+import { PrivateLabel, PublicLabel } from './messages';
+
+import type { ComponentProps } from 'react';
+import type { ArtifactVisibility } from '@konfigyr/hooks/artifactory/types';
+
+export function ArtifactVisibilityBadge({ visibility, ...props }: {
+  visibility: ArtifactVisibility;
+} & Omit<ComponentProps<typeof Badge>, 'variant'>) {
+  if (visibility === 'PUBLIC') {
+    return (
+      <Badge variant="success" {...props}>
+        <GlobeIcon /> <PublicLabel/>
+      </Badge>
+    );
+  }
+
+  return (
+    <Badge variant="secondary" {...props}>
+      <LockIcon /> <PrivateLabel/>
+    </Badge>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/messages.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/messages.tsx
@@ -7,6 +7,13 @@ export const TransfersLabel = () => (
   />
 );
 
+export const TransferDetailsLabel = () => (
+  <FormattedMessage
+    defaultMessage="Ownership transfer details"
+    description="Label for the ownership transfers details page."
+  />
+);
+
 export const GroupIdLabel = () => (
   <FormattedMessage
     defaultMessage="Group Id"
@@ -35,6 +42,20 @@ export const ResolvedAtLabel = () => (
   />
 );
 
+export const CurrentOwnerLabel = () => (
+  <FormattedMessage
+    defaultMessage="Current owner"
+    description="Label that shows the current owner of a groupId that is being transferred."
+  />
+);
+
+export const RequestingNamespaceLabel = () => (
+  <FormattedMessage
+    defaultMessage="Request namespace"
+    description="Label that shows the namespace that requested the groupId transfer."
+  />
+);
+
 export const IncomingLabel = () => (
   <FormattedMessage
     defaultMessage="Incoming"
@@ -58,7 +79,7 @@ export const RequestTransferLabel = () => (
 
 export const AcceptTransferLabel = () => (
   <FormattedMessage
-    defaultMessage="Accept"
+    defaultMessage="Accept and move artifacts"
     description="Button label that accepts an ownership transfer request."
   />
 );

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-details.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-details.tsx
@@ -1,18 +1,29 @@
 import {
   ArrowLeftRightIcon,
+  ArrowRightIcon,
   CheckIcon,
   XIcon,
 } from 'lucide-react';
 import { FormattedDate } from 'react-intl';
 import { Button } from '@konfigyr/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@konfigyr/components/ui/card';
 import { TransferStateBadge } from '@konfigyr/components/artifactory/transfers/transfer-state-badge';
 import { NamespaceLabel } from '@konfigyr/components/messages';
 import {
   AcceptTransferLabel,
   CancelTransferLabel,
+  CurrentOwnerLabel,
   RejectTransferLabel,
   RequestedAtLabel,
+  RequestingNamespaceLabel,
   ResolvedAtLabel,
+  StateLabel,
+  TransferDetailsLabel,
 } from '@konfigyr/components/artifactory/transfers/messages';
 import {
   AcceptTransferButton,
@@ -46,40 +57,69 @@ export function TransferDetails({ namespace, transfer }: {
         <TransferStateBadge state={transfer.state}/>
       </div>
 
-      <dl className="grid grid-cols-3 gap-4 text-sm">
-        <div>
-          <dt className="text-muted-foreground"><NamespaceLabel/></dt>
-          <dd>{isFromParty ? transfer.to.slug : transfer.from.slug}</dd>
-        </div>
-        <div>
-          <dt className="text-muted-foreground"><RequestedAtLabel/></dt>
-          <dd>
-            {transfer.requestedAt ? (
-              <time dateTime={transfer.requestedAt}>
-                <FormattedDate value={transfer.requestedAt} day="2-digit" month="short" year="numeric"/>
-              </time>
-            ) : (
-              <span className="text-muted-foreground">&mdash;</span>
-            )}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-muted-foreground"><ResolvedAtLabel/></dt>
-          <dd>
-            {transfer.resolvedAt ? (
-              <time dateTime={transfer.resolvedAt}>
-                <FormattedDate value={transfer.resolvedAt} day="2-digit" month="short" year="numeric"/>
-              </time>
-            ) : (
-              <span className="text-muted-foreground">&mdash;</span>
-            )}
-          </dd>
-        </div>
-      </dl>
+      <Card className="border">
+        <CardContent className="flex items-center justify-center gap-4 py-2">
+          <div className="grow text-center">
+            <p className="text-xs font-semibold  uppercase text-muted-foreground">
+              <CurrentOwnerLabel/>
+            </p>
+            <p className="font-heading font-semibold leading-relaxed">
+              {transfer.from.slug}
+            </p>
+          </div>
+          <ArrowRightIcon className="size-6" />
+          <div className="grow text-center">
+            <p className="text-xs font-semibold uppercase text-muted-foreground">
+              <RequestingNamespaceLabel/>
+            </p>
+            <p className="font-heading font-semibold leading-relaxed">
+              {transfer.to.slug}
+            </p>
+          </div>
+        </CardContent>
+      </Card>
 
-      <div className="flex flex-wrap gap-3">
+      <Card className="border">
+        <CardHeader title={<TransferDetailsLabel />} />
+        <CardContent>
+          <dl className="grid grid-cols-2 gap-4 text-sm">
+            <div>
+              <dt className="text-muted-foreground"><NamespaceLabel/></dt>
+              <dd>{isFromParty ? transfer.to.slug : transfer.from.slug}</dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground"><RequestedAtLabel/></dt>
+              <dd>
+                {transfer.requestedAt ? (
+                  <time dateTime={transfer.requestedAt}>
+                    <FormattedDate value={transfer.requestedAt} day="2-digit" month="short" year="numeric"/>
+                  </time>
+                ) : (
+                  <span className="text-muted-foreground">&mdash;</span>
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground"><StateLabel/></dt>
+              <dd><TransferStateBadge state={transfer.state}/></dd>
+            </div>
+            <div>
+              <dt className="text-muted-foreground"><ResolvedAtLabel/></dt>
+              <dd>
+                {transfer.resolvedAt ? (
+                  <time dateTime={transfer.resolvedAt}>
+                    <FormattedDate value={transfer.resolvedAt} day="2-digit" month="short" year="numeric"/>
+                  </time>
+                ) : (
+                  <span className="text-muted-foreground">&mdash;</span>
+                )}
+              </dd>
+            </div>
+          </dl>
+        </CardContent>
+
         {transfer.state === 'PENDING' && isFromParty && (
-          <>
+          <CardFooter className="gap-3">
             <AcceptTransferButton namespace={namespace.slug} transfer={transfer}>
               <Button>
                 <CheckIcon/>
@@ -93,18 +133,20 @@ export function TransferDetails({ namespace, transfer }: {
                 <RejectTransferLabel/>
               </Button>
             </RejectTransferButton>
-          </>
+          </CardFooter>
         )}
 
         {transfer.state === 'PENDING' && isToParty && (
-          <CancelTransferButton namespace={namespace.slug} transfer={transfer}>
-            <Button variant="destructive">
-              <XIcon/>
-              <CancelTransferLabel/>
-            </Button>
-          </CancelTransferButton>
+          <CardFooter>
+            <CancelTransferButton namespace={namespace.slug} transfer={transfer}>
+              <Button variant="destructive">
+                <XIcon/>
+                <CancelTransferLabel/>
+              </Button>
+            </CancelTransferButton>
+          </CardFooter>
         )}
-      </div>
+      </Card>
 
       <TransferAuditTrail
         namespace={namespace}

--- a/konfigyr-frontend/src/components/namespace/navigation/artifactory.tsx
+++ b/konfigyr-frontend/src/components/namespace/navigation/artifactory.tsx
@@ -47,9 +47,19 @@ export function NamespaceArtifactoryNavigationMenu({ namespace }: { namespace: N
                 />
               </Link>
             } />
-            <SidebarMenuButton disabled>
-              <span className="truncate">Artifact registry</span>
-            </SidebarMenuButton>
+            <SidebarMenuButton render={
+              <Link
+                to="/namespace/$namespace/artifactory/registry"
+                params={{ namespace: namespace.slug }}
+                className="truncate"
+                activeProps={{ 'data-active': true }}
+              >
+                <FormattedMessage
+                  defaultMessage="Artifact registry"
+                  description="Label for the Artifact registry page"
+                />
+              </Link>
+            } />
             <SidebarMenuButton disabled>
               <span className="truncate">Property search</span>
             </SidebarMenuButton>

--- a/konfigyr-frontend/src/hooks/artifactory/query.ts
+++ b/konfigyr-frontend/src/hooks/artifactory/query.ts
@@ -1,0 +1,125 @@
+import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import request from '@konfigyr/lib/http';
+
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+import type {
+  ArtifactDefinition,
+  ArtifactQuery,
+  ArtifactVersionQuery,
+  ChangeArtifactVisibilityPayload,
+  PropertyDescriptor,
+  PropertySearchQuery,
+  VersionedArtifact,
+} from './types';
+
+export const registryKeys = {
+  list: (namespace: string, query: ArtifactQuery) => ['namespace', namespace, 'registry', 'artifacts', query],
+  get: (namespace: string, groupId: string, artifactId: string) => ['namespace', namespace, 'registry', 'artifacts', groupId, artifactId],
+  versions: (namespace: string, groupId: string, artifactId: string, query: ArtifactVersionQuery) => [
+    ...registryKeys.get(namespace, groupId, artifactId), 'versions', query,
+  ],
+  version: (namespace: string, groupId: string, artifactId: string, version: string) => [
+    ...registryKeys.get(namespace, groupId, artifactId), version,
+  ],
+  properties: (namespace: string, query: PropertySearchQuery) => ['namespace', namespace, 'registry', 'properties', query],
+};
+
+export const getArtifacts = (namespace: string, query: ArtifactQuery = {}) => {
+  return queryOptions({
+    queryKey: registryKeys.list(namespace, query),
+    queryFn: async ({ signal }): Promise<PageResponse<ArtifactDefinition>> => {
+      return await request
+        .get(`api/namespaces/${namespace}/artifacts`, { signal, searchParams: { ...query } })
+        .json();
+    },
+    placeholderData: previousData => previousData,
+  });
+};
+
+export const getArtifact = (namespace: string, groupId: string, artifactId: string) => {
+  return queryOptions({
+    queryKey: registryKeys.get(namespace, groupId, artifactId),
+    queryFn: async ({ signal }): Promise<ArtifactDefinition> => {
+      return await request
+        .get(`api/namespaces/${namespace}/artifacts/${groupId}/${artifactId}`, { signal })
+        .json();
+    },
+  });
+};
+
+export const getArtifactVersions = (namespace: string, groupId: string, artifactId: string, query: ArtifactVersionQuery = {}) => {
+  return queryOptions({
+    queryKey: registryKeys.versions(namespace, groupId, artifactId, query),
+    queryFn: async ({ signal }): Promise<PageResponse<VersionedArtifact>> => {
+      return await request
+        .get(`api/namespaces/${namespace}/artifacts/${groupId}/${artifactId}/versions`, { signal, searchParams: { ...query } })
+        .json();
+    },
+    placeholderData: previousData => previousData,
+  });
+};
+
+export const getArtifactVersion = (namespace: string, groupId: string, artifactId: string, version: string) => {
+  return queryOptions({
+    queryKey: registryKeys.version(namespace, groupId, artifactId, version),
+    queryFn: async ({ signal }): Promise<VersionedArtifact> => {
+      return await request
+        .get(`api/namespaces/${namespace}/artifacts/${groupId}/${artifactId}/${version}`, { signal })
+        .json();
+    },
+  });
+};
+
+export const searchArtifactProperties = (namespace: string, query: PropertySearchQuery) => {
+  return queryOptions({
+    queryKey: registryKeys.properties(namespace, query),
+    queryFn: async ({ signal }): Promise<PageResponse<PropertyDescriptor>> => {
+      return await request
+        .get(`api/namespaces/${namespace}/artifacts/search`, { signal, searchParams: { ...query } })
+        .json();
+    },
+    enabled: query.term.trim().length > 0,
+    placeholderData: previousData => previousData,
+  });
+};
+
+export const useGetArtifacts = (namespace: string, query?: ArtifactQuery) => {
+  return useQuery(getArtifacts(namespace, query));
+};
+
+export const useGetArtifact = (namespace: string, groupId: string, artifactId: string) => {
+  return useQuery(getArtifact(namespace, groupId, artifactId));
+};
+
+export const useGetArtifactVersions = (namespace: string, groupId: string, artifactId: string, query?: ArtifactVersionQuery) => {
+  return useQuery(getArtifactVersions(namespace, groupId, artifactId, query));
+};
+
+export const useGetArtifactVersion = (namespace: string, groupId: string, artifactId: string, version: string) => {
+  return useQuery(getArtifactVersion(namespace, groupId, artifactId, version));
+};
+
+export const useSearchArtifactProperties = (namespace: string, query: PropertySearchQuery) => {
+  return useQuery(searchArtifactProperties(namespace, query));
+};
+
+export const useChangeArtifactVisibility = (namespace: string) => {
+  const client = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (payload: ChangeArtifactVisibilityPayload): Promise<void> => {
+      await request.put(`api/namespaces/${namespace}/artifacts/${payload.groupId}/${payload.artifactId}/visibility`, {
+        json: { visibility: payload.visibility },
+      });
+    },
+    onSuccess: async (_, payload) => {
+      client.setQueryData(
+        registryKeys.get(namespace, payload.groupId, payload.artifactId),
+        (artifact?: ArtifactDefinition) => artifact && { ...artifact, visibility: payload.visibility },
+      );
+      await client.invalidateQueries({
+        queryKey: ['namespace', namespace, 'registry', 'artifacts'],
+      });
+    },
+  });
+};

--- a/konfigyr-frontend/src/hooks/artifactory/types.ts
+++ b/konfigyr-frontend/src/hooks/artifactory/types.ts
@@ -1,3 +1,5 @@
+import type { Pageable } from '@konfigyr/hooks/hateoas/types';
+
 export interface Artifact {
   id: string;
   groupId: string;
@@ -7,6 +9,55 @@ export interface Artifact {
   description?: string;
   website?: string;
   repository?: string;
+}
+
+export type ArtifactVisibility = 'PUBLIC' | 'PRIVATE';
+
+export interface ArtifactDefinition {
+  id: string;
+  groupId: string;
+  artifactId: string;
+  visibility: ArtifactVisibility;
+  name?: string;
+  description?: string;
+  website?: string;
+  repository?: string;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface VersionedArtifact {
+  id: string;
+  groupId: string;
+  artifactId: string;
+  version: string;
+  visibility: ArtifactVisibility;
+  name?: string;
+  description?: string;
+  website?: string;
+  repository?: string;
+  publishedAt: string;
+}
+
+export interface ArtifactQuery extends Pageable {
+  term?: string;
+}
+
+export interface ArtifactVersionQuery extends Pageable {
+  term?: string;
+}
+
+export interface PropertySearchQuery extends Pageable {
+  groupId: string;
+  artifactId: string;
+  version?: string;
+  term: string;
+}
+
+export interface ChangeArtifactVisibilityPayload {
+  groupId: string;
+  artifactId: string;
+  visibility: ArtifactVisibility;
 }
 
 export interface PropertyJsonSchema {

--- a/konfigyr-frontend/src/hooks/index.ts
+++ b/konfigyr-frontend/src/hooks/index.ts
@@ -1,5 +1,6 @@
 export * from './account/context';
 export * from './account/query';
+export * from './artifactory/query';
 export * from './audit/query';
 export * from './groups/query';
 export * from './kms/query';

--- a/konfigyr-frontend/src/hooks/memberships/query.tsx
+++ b/konfigyr-frontend/src/hooks/memberships/query.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import request from '@konfigyr/lib/http';
 import { useAccount } from '@konfigyr/hooks/account/context';
@@ -102,15 +103,14 @@ export const useGetNamespaceMembers = (namespace: Namespace) => {
   return useQuery(getNamespaceMembers(namespace));
 };
 
-export const useCurrentNamespaceMember = (namespace: Namespace): Member | undefined => {
+export const useIsNamespaceAdmin = (namespace: Namespace): boolean => {
   const account = useAccount();
   const { data: members } = useGetNamespaceMembers(namespace);
-  return members?.find(member => member.email === account.email);
-};
 
-export const useIsNamespaceAdmin = (namespace: Namespace): boolean => {
-  const member = useCurrentNamespaceMember(namespace);
-  return member?.role === NamespaceRole.ADMIN;
+  return useMemo(() => {
+    const member = members?.find(it => it.email === account.email);
+    return member?.role === NamespaceRole.ADMIN;
+  }, [account, members]);
 };
 
 export const useInviteNamespaceMember = (namespace: Namespace) => {

--- a/konfigyr-frontend/src/hooks/memberships/query.tsx
+++ b/konfigyr-frontend/src/hooks/memberships/query.tsx
@@ -1,5 +1,6 @@
 import { queryOptions, useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import request from '@konfigyr/lib/http';
+import { useAccount } from '@konfigyr/hooks/account/context';
 import { NamespaceRole } from './types';
 
 import type { PageResponse, Pageable } from '@konfigyr/hooks/hateoas/types';
@@ -99,6 +100,17 @@ export const getNamespaceInvitation = (namespace: Namespace, key: string) => {
 
 export const useGetNamespaceMembers = (namespace: Namespace) => {
   return useQuery(getNamespaceMembers(namespace));
+};
+
+export const useCurrentNamespaceMember = (namespace: Namespace): Member | undefined => {
+  const account = useAccount();
+  const { data: members } = useGetNamespaceMembers(namespace);
+  return members?.find(member => member.email === account.email);
+};
+
+export const useIsNamespaceAdmin = (namespace: Namespace): boolean => {
+  const member = useCurrentNamespaceMember(namespace);
+  return member?.role === NamespaceRole.ADMIN;
 };
 
 export const useInviteNamespaceMember = (namespace: Namespace) => {

--- a/konfigyr-frontend/src/lib/authentication.ts
+++ b/konfigyr-frontend/src/lib/authentication.ts
@@ -20,7 +20,7 @@ import type {
 
 const logger = createLogger('services/authentication');
 
-const DEFAULT_SCOPES = 'openid namespaces profiles';
+const DEFAULT_SCOPES = 'openid namespaces profiles artifactory:publish';
 
 export class AuthenticationError extends Error {
 

--- a/konfigyr-frontend/src/routeTree.gen.ts
+++ b/konfigyr-frontend/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as AuthenticatedNamespaceNamespaceApplicationsIdRouteImport } fro
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceRouteRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/route'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceIndexRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/index'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/transfers/index'
+import { Route as AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/registry/index'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/groups/index'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceSettingsRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/settings'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/create-profile'
@@ -50,9 +51,12 @@ import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdIndexRo
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceManifestArtifactsRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/manifest/artifacts'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/groups/$groupId/edit'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/profiles/$profile/route'
+import { Route as AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/route'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceRequestsNumberIndexRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/requests/$number/index'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileIndexRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/profiles/$profile/index'
+import { Route as AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/index'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/profiles/$profile/history'
+import { Route as AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/index'
 
 const ErrorRoute = ErrorRouteImport.update({
   id: '/error',
@@ -203,6 +207,12 @@ const AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute =
     path: '/artifactory/transfers/',
     getParentRoute: () => AuthenticatedNamespaceNamespaceRouteRoute,
   } as any)
+const AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute =
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRouteImport.update({
+    id: '/artifactory/registry/',
+    path: '/artifactory/registry/',
+    getParentRoute: () => AuthenticatedNamespaceNamespaceRouteRoute,
+  } as any)
 const AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute =
   AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRouteImport.update({
     id: '/artifactory/groups/',
@@ -325,6 +335,14 @@ const AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRoute =
         AuthenticatedNamespaceNamespaceServicesServiceRouteRoute,
     } as any,
   )
+const AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute =
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteImport.update(
+    {
+      id: '/artifactory/registry/$groupId/$artifactId',
+      path: '/artifactory/registry/$groupId/$artifactId',
+      getParentRoute: () => AuthenticatedNamespaceNamespaceRouteRoute,
+    } as any,
+  )
 const AuthenticatedNamespaceNamespaceServicesServiceRequestsNumberIndexRoute =
   AuthenticatedNamespaceNamespaceServicesServiceRequestsNumberIndexRouteImport.update(
     {
@@ -343,6 +361,15 @@ const AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileIndexRoute =
         AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRoute,
     } as any,
   )
+const AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRoute =
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRouteImport.update(
+    {
+      id: '/',
+      path: '/',
+      getParentRoute: () =>
+        AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute,
+    } as any,
+  )
 const AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRoute =
   AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRouteImport.update(
     {
@@ -350,6 +377,15 @@ const AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRoute 
       path: '/history',
       getParentRoute: () =>
         AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRoute,
+    } as any,
+  )
+const AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRoute =
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRouteImport.update(
+    {
+      id: '/$version/',
+      path: '/$version/',
+      getParentRoute: () =>
+        AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute,
     } as any,
   )
 
@@ -385,8 +421,10 @@ export interface FileRoutesByFullPath {
   '/namespace/$namespace/services/$service/create-profile': typeof AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRoute
   '/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/namespace/$namespace/artifactory/groups/': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
+  '/namespace/$namespace/artifactory/registry/': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute
   '/namespace/$namespace/artifactory/transfers/': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/namespace/$namespace/services/$service/': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
+  '/namespace/$namespace/artifactory/registry/$groupId/$artifactId': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteWithChildren
   '/namespace/$namespace/services/$service/profiles/$profile': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRouteWithChildren
   '/namespace/$namespace/artifactory/groups/$groupId/edit': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRoute
   '/namespace/$namespace/services/$service/manifest/artifacts': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestArtifactsRoute
@@ -395,8 +433,10 @@ export interface FileRoutesByFullPath {
   '/namespace/$namespace/services/$service/manifest/': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRoute
   '/namespace/$namespace/services/$service/requests/': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsIndexRoute
   '/namespace/$namespace/services/$service/profiles/$profile/history': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRoute
+  '/namespace/$namespace/artifactory/registry/$groupId/$artifactId/': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRoute
   '/namespace/$namespace/services/$service/profiles/$profile/': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileIndexRoute
   '/namespace/$namespace/services/$service/requests/$number/': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsNumberIndexRoute
+  '/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRoute
 }
 export interface FileRoutesByTo {
   '/error': typeof ErrorRoute
@@ -423,6 +463,7 @@ export interface FileRoutesByTo {
   '/namespace/$namespace/services/$service/create-profile': typeof AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRoute
   '/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/namespace/$namespace/artifactory/groups': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
+  '/namespace/$namespace/artifactory/registry': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute
   '/namespace/$namespace/artifactory/transfers': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/namespace/$namespace/services/$service': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
   '/namespace/$namespace/artifactory/groups/$groupId/edit': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRoute
@@ -432,8 +473,10 @@ export interface FileRoutesByTo {
   '/namespace/$namespace/services/$service/manifest': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRoute
   '/namespace/$namespace/services/$service/requests': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsIndexRoute
   '/namespace/$namespace/services/$service/profiles/$profile/history': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRoute
+  '/namespace/$namespace/artifactory/registry/$groupId/$artifactId': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRoute
   '/namespace/$namespace/services/$service/profiles/$profile': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileIndexRoute
   '/namespace/$namespace/services/$service/requests/$number': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsNumberIndexRoute
+  '/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -469,8 +512,10 @@ export interface FileRoutesById {
   '/_authenticated/namespace/$namespace/services/$service/create-profile': typeof AuthenticatedNamespaceNamespaceServicesServiceCreateProfileRoute
   '/_authenticated/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/_authenticated/namespace/$namespace/artifactory/groups/': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
+  '/_authenticated/namespace/$namespace/artifactory/registry/': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute
   '/_authenticated/namespace/$namespace/artifactory/transfers/': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
+  '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteWithChildren
   '/_authenticated/namespace/$namespace/services/$service/profiles/$profile': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRouteWithChildren
   '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/edit': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRoute
   '/_authenticated/namespace/$namespace/services/$service/manifest/artifacts': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestArtifactsRoute
@@ -479,8 +524,10 @@ export interface FileRoutesById {
   '/_authenticated/namespace/$namespace/services/$service/manifest/': typeof AuthenticatedNamespaceNamespaceServicesServiceManifestIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/requests/': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/profiles/$profile/history': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRoute
+  '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/profiles/$profile/': typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/requests/$number/': typeof AuthenticatedNamespaceNamespaceServicesServiceRequestsNumberIndexRoute
+  '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -516,8 +563,10 @@ export interface FileRouteTypes {
     | '/namespace/$namespace/services/$service/create-profile'
     | '/namespace/$namespace/services/$service/settings'
     | '/namespace/$namespace/artifactory/groups/'
+    | '/namespace/$namespace/artifactory/registry/'
     | '/namespace/$namespace/artifactory/transfers/'
     | '/namespace/$namespace/services/$service/'
+    | '/namespace/$namespace/artifactory/registry/$groupId/$artifactId'
     | '/namespace/$namespace/services/$service/profiles/$profile'
     | '/namespace/$namespace/artifactory/groups/$groupId/edit'
     | '/namespace/$namespace/services/$service/manifest/artifacts'
@@ -526,8 +575,10 @@ export interface FileRouteTypes {
     | '/namespace/$namespace/services/$service/manifest/'
     | '/namespace/$namespace/services/$service/requests/'
     | '/namespace/$namespace/services/$service/profiles/$profile/history'
+    | '/namespace/$namespace/artifactory/registry/$groupId/$artifactId/'
     | '/namespace/$namespace/services/$service/profiles/$profile/'
     | '/namespace/$namespace/services/$service/requests/$number/'
+    | '/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/error'
@@ -554,6 +605,7 @@ export interface FileRouteTypes {
     | '/namespace/$namespace/services/$service/create-profile'
     | '/namespace/$namespace/services/$service/settings'
     | '/namespace/$namespace/artifactory/groups'
+    | '/namespace/$namespace/artifactory/registry'
     | '/namespace/$namespace/artifactory/transfers'
     | '/namespace/$namespace/services/$service'
     | '/namespace/$namespace/artifactory/groups/$groupId/edit'
@@ -563,8 +615,10 @@ export interface FileRouteTypes {
     | '/namespace/$namespace/services/$service/manifest'
     | '/namespace/$namespace/services/$service/requests'
     | '/namespace/$namespace/services/$service/profiles/$profile/history'
+    | '/namespace/$namespace/artifactory/registry/$groupId/$artifactId'
     | '/namespace/$namespace/services/$service/profiles/$profile'
     | '/namespace/$namespace/services/$service/requests/$number'
+    | '/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version'
   id:
     | '__root__'
     | '/_authenticated'
@@ -599,8 +653,10 @@ export interface FileRouteTypes {
     | '/_authenticated/namespace/$namespace/services/$service/create-profile'
     | '/_authenticated/namespace/$namespace/services/$service/settings'
     | '/_authenticated/namespace/$namespace/artifactory/groups/'
+    | '/_authenticated/namespace/$namespace/artifactory/registry/'
     | '/_authenticated/namespace/$namespace/artifactory/transfers/'
     | '/_authenticated/namespace/$namespace/services/$service/'
+    | '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId'
     | '/_authenticated/namespace/$namespace/services/$service/profiles/$profile'
     | '/_authenticated/namespace/$namespace/artifactory/groups/$groupId/edit'
     | '/_authenticated/namespace/$namespace/services/$service/manifest/artifacts'
@@ -609,8 +665,10 @@ export interface FileRouteTypes {
     | '/_authenticated/namespace/$namespace/services/$service/manifest/'
     | '/_authenticated/namespace/$namespace/services/$service/requests/'
     | '/_authenticated/namespace/$namespace/services/$service/profiles/$profile/history'
+    | '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/'
     | '/_authenticated/namespace/$namespace/services/$service/profiles/$profile/'
     | '/_authenticated/namespace/$namespace/services/$service/requests/$number/'
+    | '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -805,6 +863,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceRouteRoute
     }
+    '/_authenticated/namespace/$namespace/artifactory/registry/': {
+      id: '/_authenticated/namespace/$namespace/artifactory/registry/'
+      path: '/artifactory/registry'
+      fullPath: '/namespace/$namespace/artifactory/registry/'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceRouteRoute
+    }
     '/_authenticated/namespace/$namespace/artifactory/groups/': {
       id: '/_authenticated/namespace/$namespace/artifactory/groups/'
       path: '/artifactory/groups'
@@ -910,6 +975,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceRouteRoute
     }
+    '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId': {
+      id: '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId'
+      path: '/artifactory/registry/$groupId/$artifactId'
+      fullPath: '/namespace/$namespace/artifactory/registry/$groupId/$artifactId'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceRouteRoute
+    }
     '/_authenticated/namespace/$namespace/services/$service/requests/$number/': {
       id: '/_authenticated/namespace/$namespace/services/$service/requests/$number/'
       path: '/requests/$number'
@@ -924,12 +996,26 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileIndexRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRoute
     }
+    '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/': {
+      id: '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/'
+      path: '/'
+      fullPath: '/namespace/$namespace/artifactory/registry/$groupId/$artifactId/'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute
+    }
     '/_authenticated/namespace/$namespace/services/$service/profiles/$profile/history': {
       id: '/_authenticated/namespace/$namespace/services/$service/profiles/$profile/history'
       path: '/history'
       fullPath: '/namespace/$namespace/services/$service/profiles/$profile/history'
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileHistoryRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceServicesServiceProfilesProfileRouteRoute
+    }
+    '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/': {
+      id: '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/'
+      path: '/$version'
+      fullPath: '/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute
     }
   }
 }
@@ -1078,6 +1164,24 @@ const AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteWit
     AuthenticatedNamespaceNamespaceArtifactoryTransfersTransferIdRouteRouteChildren,
   )
 
+interface AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteChildren {
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRoute
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRoute
+}
+
+const AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteChildren: AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteChildren =
+  {
+    AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRoute:
+      AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdIndexRoute,
+    AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRoute:
+      AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdVersionIndexRoute,
+  }
+
+const AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteWithChildren =
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute._addFileChildren(
+    AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteChildren,
+  )
+
 interface AuthenticatedNamespaceNamespaceRouteRouteChildren {
   AuthenticatedNamespaceNamespaceApplicationsRouteRoute: typeof AuthenticatedNamespaceNamespaceApplicationsRouteRouteWithChildren
   AuthenticatedNamespaceNamespaceKmsRouteRoute: typeof AuthenticatedNamespaceNamespaceKmsRouteRouteWithChildren
@@ -1092,7 +1196,9 @@ interface AuthenticatedNamespaceNamespaceRouteRouteChildren {
   AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsCreateRoute
   AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute
   AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute
   AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
+  AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteWithChildren
 }
 
 const AuthenticatedNamespaceNamespaceRouteRouteChildren: AuthenticatedNamespaceNamespaceRouteRouteChildren =
@@ -1123,8 +1229,12 @@ const AuthenticatedNamespaceNamespaceRouteRouteChildren: AuthenticatedNamespaceN
       AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute,
     AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute:
       AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute,
+    AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute:
+      AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute,
     AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute:
       AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute,
+    AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute:
+      AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteWithChildren,
   }
 
 const AuthenticatedNamespaceNamespaceRouteRouteWithChildren =

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/index.tsx
@@ -1,0 +1,71 @@
+import { FormattedMessage } from 'react-intl';
+import { TagIcon } from 'lucide-react';
+import { Link, createFileRoute } from '@tanstack/react-router';
+import { useGetArtifactVersion, useNamespace } from '@konfigyr/hooks';
+import { ErrorState } from '@konfigyr/components/error';
+import { BreadcrumbItem, BreadcrumbLink, BreadcrumbSeparator } from '@konfigyr/components/ui/breadcrumb';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import { RegistryBreadcrumbs } from '@konfigyr/components/artifactory/registry/breadcrumbs';
+import { VersionDetail } from '@konfigyr/components/artifactory/registry/version-detail';
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/',
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent () {
+  const namespace = useNamespace();
+  const { groupId, artifactId, version } = Route.useParams();
+
+  const { data: artifactVersion, error, isError, isPending } = useGetArtifactVersion(namespace.slug, groupId, artifactId, version);
+
+  return (
+    <>
+      <RegistryBreadcrumbs namespace={namespace}>
+        <BreadcrumbItem>
+          <BreadcrumbLink
+            render={
+              <Link
+                to="/namespace/$namespace/artifactory/registry/$groupId/$artifactId"
+                params={{ namespace: namespace.slug, groupId, artifactId }}
+              >
+                {groupId}:{artifactId}
+              </Link>
+            }
+          />
+        </BreadcrumbItem>
+        <BreadcrumbSeparator/>
+        {version}
+      </RegistryBreadcrumbs>
+
+      <div className="mx-auto w-full space-y-6 lg:w-2/3 xl:w-3/5">
+        {isPending && (
+          <EmptyState
+            icon={<TagIcon/>}
+            title={(
+              <FormattedMessage
+                defaultMessage="Loading artifact version"
+                description="Loading state title for the artifact version detail page."
+              />
+            )}
+            description={(
+              <FormattedMessage
+                defaultMessage="Fetching the current artifact version metadata."
+                description="Loading state description for the artifact version detail page."
+              />
+            )}
+          />
+        )}
+
+        {isError && (
+          <ErrorState error={error} className="border-none"/>
+        )}
+
+        {artifactVersion && (
+          <VersionDetail namespace={namespace.slug} version={artifactVersion}/>
+        )}
+      </div>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/index.tsx
@@ -1,0 +1,83 @@
+import { FormattedMessage } from 'react-intl';
+import { PackageIcon } from 'lucide-react';
+import { createFileRoute } from '@tanstack/react-router';
+import { useGetArtifact, useGetArtifactVersions, useNamespace } from '@konfigyr/hooks';
+import { ErrorState } from '@konfigyr/components/error';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import { RegistryBreadcrumbs } from '@konfigyr/components/artifactory/registry/breadcrumbs';
+import { ArtifactOverview } from '@konfigyr/components/artifactory/registry/artifact-overview';
+import { VersionTable } from '@konfigyr/components/artifactory/registry/version-table';
+import { VersionsLabel } from '@konfigyr/components/artifactory/registry/messages';
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/',
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent () {
+  const namespace = useNamespace();
+  const { groupId, artifactId } = Route.useParams();
+
+  const {
+    data: artifact,
+    error: artifactError,
+    isError: isArtifactError,
+    isPending: isArtifactPending,
+  } = useGetArtifact(namespace.slug, groupId, artifactId);
+
+  const {
+    data: versions,
+    error: versionsError,
+    isPending: isVersionsPending,
+  } = useGetArtifactVersions(namespace.slug, groupId, artifactId);
+
+  return (
+    <>
+      <RegistryBreadcrumbs namespace={namespace}>
+        {groupId}:{artifactId}
+      </RegistryBreadcrumbs>
+
+      <div className="mx-auto w-full space-y-6 lg:w-2/3 xl:w-3/5">
+        {isArtifactPending && (
+          <EmptyState
+            icon={<PackageIcon/>}
+            title={(
+              <FormattedMessage
+                defaultMessage="Loading artifact"
+                description="Loading state title for the artifact overview page."
+              />
+            )}
+            description={(
+              <FormattedMessage
+                defaultMessage="Fetching the current artifact metadata."
+                description="Loading state description for the artifact overview page."
+              />
+            )}
+          />
+        )}
+
+        {isArtifactError && (
+          <ErrorState error={artifactError} className="border-none"/>
+        )}
+
+        {artifact && (
+          <>
+            <ArtifactOverview namespace={namespace} artifact={artifact}/>
+
+            <h2 className="text-lg font-medium">
+              <VersionsLabel/>
+            </h2>
+
+            <VersionTable
+              namespace={namespace.slug}
+              data={versions}
+              error={versionsError}
+              isPending={isVersionsPending}
+            />
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/route.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/route.tsx
@@ -1,0 +1,20 @@
+import { Outlet, createFileRoute } from '@tanstack/react-router';
+import { LayoutContent, LayoutNavbar } from '@konfigyr/components/layout';
+import { RegistryLabel } from '@konfigyr/components/artifactory/registry/messages';
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId',
+)({
+  component: RouteComponent,
+});
+
+function RouteComponent () {
+  return (
+    <LayoutContent>
+      <LayoutNavbar title={( <RegistryLabel /> )} />
+      <div className="mx-4 space-y-6">
+        <Outlet />
+      </div>
+    </LayoutContent>
+  );
+}

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/index.tsx
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+import { useCallback } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useGetArtifacts, useNamespace } from '@konfigyr/hooks';
+import { LayoutContent, LayoutNavbar } from '@konfigyr/components/layout';
+import { ArtifactFilters } from '@konfigyr/components/artifactory/registry/artifact-filters';
+import { ArtifactTable } from '@konfigyr/components/artifactory/registry/artifact-table';
+import { RegistryLabel } from '@konfigyr/components/artifactory/registry/messages';
+
+import type { ArtifactQuery } from '@konfigyr/hooks/artifactory/types';
+
+const searchQuerySchema = z.object({
+  term: z.string().min(2).optional().catch(undefined),
+  page: z.number().optional().catch(undefined),
+  size: z.number().optional().catch(undefined),
+});
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/registry/',
+)({
+  validateSearch: searchQuerySchema,
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const namespace = useNamespace();
+  const query: ArtifactQuery = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const { data, isPending, error } = useGetArtifacts(namespace.slug, query);
+
+  const onQueryChange = useCallback(async (value: ArtifactQuery) => {
+    await navigate({
+      search: current => ({ ...current, ...value, page: 1 }),
+      viewTransition: false,
+    });
+  }, []);
+
+  return (
+    <LayoutContent>
+      <LayoutNavbar title={( <RegistryLabel/> )}/>
+      <div className="w-full lg:w-4/5 xl:w-2/3 space-y-6 px-4 mx-auto">
+        <p className="text-sm text-muted-foreground max-w-2xl">
+          <FormattedMessage
+            defaultMessage="Browse every artifact this namespace has published, public and private, and drill into a version to inspect its configuration property definitions."
+            description="Description of the artifact registry page."
+          />
+        </p>
+
+        <div className="flex justify-between items-center gap-4">
+          <ArtifactFilters
+            query={query}
+            onQueryChange={onQueryChange}
+          />
+        </div>
+
+        <ArtifactTable
+          namespace={namespace.slug}
+          data={data}
+          isPending={isPending}
+          error={error}
+          page={query.page}
+          size={query.size}
+        />
+      </div>
+    </LayoutContent>
+  );
+}

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/transfers/index.tsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { Link, createFileRoute, useNavigate } from '@tanstack/react-router';
 import { useGetIncomingTransfers, useGetOutgoingTransfers, useNamespace } from '@konfigyr/hooks';
 import { LayoutContent, LayoutNavbar } from '@konfigyr/components/layout';
+import { Badge } from '@konfigyr/components/ui/badge';
 import { buttonVariants } from '@konfigyr/components/ui/button';
 import { TransferFilters } from '@konfigyr/components/artifactory/transfers/transfer-filters';
 import { TransferTable } from '@konfigyr/components/artifactory/transfers/transfer-table';
@@ -25,7 +26,27 @@ export const Route = createFileRoute(
   component: RouteComponent,
 });
 
-function DirectionToggle ({ direction }: { direction: 'incoming' | 'outgoing' }) {
+function TransferCountBadge({ count, active }: { count: number; active: boolean }) {
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <Badge
+      aria-hidden
+      className="rounded-full size-5"
+      variant={active ? 'ghost' : 'secondary'}
+    >
+      {count}
+    </Badge>
+  );
+}
+
+function DirectionToggle ({ direction, incoming, outgoing }: {
+  direction: 'incoming' | 'outgoing';
+  incoming: number;
+  outgoing: number;
+}) {
   return (
     <div className="flex gap-1">
       <Link
@@ -34,6 +55,7 @@ function DirectionToggle ({ direction }: { direction: 'incoming' | 'outgoing' })
         className={buttonVariants({ variant: direction === 'incoming' ? 'secondary' : 'ghost' })}
       >
         <IncomingLabel/>
+        <TransferCountBadge count={incoming} active={direction === 'incoming'}/>
       </Link>
       <Link
         to="."
@@ -41,6 +63,7 @@ function DirectionToggle ({ direction }: { direction: 'incoming' | 'outgoing' })
         className={buttonVariants({ variant: direction === 'outgoing' ? 'secondary' : 'ghost' })}
       >
         <OutgoingLabel/>
+        <TransferCountBadge count={outgoing} active={direction === 'outgoing'}/>
       </Link>
     </div>
   );
@@ -70,12 +93,16 @@ function RouteComponent() {
       <div className="w-full lg:w-4/5 xl:w-2/3 space-y-6 px-4 mx-auto">
         <p className="text-sm text-muted-foreground max-w-2xl">
           <FormattedMessage
-            defaultMessage="Request, accept, reject, or cancel ownership transfers of Maven groupId coordinates between namespaces."
+            defaultMessage="Request, accept, reject, or cancel ownership transfers of Maven groupId coordinates between namespaces. Incoming requests ask you to release artifacts you own; outgoing requests are ones you've made."
             description="Description of the ownership transfers page."
           />
         </p>
 
-        <DirectionToggle direction={direction}/>
+        <DirectionToggle
+          direction={direction}
+          incoming={incoming.data?.metadata.total || 0}
+          outgoing={outgoing.data?.metadata.total || 0}
+        />
 
         <div className="flex justify-between items-center gap-4">
           <TransferFilters

--- a/konfigyr-frontend/test/components/artifactory/registry/artifact-overview.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/registry/artifact-overview.test.tsx
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import { AccountContext, membershipKeys } from '@konfigyr/hooks';
+import { createTestQueryClient, renderWithQueryClient } from '@konfigyr/test/helpers/query-client';
+import { accounts, artifacts, namespaces } from '@konfigyr/test/helpers/mocks';
+import { ArtifactOverview } from '@konfigyr/components/artifactory/registry/artifact-overview';
+
+import type { ReactNode } from 'react';
+
+function withAccount(children: ReactNode) {
+  return (
+    <AccountContext.Provider value={{ account: accounts.johnDoe, memberships: [namespaces.konfigyr, namespaces.johnDoe] }}>
+      {children}
+    </AccountContext.Provider>
+  );
+}
+
+describe('components | registry | <ArtifactOverview/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render artifact metadata', () => {
+    const { getByRole, getByText } = renderWithQueryClient(withAccount(
+      <ArtifactOverview namespace={namespaces.konfigyr} artifact={artifacts.publicArtifact}/>,
+    ));
+
+    expect(getByRole('heading', { name: 'com.example:public-service' })).toBeInTheDocument();
+    expect(getByText('A publicly readable artifact.')).toBeInTheDocument();
+    expect(getByRole('link', { name: artifacts.publicArtifact.website })).toBeInTheDocument();
+  });
+
+  test('should show the change visibility action for an admin of the owning namespace', async () => {
+    const { findByRole } = renderWithQueryClient(withAccount(
+      <ArtifactOverview namespace={namespaces.konfigyr} artifact={artifacts.publicArtifact}/>,
+    ));
+
+    expect(await findByRole('button', { name: 'Make private' })).toBeInTheDocument();
+  });
+
+  test('should not show the change visibility action for a non-admin member', async () => {
+    const queryClient = createTestQueryClient();
+
+    const { queryByRole } = renderWithQueryClient(withAccount(
+      <ArtifactOverview namespace={namespaces.johnDoe} artifact={artifacts.publicArtifact}/>,
+    ), { queryClient });
+
+    await waitFor(() => {
+      expect(queryClient.getQueryData(membershipKeys.getNamespaceMembers(namespaces.johnDoe.slug))).toBeDefined();
+    });
+
+    expect(queryByRole('button', { name: 'Make private' })).not.toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/registry/artifact-table.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/registry/artifact-table.test.tsx
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
+import { artifacts } from '@konfigyr/test/helpers/mocks';
+import { ArtifactTable } from '@konfigyr/components/artifactory/registry/artifact-table';
+
+import type { ArtifactDefinition } from '@konfigyr/hooks/artifactory/types';
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+
+function page(data: Array<ArtifactDefinition>): PageResponse<ArtifactDefinition> {
+  return { data, metadata: { number: 1, size: 20, total: data.length, pages: 1 } };
+}
+
+describe('components | registry | <ArtifactTable/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render artifacts with their coordinates and visibility indicator', () => {
+    const { getByText } = renderComponentWithRouter(
+      <ArtifactTable namespace="konfigyr" data={page([artifacts.publicArtifact, artifacts.privateArtifact])} isPending={false}/>,
+    );
+
+    expect(getByText('com.example:public-service')).toBeInTheDocument();
+    expect(getByText('Public')).toBeInTheDocument();
+    expect(getByText('com.example:private-service')).toBeInTheDocument();
+    expect(getByText('Private')).toBeInTheDocument();
+  });
+
+  test('should render an empty state when no artifacts exist', () => {
+    const { getByText } = renderComponentWithRouter(
+      <ArtifactTable namespace="konfigyr" data={page([])} isPending={false}/>,
+    );
+
+    expect(getByText('No artifacts found')).toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/registry/change-visibility-button.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/registry/change-visibility-button.test.tsx
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { cleanup, waitFor, within } from '@testing-library/react';
+import userEvents from '@testing-library/user-event';
+import { renderWithQueryClient } from '@konfigyr/test/helpers/query-client';
+import { artifacts, namespaces } from '@konfigyr/test/helpers/mocks';
+import { ChangeVisibilityButton } from '@konfigyr/components/artifactory/registry/change-visibility-button';
+
+const toast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+
+vi.mock('sonner', () => ({ toast }));
+
+describe('components | registry | <ChangeVisibilityButton/>', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  test('should offer to make a PUBLIC artifact private', async () => {
+    const user = userEvents.setup();
+
+    const { getByRole } = renderWithQueryClient(
+      <ChangeVisibilityButton namespace={namespaces.konfigyr.slug} artifact={artifacts.publicArtifact}/>,
+    );
+
+    await user.click(getByRole('button', { name: 'Make private' }));
+
+    const dialog = await waitFor(() => getByRole('alertdialog'));
+    expect(dialog).toHaveAccessibleName('Change artifact visibility');
+  });
+
+  test('should submit the visibility change successfully', async () => {
+    const user = userEvents.setup();
+
+    const { getByRole } = renderWithQueryClient(
+      <ChangeVisibilityButton namespace={namespaces.konfigyr.slug} artifact={artifacts.publicArtifact}/>,
+    );
+
+    await user.click(getByRole('button', { name: 'Make private' }));
+
+    const dialog = await waitFor(() => getByRole('alertdialog'));
+    await user.click(within(dialog).getByRole('button', { name: 'Make private' }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledOnce();
+    });
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  test('should report an error when the artifact can not be found', async () => {
+    const user = userEvents.setup();
+
+    const unknownArtifact = { ...artifacts.publicArtifact, groupId: 'unknown.group' };
+
+    const { getByRole } = renderWithQueryClient(
+      <ChangeVisibilityButton namespace={namespaces.konfigyr.slug} artifact={unknownArtifact}/>,
+    );
+
+    await user.click(getByRole('button', { name: 'Make private' }));
+
+    const dialog = await waitFor(() => getByRole('alertdialog'));
+    await user.click(within(dialog).getByRole('button', { name: 'Make private' }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledOnce();
+    });
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/registry/version-detail.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/registry/version-detail.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import userEvents from '@testing-library/user-event';
+import { renderWithQueryClient } from '@konfigyr/test/helpers/query-client';
+import { artifacts, namespaces } from '@konfigyr/test/helpers/mocks';
+import { VersionDetail } from '@konfigyr/components/artifactory/registry/version-detail';
+
+describe('components | registry | <VersionDetail/>', () => {
+  afterEach(() => cleanup());
+
+  test('should prompt for a search term before showing any properties', () => {
+    const { getByText, queryByText } = renderWithQueryClient(
+      <VersionDetail namespace={namespaces.konfigyr.slug} version={artifacts.publicArtifactVersionTwo}/>,
+    );
+
+    expect(getByText('Search this version\'s properties')).toBeInTheDocument();
+    expect(queryByText('example.timeout')).not.toBeInTheDocument();
+  });
+
+  test('should show matching properties once a search term is entered', async () => {
+    const user = userEvents.setup();
+
+    const { getByRole, getByText } = renderWithQueryClient(
+      <VersionDetail namespace={namespaces.konfigyr.slug} version={artifacts.publicArtifactVersionTwo}/>,
+    );
+
+    await user.type(getByRole('searchbox'), 'timeout');
+
+    await waitFor(() => {
+      expect(getByText('example.timeout')).toBeInTheDocument();
+    });
+  });
+
+  test('should show an empty state when no properties match the search term', async () => {
+    const user = userEvents.setup();
+
+    const { getByRole, getByText } = renderWithQueryClient(
+      <VersionDetail namespace={namespaces.konfigyr.slug} version={artifacts.publicArtifactVersionTwo}/>,
+    );
+
+    await user.type(getByRole('searchbox'), 'no-such-property');
+
+    await waitFor(() => {
+      expect(getByText('No matching properties found')).toBeInTheDocument();
+    });
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/registry/version-table.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/registry/version-table.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
+import { artifacts } from '@konfigyr/test/helpers/mocks';
+import { VersionTable } from '@konfigyr/components/artifactory/registry/version-table';
+
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+import type { VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
+
+function page(data: Array<VersionedArtifact>): PageResponse<VersionedArtifact> {
+  return { data, metadata: { number: 1, size: 20, total: data.length, pages: 1 } };
+}
+
+describe('components | registry | <VersionTable/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render versions newest first as provided by the caller', () => {
+    const { getByText, getAllByRole } = renderComponentWithRouter(
+      <VersionTable
+        namespace="konfigyr"
+        data={page([artifacts.publicArtifactVersionTwo, artifacts.publicArtifactVersionOne])}
+        isPending={false}
+      />,
+    );
+
+    expect(getByText('2.0.0')).toBeInTheDocument();
+    expect(getByText('1.0.0')).toBeInTheDocument();
+    expect(getAllByRole('row')).toHaveLength(3); // header + 2 versions
+  });
+
+  test('should not render pagination controls for a single version', () => {
+    const { queryByRole } = renderComponentWithRouter(
+      <VersionTable namespace="konfigyr" data={page([artifacts.singleVersion])} isPending={false}/>,
+    );
+
+    expect(queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  test('should render an empty state when no versions exist', () => {
+    const { getByText } = renderComponentWithRouter(
+      <VersionTable namespace="konfigyr" data={page([])} isPending={false}/>,
+    );
+
+    expect(getByText('No versions found')).toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/registry/visibility-badge.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/registry/visibility-badge.test.tsx
@@ -1,0 +1,18 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { renderWithQueryClient } from '@konfigyr/test/helpers/query-client';
+import { ArtifactVisibilityBadge } from '@konfigyr/components/artifactory/registry/visibility-badge';
+
+describe('components | registry | <ArtifactVisibilityBadge/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render the Public label for a PUBLIC artifact', () => {
+    const { getByText } = renderWithQueryClient(<ArtifactVisibilityBadge visibility="PUBLIC"/>);
+    expect(getByText('Public')).toBeInTheDocument();
+  });
+
+  test('should render the Private label for a PRIVATE artifact', () => {
+    const { getByText } = renderWithQueryClient(<ArtifactVisibilityBadge visibility="PRIVATE"/>);
+    expect(getByText('Private')).toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/transfers/transfer-actions.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/transfers/transfer-actions.test.tsx
@@ -81,7 +81,9 @@ describe('components | transfers | <AcceptTransferButton/>', () => {
 
     await user.click(getByRole('button', { name: 'Accept transfer' }));
 
-    const submitButton = await waitFor(() => getByRole('button', { name: 'Accept' }));
+    const submitButton = await waitFor(() => getByRole(
+      'button', { name: 'Accept and move artifacts' },
+    ));
     await user.click(submitButton);
 
     await waitFor(() => {
@@ -109,7 +111,9 @@ describe('components | transfers | <AcceptTransferButton/>', () => {
 
     await user.click(getByRole('button', { name: 'Accept transfer' }));
 
-    const submitButton = await waitFor(() => getByRole('button', { name: 'Accept' }));
+    const submitButton = await waitFor(() => getByRole(
+      'button', { name: 'Accept and move artifacts' },
+    ));
     await user.click(submitButton);
 
     await waitFor(() => {

--- a/konfigyr-frontend/test/components/artifactory/transfers/transfer-details.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/transfers/transfer-details.test.tsx
@@ -14,7 +14,7 @@ describe('components | transfers | <TransferDetails/>', () => {
       <TransferDetails namespace={namespaces.konfigyr} transfer={transfers.incomingPending}/>,
     );
 
-    expect(getByRole('button', { name: 'Accept' })).toBeInTheDocument();
+    expect(getByRole('button', { name: 'Accept and move artifacts' })).toBeInTheDocument();
     expect(getByRole('button', { name: 'Reject' })).toBeInTheDocument();
     expect(queryByRole('button', { name: 'Cancel request' })).not.toBeInTheDocument();
   });

--- a/konfigyr-frontend/test/components/namespace/navigation/artifactory.test.tsx
+++ b/konfigyr-frontend/test/components/namespace/navigation/artifactory.test.tsx
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { Layout } from '@konfigyr/components/layout';
+import { NamespaceArtifactoryNavigationMenu } from '@konfigyr/components/namespace/navigation/artifactory';
+import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
+import { namespaces } from '@konfigyr/test/helpers/mocks';
+
+describe('components | namespace | navigation | <NamespaceArtifactoryNavigationMenu/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render a link to the artifact registry', () => {
+    const { getByRole } = renderComponentWithRouter(
+      <Layout>
+        <NamespaceArtifactoryNavigationMenu namespace={namespaces.konfigyr}/>
+      </Layout>,
+    );
+
+    expect(getByRole('link', { name: 'Artifact registry' }).getAttribute('href'))
+      .toBe('/namespace/konfigyr/artifactory/registry');
+  });
+
+  test('should render the group verifications and ownership transfers links', () => {
+    const { getByRole } = renderComponentWithRouter(
+      <Layout>
+        <NamespaceArtifactoryNavigationMenu namespace={namespaces.konfigyr}/>
+      </Layout>,
+    );
+
+    expect(getByRole('link', { name: 'Group verifications' }).getAttribute('href'))
+      .toBe('/namespace/konfigyr/artifactory/groups');
+    expect(getByRole('link', { name: 'Ownership transfers' }).getAttribute('href'))
+      .toBe('/namespace/konfigyr/artifactory/transfers');
+  });
+});

--- a/konfigyr-frontend/test/helpers/mocks.ts
+++ b/konfigyr-frontend/test/helpers/mocks.ts
@@ -3,6 +3,7 @@ import * as services from './mocks/services';
 
 export * as propertyDescriptors from './mocks/property-descriptors';
 export * as accounts from './mocks/account';
+export * as artifacts from './mocks/artifacts';
 export * as kms from './mocks/kms';
 export * as namespaces from './mocks/namespace';
 export * as applications from './mocks/application';

--- a/konfigyr-frontend/test/helpers/mocks/artifacts.ts
+++ b/konfigyr-frontend/test/helpers/mocks/artifacts.ts
@@ -1,0 +1,78 @@
+import type { ArtifactDefinition, PropertyDescriptor, VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
+
+export const publicArtifact: ArtifactDefinition = {
+  id: 'artifact-public',
+  groupId: 'com.example',
+  artifactId: 'public-service',
+  visibility: 'PUBLIC',
+  name: 'Public Service',
+  description: 'A publicly readable artifact.',
+  website: 'https://example.com',
+  repository: 'https://github.com/example/public-service',
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-07-10T00:00:00Z',
+};
+
+export const privateArtifact: ArtifactDefinition = {
+  id: 'artifact-private',
+  groupId: 'com.example',
+  artifactId: 'private-service',
+  visibility: 'PRIVATE',
+  name: 'Private Service',
+  description: 'A private artifact only readable by its owning namespace.',
+  createdAt: '2026-06-05T00:00:00Z',
+  updatedAt: '2026-07-11T00:00:00Z',
+};
+
+export const singleVersionArtifact: ArtifactDefinition = {
+  id: 'artifact-single-version',
+  groupId: 'com.example',
+  artifactId: 'single-version-service',
+  visibility: 'PUBLIC',
+  name: 'Single Version Service',
+  createdAt: '2026-06-06T00:00:00Z',
+  updatedAt: '2026-06-06T00:00:00Z',
+};
+
+export const publicArtifactVersionOne: VersionedArtifact = {
+  id: 'version-public-1',
+  groupId: publicArtifact.groupId,
+  artifactId: publicArtifact.artifactId,
+  version: '1.0.0',
+  visibility: 'PUBLIC',
+  name: publicArtifact.name,
+  publishedAt: '2026-06-01T00:00:00Z',
+};
+
+export const publicArtifactVersionTwo: VersionedArtifact = {
+  id: 'version-public-2',
+  groupId: publicArtifact.groupId,
+  artifactId: publicArtifact.artifactId,
+  version: '2.0.0',
+  visibility: 'PUBLIC',
+  name: publicArtifact.name,
+  publishedAt: '2026-07-10T00:00:00Z',
+};
+
+export const singleVersion: VersionedArtifact = {
+  id: 'version-single',
+  groupId: singleVersionArtifact.groupId,
+  artifactId: singleVersionArtifact.artifactId,
+  version: '1.0.0',
+  visibility: 'PUBLIC',
+  publishedAt: '2026-06-06T00:00:00Z',
+};
+
+export const publicArtifactProperties: Array<PropertyDescriptor> = [{
+  name: 'example.timeout',
+  typeName: 'java.time.Duration',
+  schema: { type: 'string', format: 'duration' },
+  description: 'Timeout duration for example service calls.',
+  defaultValue: '30s',
+}, {
+  name: 'example.retries',
+  typeName: 'java.lang.Integer',
+  schema: { type: 'integer' },
+  description: 'Number of retries before failing.',
+  defaultValue: '3',
+}];

--- a/konfigyr-frontend/test/helpers/server.ts
+++ b/konfigyr-frontend/test/helpers/server.ts
@@ -5,6 +5,7 @@ import kms from './server/kms';
 import memberships from './server/memberships';
 import namespaces from './server/namespaces';
 import applications from './server/namespace/applications';
+import artifacts from './server/namespace/artifacts';
 import groups from './server/namespace/groups';
 import invitations from './server/namespace/invitations';
 import transfers from './server/namespace/transfers';
@@ -21,6 +22,7 @@ export const handlers = [
   ...memberships,
   ...namespaces,
   ...applications,
+  ...artifacts,
   ...groups,
   ...invitations,
   ...transfers,

--- a/konfigyr-frontend/test/helpers/server/namespace/artifacts.ts
+++ b/konfigyr-frontend/test/helpers/server/namespace/artifacts.ts
@@ -1,0 +1,151 @@
+import { HttpResponse, http } from 'msw';
+import { namespaces } from '../../mocks';
+import {
+  privateArtifact,
+  publicArtifact,
+  publicArtifactProperties,
+  publicArtifactVersionOne,
+  publicArtifactVersionTwo,
+  singleVersion,
+  singleVersionArtifact,
+} from '../../mocks/artifacts';
+
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+import type { ArtifactDefinition, VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
+
+const artifacts = new Map<string, ArtifactDefinition>([
+  [`${publicArtifact.groupId}:${publicArtifact.artifactId}`, publicArtifact],
+  [`${privateArtifact.groupId}:${privateArtifact.artifactId}`, privateArtifact],
+  [`${singleVersionArtifact.groupId}:${singleVersionArtifact.artifactId}`, singleVersionArtifact],
+]);
+
+const versionsByArtifact = new Map<string, Array<VersionedArtifact>>([
+  [`${publicArtifact.groupId}:${publicArtifact.artifactId}`, [publicArtifactVersionTwo, publicArtifactVersionOne]],
+  [`${privateArtifact.groupId}:${privateArtifact.artifactId}`, []],
+  [`${singleVersionArtifact.groupId}:${singleVersionArtifact.artifactId}`, [singleVersion]],
+]);
+
+const notFound = (detail: string) => HttpResponse.json({ status: 404, title: 'Not found', detail }, { status: 404 });
+
+const matchesTerm = (artifact: ArtifactDefinition, term: string) => {
+  const value = term.toLowerCase();
+  return artifact.groupId.toLowerCase().includes(value)
+    || artifact.artifactId.toLowerCase().includes(value)
+    || (artifact.name?.toLowerCase().includes(value) ?? false);
+};
+
+const list = http.get('http://localhost/api/namespaces/:slug/artifacts', ({ params, request }) => {
+  const { slug } = params;
+  const term = new URL(request.url).searchParams.get('term');
+
+  let data = slug === namespaces.konfigyr.slug ? Array.from(artifacts.values()) : [];
+
+  if (term) {
+    data = data.filter(artifact => matchesTerm(artifact, term));
+  }
+
+  const response: PageResponse<ArtifactDefinition> = {
+    data,
+    metadata: { number: 1, size: 20, total: data.length, pages: 1 },
+  };
+
+  return HttpResponse.json(response);
+});
+
+const get = http.get('http://localhost/api/namespaces/:slug/artifacts/:groupId/:artifactId', ({ params }) => {
+  const { slug, groupId, artifactId } = params;
+  const artifact = artifacts.get(`${groupId}:${artifactId}`);
+
+  if (slug !== namespaces.konfigyr.slug || !artifact) {
+    return notFound(`Could not find artifact '${groupId}:${artifactId}'.`);
+  }
+
+  return HttpResponse.json(artifact);
+});
+
+const versions = http.get('http://localhost/api/namespaces/:slug/artifacts/:groupId/:artifactId/versions', ({ params }) => {
+  const { slug, groupId, artifactId } = params;
+  const key = `${groupId}:${artifactId}`;
+
+  if (slug !== namespaces.konfigyr.slug || !artifacts.has(key)) {
+    return notFound(`Could not find artifact '${key}'.`);
+  }
+
+  const data = versionsByArtifact.get(key) || [];
+
+  const response: PageResponse<VersionedArtifact> = {
+    data,
+    metadata: { number: 1, size: 20, total: data.length, pages: 1 },
+  };
+
+  return HttpResponse.json(response);
+});
+
+const getVersion = http.get('http://localhost/api/namespaces/:slug/artifacts/:groupId/:artifactId/:version', ({ params }) => {
+  const { slug, groupId, artifactId, version } = params;
+  const key = `${groupId}:${artifactId}`;
+  const found = (versionsByArtifact.get(key) || []).find(v => v.version === version);
+
+  if (slug !== namespaces.konfigyr.slug || !found) {
+    return notFound(`Could not find artifact version '${key}:${version}'.`);
+  }
+
+  return HttpResponse.json(found);
+});
+
+const changeVisibility = http.put('http://localhost/api/namespaces/:slug/artifacts/:groupId/:artifactId/visibility', async ({ params, request }) => {
+  const { slug, groupId, artifactId } = params;
+  const key = `${groupId}:${artifactId}`;
+  const artifact = artifacts.get(key);
+
+  if (slug !== namespaces.konfigyr.slug || !artifact) {
+    return notFound(`Could not find artifact '${key}'.`);
+  }
+
+  const body = await request.clone().json() as { visibility?: ArtifactDefinition['visibility'] };
+  artifacts.set(key, { ...artifact, visibility: body.visibility! });
+
+  return new HttpResponse(null, { status: 204 });
+});
+
+const search = http.get('http://localhost/api/namespaces/:slug/artifacts/search', ({ request }) => {
+  const url = new URL(request.url);
+  const term = url.searchParams.get('term');
+  const groupId = url.searchParams.get('groupId');
+  const artifactId = url.searchParams.get('artifactId');
+  const version = url.searchParams.get('version');
+
+  if (!term || term.trim().length === 0) {
+    return HttpResponse.json({
+      status: 400,
+      title: 'Bad request',
+      detail: 'The term query parameter must not be blank.',
+    }, { status: 400 });
+  }
+
+  let data = groupId === publicArtifact.groupId && artifactId === publicArtifact.artifactId
+    && (!version || version === publicArtifactVersionTwo.version)
+    ? publicArtifactProperties
+    : [];
+
+  data = data.filter(property => (
+    property.name.toLowerCase().includes(term.toLowerCase())
+    || (property.description?.toLowerCase().includes(term.toLowerCase()) ?? false)
+  ));
+
+  const response: PageResponse<typeof publicArtifactProperties[number]> = {
+    data,
+    metadata: { number: 1, size: 20, total: data.length, pages: 1 },
+  };
+
+  return HttpResponse.json(response);
+});
+
+export default [
+  list,
+  get,
+  versions,
+  getVersion,
+  changeVisibility,
+  search,
+];

--- a/konfigyr-frontend/test/lib/authentication.test.ts
+++ b/konfigyr-frontend/test/lib/authentication.test.ts
@@ -46,7 +46,7 @@ describe('services | authentication', () => {
     expect(authorizationUri.pathname).toEqual('/oauth/authorize');
     expect(authorizationUri.searchParams.get('client_id')).toEqual('konfigyr');
     expect(authorizationUri.searchParams.get('response_type')).toEqual('code');
-    expect(authorizationUri.searchParams.get('scope')).toEqual('openid namespaces profiles');
+    expect(authorizationUri.searchParams.get('scope')).toEqual('openid namespaces profiles artifactory:publish');
     expect(authorizationUri.searchParams.get('redirect_uri')).toEqual('http://localhost/auth/code');
     expect(authorizationUri.searchParams.get('code_challenge_method')).toEqual('S256');
     expect(authorizationUri.searchParams.get('state')).toEqual(state!.id);

--- a/konfigyr-frontend/test/routes/namespace/artifactory/registry/$groupId/$artifactId/$version/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/registry/$groupId/$artifactId/$version/index.test.tsx
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '@konfigyr/test/helpers/router';
+
+describe('routes | namespace | registry | version detail', () => {
+  afterEach(() => cleanup());
+
+  test('should render the artifact version detail page', async () => {
+    const { getByRole } = renderWithRouter('/namespace/konfigyr/artifactory/registry/com.example/public-service/2.0.0/');
+
+    await waitFor(() => {
+      expect(getByRole('heading', { name: 'com.example:public-service:2.0.0' })).toBeInTheDocument();
+    });
+  });
+
+  test('should render a 404 state for an unknown version', async () => {
+    const { getByText } = renderWithRouter('/namespace/konfigyr/artifactory/registry/com.example/public-service/9.9.9/');
+
+    await waitFor(() => {
+      expect(getByText('Not found')).toBeInTheDocument();
+    });
+  });
+});

--- a/konfigyr-frontend/test/routes/namespace/artifactory/registry/$groupId/$artifactId/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/registry/$groupId/$artifactId/index.test.tsx
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '@konfigyr/test/helpers/router';
+
+describe('routes | namespace | registry | detail', () => {
+  afterEach(() => cleanup());
+
+  test('should render the artifact overview with its versions', async () => {
+    const { getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/registry/com.example/public-service/');
+
+    await waitFor(() => {
+      expect(getByRole('heading', { name: 'com.example:public-service' })).toBeInTheDocument();
+      expect(getByText('2.0.0')).toBeInTheDocument();
+      expect(getByText('1.0.0')).toBeInTheDocument();
+    });
+  });
+
+  test('should render a 404 state for unknown coordinates', async () => {
+    const { getByText } = renderWithRouter('/namespace/konfigyr/artifactory/registry/unknown.group/unknown-artifact/');
+
+    await waitFor(() => {
+      expect(getByText('Not found')).toBeInTheDocument();
+    });
+  });
+});

--- a/konfigyr-frontend/test/routes/namespace/artifactory/registry/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/registry/index.test.tsx
@@ -1,0 +1,16 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import { renderWithRouter } from '@konfigyr/test/helpers/router';
+
+describe('routes | namespace | registry', () => {
+  afterEach(() => cleanup());
+
+  test('should render the artifact registry list', async () => {
+    const { getByText } = renderWithRouter('/namespace/konfigyr/artifactory/registry');
+
+    await waitFor(() => {
+      expect(getByText('com.example:public-service')).toBeInTheDocument();
+      expect(getByText('com.example:private-service')).toBeInTheDocument();
+    });
+  });
+});

--- a/konfigyr-frontend/test/routes/namespace/artifactory/transfers/$transferId/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/transfers/$transferId/index.test.tsx
@@ -6,11 +6,10 @@ describe('routes | namespace | transfers | detail', () => {
   afterEach(() => cleanup());
 
   test('should render the transfer detail page', async () => {
-    const { getByRole, getByText } = renderWithRouter('/namespace/konfigyr/artifactory/transfers/transfer-incoming-pending/');
+    const { getByRole } = renderWithRouter('/namespace/konfigyr/artifactory/transfers/transfer-incoming-pending/');
 
     await waitFor(() => {
       expect(getByRole('heading', { name: 'com.example.group' })).toBeInTheDocument();
-      expect(getByText('Pending')).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
- Adds the artifact registry list, overview, and version detail pages so namespace admins can browse every artifact their namespace has published (public and private), drill into an artifact's versions, and inspect a specific version's property definitions, reusing the same property-rendering components already powering Vault's property view.
- Admins can toggle an artifact's visibility in place with a confirmation dialog and success toast; the toggle is hidden entirely for non-admin members (`useIsNamespaceAdmin`, matched against the current account by email).
- Requests the `artifactory:publish` OAuth scope on login so the visibility mutation is actually authorized for the browser client.
- Wires the sidebar's "Artifact registry" entry to the new route.
- Redesigns the ownership transfer details page (split into distinct cards, clearer accept button label) and adds pending counts to the incoming/outgoing toggle.
