### PR TITLE
Add cross-artifact property search page to Artifactory

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/PublicationsController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/PublicationsController.java
@@ -6,7 +6,6 @@ import com.konfigyr.hateoas.PagedModel;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
 import com.konfigyr.support.SearchQuery;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NullMarked;

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/PublicationsController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/PublicationsController.java
@@ -196,7 +196,7 @@ class PublicationsController {
 			@Nullable @RequestParam(required = false) String groupId,
 			@Nullable @RequestParam(required = false) String artifactId,
 			@Nullable @RequestParam(required = false) String version,
-			@NotBlank @RequestParam String term,
+			@Nullable @RequestParam(required = false) String term,
 			Pageable pageable
 	) {
 		final SearchQuery query = SearchQuery.builder()

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/batch/ArtifactoryPublicationJobTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/batch/ArtifactoryPublicationJobTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 
+import static com.konfigyr.data.tables.PropertyDefinitions.PROPERTY_DEFINITIONS;
 import static com.konfigyr.data.tables.ArtifactVersions.ARTIFACT_VERSIONS;
 import static com.konfigyr.data.tables.AuditEvents.AUDIT_EVENTS;
 import static org.assertj.core.api.Assertions.*;
@@ -51,6 +52,10 @@ class ArtifactoryPublicationJobTest extends AbstractIntegrationTest {
 				.where(ARTIFACT_VERSIONS.ARTIFACT_ID.eq(4L))
 				.returning(ARTIFACT_VERSIONS.ID)
 				.fetch(ARTIFACT_VERSIONS.ID);
+
+		context.getBean(DSLContext.class).deleteFrom(PROPERTY_DEFINITIONS)
+				.where(PROPERTY_DEFINITIONS.ARTIFACT_ID.eq(4L))
+				.execute();
 
 		context.getBean(DSLContext.class).deleteFrom(AUDIT_EVENTS)
 				.where(AUDIT_EVENTS.ENTITY_ID.in(versions))

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/PublicationsControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/PublicationsControllerTest.java
@@ -541,25 +541,39 @@ class PublicationsControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
-	@DisplayName("should reject a property search with a blank term")
-	void shouldRejectSearchWithBlankTerm() {
+	@DisplayName("should return every visible property when searching with a blank term")
+	void shouldSearchReturnAllVisiblePropertiesForBlankTerm() {
 		mvc.get().uri("/namespaces/{namespace}/artifacts/search?term=", "konfigyr")
 				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
 				.exchange()
 				.assertThat()
 				.apply(log())
-				.hasStatus(HttpStatus.BAD_REQUEST);
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(PropertyDefinition::id)
+						.hasSize(19)
+						.contains(EntityId.from(19), EntityId.from(20), EntityId.from(21))
+						.doesNotContain(EntityId.from(17), EntityId.from(18)));
 	}
 
 	@Test
-	@DisplayName("should reject a property search with a missing term")
-	void shouldRejectSearchWithMissingTerm() {
+	@DisplayName("should return every visible property when the term query parameter is missing")
+	void shouldSearchReturnAllVisiblePropertiesForMissingTerm() {
 		mvc.get().uri("/namespaces/{namespace}/artifacts/search", "konfigyr")
 				.with(authentication(TestPrincipals.john(), OAuthScope.READ_ARTIFACTS))
 				.exchange()
 				.assertThat()
 				.apply(log())
-				.hasStatus(HttpStatus.BAD_REQUEST);
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(pagedModel(PropertyDefinition.class))
+				.satisfies(it -> assertThat(it.getContent())
+						.extracting(PropertyDefinition::id)
+						.hasSize(19)
+						.contains(EntityId.from(19), EntityId.from(20), EntityId.from(21))
+						.doesNotContain(EntityId.from(17), EntityId.from(18)));
 	}
 
 	@Test

--- a/konfigyr-frontend/src/components/artifactory/groups/group-verification-table.tsx
+++ b/konfigyr-frontend/src/components/artifactory/groups/group-verification-table.tsx
@@ -5,15 +5,7 @@ import { ErrorState } from '@konfigyr/components/error';
 import { Button } from '@konfigyr/components/ui/button';
 import { Card, CardContent } from '@konfigyr/components/ui/card';
 import { EmptyState } from '@konfigyr/components/ui/empty';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  PaginationRange,
-} from '@konfigyr/components/ui/pagination';
+import { PageResponsePagination } from '@konfigyr/components/ui/pagination';
 import { Skeleton } from '@konfigyr/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@konfigyr/components/ui/table';
 import { EllipsisVerticalIcon, Package, ShieldCheckIcon } from 'lucide-react';
@@ -159,52 +151,6 @@ function GroupVerificationSkeleton () {
   );
 }
 
-function GroupVerificationPagination ({ page = 1, size = 20, data }: {
-  page?: number;
-  size?: number;
-  data?: PageResponse<GroupVerification>;
-}) {
-  const pages = data?.metadata.pages || 1;
-  const total = data?.metadata.total || 0;
-
-  if (pages < 2) {
-    return null;
-  }
-
-  return (
-    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationPrevious
-            render={(
-              <Link to="." search={search => ({ ...search, page: page - 1 })}/>
-            )}
-          />
-        </PaginationItem>
-        <PaginationRange>
-          {(state) => (
-            <PaginationLink
-              isActive={state.active}
-              render={(
-                <Link to="." search={search => ({ ...search, page: state.page })}>
-                  {state.page}
-                </Link>
-              )}
-            />
-          )}
-        </PaginationRange>
-        <PaginationItem>
-          <PaginationNext
-            render={(
-              <Link to="." search={search => ({ ...search, page: page + 1 })}/>
-            )}
-          />
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
-  );
-}
-
 export function GroupVerificationTable ({ namespace, data, error, isPending, page, size }: {
   namespace: string;
   data?: PageResponse<GroupVerification>;
@@ -278,7 +224,7 @@ export function GroupVerificationTable ({ namespace, data, error, isPending, pag
         </CardContent>
       </Card>
 
-      <GroupVerificationPagination page={page} size={size} data={data}/>
+      <PageResponsePagination page={page} size={size} response={data} className="mt-4"/>
     </>
   );
 }

--- a/konfigyr-frontend/src/components/artifactory/registry/artifact-table.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/artifact-table.tsx
@@ -6,15 +6,7 @@ import { ErrorState } from '@konfigyr/components/error';
 import { buttonVariants } from '@konfigyr/components/ui/button';
 import { Card, CardContent } from '@konfigyr/components/ui/card';
 import { EmptyState } from '@konfigyr/components/ui/empty';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  PaginationRange,
-} from '@konfigyr/components/ui/pagination';
+import { PageResponsePagination } from '@konfigyr/components/ui/pagination';
 import { Skeleton } from '@konfigyr/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@konfigyr/components/ui/table';
 import { ArtifactVisibilityBadge } from '@konfigyr/components/artifactory/registry/visibility-badge';
@@ -73,52 +65,6 @@ function ArtifactSkeleton() {
       <TableCell><Skeleton className="h-5 w-24"/></TableCell>
       <TableCell><Skeleton className="h-5 w-24 ml-auto"/></TableCell>
     </TableRow>
-  );
-}
-
-function ArtifactPagination({ page = 1, size = 20, data }: {
-  page?: number;
-  size?: number;
-  data?: PageResponse<ArtifactDefinition>;
-}) {
-  const pages = data?.metadata.pages || 1;
-  const total = data?.metadata.total || 0;
-
-  if (pages < 2) {
-    return null;
-  }
-
-  return (
-    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationPrevious
-            render={(
-              <Link to="." search={search => ({ ...search, page: page - 1 })}/>
-            )}
-          />
-        </PaginationItem>
-        <PaginationRange>
-          {(state) => (
-            <PaginationLink
-              isActive={state.active}
-              render={(
-                <Link to="." search={search => ({ ...search, page: state.page })}>
-                  {state.page}
-                </Link>
-              )}
-            />
-          )}
-        </PaginationRange>
-        <PaginationItem>
-          <PaginationNext
-            render={(
-              <Link to="." search={search => ({ ...search, page: page + 1 })}/>
-            )}
-          />
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
   );
 }
 
@@ -185,7 +131,7 @@ export function ArtifactTable({ namespace, data, error, isPending, page, size }:
         </CardContent>
       </Card>
 
-      <ArtifactPagination page={page} size={size} data={data}/>
+      <PageResponsePagination page={page} size={size} response={data} className="mt-4"/>
     </>
   );
 }

--- a/konfigyr-frontend/src/components/artifactory/registry/messages.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/messages.tsx
@@ -121,24 +121,3 @@ export const NoVersionsFoundTitle = () => (
     description="Empty state title when an artifact has no published versions."
   />
 );
-
-export const SearchPropertiesPromptTitle = () => (
-  <FormattedMessage
-    defaultMessage="Search this version's properties"
-    description="Empty state title shown before a property search term has been entered on the version detail page."
-  />
-);
-
-export const SearchPropertiesPromptDescription = () => (
-  <FormattedMessage
-    defaultMessage="Type a property name or description to see matching configuration properties published with this version."
-    description="Empty state description shown before a property search term has been entered on the version detail page."
-  />
-);
-
-export const NoMatchingPropertiesTitle = () => (
-  <FormattedMessage
-    defaultMessage="No matching properties found"
-    description="Empty state title when no properties match the search term on the version detail page."
-  />
-);

--- a/konfigyr-frontend/src/components/artifactory/registry/version-detail.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/version-detail.tsx
@@ -1,90 +1,44 @@
-import { useCallback, useState } from 'react';
-import { FormattedDate, useIntl } from 'react-intl';
-import { SearchIcon, TagIcon } from 'lucide-react';
-import { useDebouncedCallback } from 'use-debounce';
+import { FormattedDate, FormattedMessage, useIntl } from 'react-intl';
+import { TagIcon } from 'lucide-react';
 import { useSearchArtifactProperties } from '@konfigyr/hooks';
 import { ErrorState } from '@konfigyr/components/error';
-import { PropertyDeprecation } from '@konfigyr/components/artifactory/property-deprecation';
-import { PropertyDescription } from '@konfigyr/components/artifactory/property-description';
-import { PropertyName } from '@konfigyr/components/artifactory/property-name';
-import { PropertySchema } from '@konfigyr/components/artifactory/property-schema';
-import { PropertyDefaultValue } from '@konfigyr/components/artifactory/property-default-value';
-import { PropertyTypeName } from '@konfigyr/components/artifactory/property-type-name';
-import { Card, CardContent } from '@konfigyr/components/ui/card';
-import { EmptyState } from '@konfigyr/components/ui/empty';
-import { InputGroup, InputGroupAddon, InputGroupInput } from '@konfigyr/components/ui/input-group';
-import { Item, ItemContent, ItemGroup, ItemTitle } from '@konfigyr/components/ui/item';
 import { Skeleton } from '@konfigyr/components/ui/skeleton';
 import { ArtifactVisibilityBadge } from '@konfigyr/components/artifactory/registry/visibility-badge';
-import {
-  NoMatchingPropertiesTitle,
-  PublishedAtLabel,
-  SearchPropertiesPromptDescription,
-  SearchPropertiesPromptTitle,
-} from '@konfigyr/components/artifactory/registry/messages';
+import { PropertyTable } from '@konfigyr/components/artifactory/search/property-table';
+import { PropertySearchField } from '@konfigyr/components/artifactory/search/property-search-field';
+import { PublishedAtLabel } from '@konfigyr/components/artifactory/registry/messages';
 
-import type { ChangeEvent } from 'react';
-import type { PropertyDescriptor, VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
-
-function PropertyItem({ property }: { property: PropertyDescriptor }) {
-  return (
-    <Item variant="list">
-      <ItemContent>
-        <ItemTitle>
-          <PropertyName value={property.name}/>
-          <PropertyTypeName value={property.typeName}/>
-          <PropertyDeprecation deprecation={property.deprecation}/>
-        </ItemTitle>
-        <PropertyDescription value={property.description}/>
-        <div className="text-xs mt-2 space-y-1">
-          <PropertyDefaultValue variant="labeled" value={property.defaultValue}/>
-          <p>
-            <span className="text-muted-foreground mr-1">JSON Schema type:</span>
-            <PropertySchema value={property.schema}/>
-          </p>
-        </div>
-      </ItemContent>
-    </Item>
-  );
-}
+import type { VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
 
 function PropertySearchForm({ term, onTermChange }: { term: string; onTermChange: (term: string) => void }) {
   const intl = useIntl();
-  const debounced = useDebouncedCallback((value: string) => onTermChange(value), 260);
-
-  const onChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    debounced(event.target.value);
-  }, [debounced]);
 
   return (
-    <InputGroup className="max-w-sm">
-      <InputGroupInput
-        type="search"
-        defaultValue={term}
-        placeholder={intl.formatMessage({
-          defaultMessage: 'Search properties...',
-          description: 'Placeholder for the version property search input.',
-        })}
-        aria-label={intl.formatMessage({
-          defaultMessage: 'Search properties in this version',
-          description: 'Aria label for the version property search input.',
-        })}
-        onChange={onChange}
-      />
-      <InputGroupAddon>
-        <SearchIcon size="1rem" className="text-muted-foreground"/>
-      </InputGroupAddon>
-    </InputGroup>
+    <PropertySearchField
+      term={term}
+      label={intl.formatMessage({
+        defaultMessage: 'Search properties in this version',
+        description: 'Aria label for the version property search input.',
+      })}
+      onTermChange={onTermChange}
+    />
   );
 }
 
-export function VersionDetail({ namespace, version }: { namespace: string; version: VersionedArtifact }) {
-  const [term, setTerm] = useState('');
-
+export function VersionDetail({ namespace, version, term, page, size, onTermChange }: {
+  namespace: string;
+  version: VersionedArtifact;
+  term?: string;
+  page?: number;
+  size?: number;
+  onTermChange: (term: string) => void;
+}) {
   const { data, error, isPending, isError } = useSearchArtifactProperties(namespace, {
     groupId: version.groupId,
     artifactId: version.artifactId,
     version: version.version,
+    page,
+    size,
     term,
   });
 
@@ -113,46 +67,36 @@ export function VersionDetail({ namespace, version }: { namespace: string; versi
         />
       </div>
 
-      <PropertySearchForm term={term} onTermChange={setTerm}/>
+      <PropertySearchForm term={term ?? ''} onTermChange={onTermChange}/>
 
-      <Card className="border">
-        <CardContent>
-          {term.trim().length === 0 && (
-            <EmptyState
-              icon={<SearchIcon size="2rem"/>}
-              title={<SearchPropertiesPromptTitle/>}
-              description={<SearchPropertiesPromptDescription/>}
-            />
-          )}
+      {isPending && (
+        <div data-slot="property-search-skeleton" className="border border-accent rounded-xl p-4">
+          <Skeleton className="h-4 w-72 mb-2"/>
+          <Skeleton className="h-4 w-48 mb-3"/>
+          <Skeleton className="h-4 w-56 mb-1"/>
+          <Skeleton className="h-4 w-64"/>
+        </div>
+      )}
 
-          {term.trim().length > 0 && isPending && (
-            <div data-slot="property-search-skeleton" className="space-y-3">
-              <Skeleton className="h-4 w-64"/>
-              <Skeleton className="h-4 w-48"/>
-              <Skeleton className="h-4 w-56"/>
-            </div>
-          )}
+      {isError && (
+        <ErrorState error={error} />
+      )}
 
-          {isError && (
-            <ErrorState error={error} className="border-none"/>
-          )}
-
-          {term.trim().length > 0 && data?.data.length === 0 && (
-            <EmptyState
-              icon={<SearchIcon size="2rem"/>}
-              title={<NoMatchingPropertiesTitle/>}
-            />
-          )}
-
-          {data && data.data.length > 0 && (
-            <ItemGroup>
-              {data.data.map(property => (
-                <PropertyItem key={property.name} property={property}/>
-              ))}
-            </ItemGroup>
-          )}
-        </CardContent>
-      </Card>
+      {data && (
+        <div>
+          <div className="flex justify-between mb-2">
+            <p className="font-heading font-semibold test-lg">Property definitions</p>
+            <p className="text-sm text-muted-foreground">
+              <FormattedMessage
+                defaultMessage="{count, plural, one {1 property} other {# properties}}"
+                description="Label used to describe the number of properties in a version."
+                values={{ count: data.metadata.total }}
+              />
+            </p>
+          </div>
+          <PropertyTable page={page} size={size} properties={data} variant="version" />
+        </div>
+      )}
     </>
   );
 }

--- a/konfigyr-frontend/src/components/artifactory/registry/version-table.tsx
+++ b/konfigyr-frontend/src/components/artifactory/registry/version-table.tsx
@@ -6,15 +6,7 @@ import { ErrorState } from '@konfigyr/components/error';
 import { buttonVariants } from '@konfigyr/components/ui/button';
 import { Card, CardContent } from '@konfigyr/components/ui/card';
 import { EmptyState } from '@konfigyr/components/ui/empty';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  PaginationRange,
-} from '@konfigyr/components/ui/pagination';
+import { PageResponsePagination } from '@konfigyr/components/ui/pagination';
 import { Skeleton } from '@konfigyr/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@konfigyr/components/ui/table';
 import { ArtifactVisibilityBadge } from '@konfigyr/components/artifactory/registry/visibility-badge';
@@ -62,52 +54,6 @@ function VersionSkeleton() {
       <TableCell><Skeleton className="h-5 w-24"/></TableCell>
       <TableCell><Skeleton className="h-5 w-24 ml-auto"/></TableCell>
     </TableRow>
-  );
-}
-
-function VersionPagination({ page = 1, size = 20, data }: {
-  page?: number;
-  size?: number;
-  data?: PageResponse<VersionedArtifact>;
-}) {
-  const pages = data?.metadata.pages || 1;
-  const total = data?.metadata.total || 0;
-
-  if (pages < 2) {
-    return null;
-  }
-
-  return (
-    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationPrevious
-            render={(
-              <Link to="." search={search => ({ ...search, page: page - 1 })}/>
-            )}
-          />
-        </PaginationItem>
-        <PaginationRange>
-          {(state) => (
-            <PaginationLink
-              isActive={state.active}
-              render={(
-                <Link to="." search={search => ({ ...search, page: state.page })}>
-                  {state.page}
-                </Link>
-              )}
-            />
-          )}
-        </PaginationRange>
-        <PaginationItem>
-          <PaginationNext
-            render={(
-              <Link to="." search={search => ({ ...search, page: page + 1 })}/>
-            )}
-          />
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
   );
 }
 
@@ -169,7 +115,7 @@ export function VersionTable({ namespace, data, error, isPending, page, size }: 
         </CardContent>
       </Card>
 
-      <VersionPagination page={page} size={size} data={data}/>
+      <PageResponsePagination page={page} size={size} response={data} className="mt-4"/>
     </>
   );
 }

--- a/konfigyr-frontend/src/components/artifactory/search/messages.tsx
+++ b/konfigyr-frontend/src/components/artifactory/search/messages.tsx
@@ -1,0 +1,23 @@
+import { FormattedMessage } from 'react-intl';
+
+export const PropertySearchLabel = () => (
+  <FormattedMessage
+    defaultMessage="Property search"
+    description="Breadcrumb and sidebar label for the artifact property search page."
+  />
+);
+
+export const OwnedByLabel = ({ owner }: { owner: string }) => (
+  <FormattedMessage
+    defaultMessage="Owned by {owner}"
+    description="Label used to describe the owner of a property."
+    values={{ owner: <span className="font-semibold">{owner}</span> }}
+  />
+);
+
+export const NoMatchingPropertiesTitle = () => (
+  <FormattedMessage
+    defaultMessage="No matching properties found"
+    description="Empty state title when no properties match the search term on the version detail page."
+  />
+);

--- a/konfigyr-frontend/src/components/artifactory/search/property-filters.tsx
+++ b/konfigyr-frontend/src/components/artifactory/search/property-filters.tsx
@@ -1,0 +1,48 @@
+import { useForm, useFormSubmit } from '@konfigyr/components/ui/form';
+import { PropertySearchField } from './property-search-field';
+
+import type { PropertySearchQuery } from '@konfigyr/hooks/types';
+
+export function PropertyFilters({ query, onQueryChange }: { query: PropertySearchQuery, onQueryChange: (query: PropertySearchQuery) => void }) {
+  const form = useForm({
+    defaultValues: {
+      term: query.term || '',
+    },
+    listeners: {
+      onChangeDebounceMs: 200,
+      onChange: ({ formApi }) => formApi.handleSubmit(),
+    },
+    onSubmit: ({ value }) => onQueryChange({
+      term: value.term ? value.term : '',
+    }),
+  });
+
+  const onSubmit = useFormSubmit(form);
+
+  return (
+    <form.AppForm>
+      <form name="property-search-filters" className="flex gap-4 grow" onSubmit={onSubmit}>
+        <form.AppField
+          name="term"
+          listeners={{
+            onBlurDebounceMs: 200,
+            onChangeDebounceMs: 200,
+          }}
+          children={(field) => (
+            <field.Control
+              className="grow"
+              render={
+                <PropertySearchField
+                  debounce={0}
+                  term={field.state.value}
+                  onTermChange={field.handleChange}
+                  onBlur={field.handleBlur}
+                />
+              }
+            />
+          )}
+        />
+      </form>
+    </form.AppForm>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/search/property-item.tsx
+++ b/konfigyr-frontend/src/components/artifactory/search/property-item.tsx
@@ -1,0 +1,70 @@
+import { BoxIcon, BuildingIcon } from 'lucide-react';
+import { Item, ItemContent, ItemFooter, ItemTitle } from '@konfigyr/components/ui/item';
+import { Skeleton } from '@konfigyr/components/ui/skeleton';
+import { PropertyName } from '@konfigyr/components/artifactory/property-name';
+import { PropertyTypeName } from '@konfigyr/components/artifactory/property-type-name';
+import { PropertyDeprecation } from '@konfigyr/components/artifactory/property-deprecation';
+import { PropertyDescription } from '@konfigyr/components/artifactory/property-description';
+import { PropertyDefaultValue } from '@konfigyr/components/artifactory/property-default-value';
+import { PropertySchema } from '@konfigyr/components/artifactory/property-schema';
+import { OwnedByLabel } from '@konfigyr/components/artifactory/search/messages';
+
+import type { PropertyDefinition } from '@konfigyr/hooks/artifactory/types';
+
+export type PropertyVariant = 'default' | 'version';
+
+export function PropertySkeleton({ variant = 'default' }: { variant?: PropertyVariant }) {
+  return (
+    <div data-slot="property-search-skeleton" className="border border-accent rounded-xl p-4">
+      <div className="flex items-center gap-2">
+        <Skeleton className="h-4 w-72 mb-2"/>
+        <Skeleton className="h-4 w-16 mb-2"/>
+      </div>
+      <Skeleton className="h-4 w-48 mb-3"/>
+      <Skeleton className="h-4 w-56 mb-1"/>
+      <Skeleton className="h-4 w-64"/>
+      {variant === 'default' && (
+        <div className="flex items-center gap-2 mt-4">
+          <Skeleton className="h-4 w-56"/>
+          <Skeleton className="h-4 w-42"/>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function PropertyItem({ property, variant = 'default' }: { property: PropertyDefinition, variant?: PropertyVariant }) {
+  return (
+    <Item variant="list">
+      <ItemContent>
+        <ItemTitle>
+          <PropertyName value={property.name}/>
+          <PropertyTypeName value={property.typeName}/>
+          <PropertyDeprecation deprecation={property.deprecation}/>
+        </ItemTitle>
+        <PropertyDescription value={property.description}/>
+        <div className="text-xs mt-2 space-y-1">
+          <PropertyDefaultValue variant="labeled" value={property.defaultValue}/>
+          <p>
+            <span className="text-muted-foreground mr-1">JSON Schema type:</span>
+            <PropertySchema value={property.schema}/>
+          </p>
+        </div>
+        {variant === 'default' && (
+          <ItemFooter className="mt-2">
+            <ol className="flex gap-2 text-muted-foreground font-sm [&_svg]:size-4">
+              <li className="flex items-center gap-1">
+                <BoxIcon />
+                <span>{property.key}</span>
+              </li>
+              <li>·</li>
+              <li className="flex items-center align-center gap-1">
+                <BuildingIcon /> <OwnedByLabel owner={property.owner.slug} />
+              </li>
+            </ol>
+          </ItemFooter>
+        )}
+      </ItemContent>
+    </Item>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/search/property-search-field.tsx
+++ b/konfigyr-frontend/src/components/artifactory/search/property-search-field.tsx
@@ -1,0 +1,58 @@
+import { useCallback } from 'react';
+import { FormattedDate, useIntl } from 'react-intl';
+import { SearchIcon, TagIcon } from 'lucide-react';
+import { useDebouncedCallback } from 'use-debounce';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '@konfigyr/components/ui/input-group';
+
+import type { ChangeEvent, ComponentProps } from 'react';
+
+export type PropertySearchFieldProps = {
+  term: string;
+  onTermChange: (term: string) => void;
+  onBlur?: () => void;
+  label?: string;
+  placeholder?: string;
+  debounce?: number;
+} & ComponentProps<typeof InputGroup>;
+
+export function PropertySearchField({
+  term,
+  label,
+  placeholder,
+  debounce = 260,
+  onTermChange,
+  ...props
+}: PropertySearchFieldProps) {
+  const intl = useIntl();
+
+  const debounced = useDebouncedCallback(
+    (value: string) => onTermChange(value),
+    debounce,
+  );
+
+  const onChange = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => debounced(event.target.value),
+    [debounced],
+  );
+
+  return (
+    <InputGroup {...props}>
+      <InputGroupInput
+        type="search"
+        defaultValue={term}
+        placeholder={placeholder ?? intl.formatMessage({
+          defaultMessage: 'Search properties...',
+          description: 'Placeholder for the configuration property search input.',
+        })}
+        aria-label={label ?? intl.formatMessage({
+          defaultMessage: 'Search for configuration property metadata',
+          description: 'Aria label for the configuration property search input.',
+        })}
+        onChange={onChange}
+      />
+      <InputGroupAddon>
+        <SearchIcon size="1rem" className="text-muted-foreground"/>
+      </InputGroupAddon>
+    </InputGroup>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/search/property-table.tsx
+++ b/konfigyr-frontend/src/components/artifactory/search/property-table.tsx
@@ -1,0 +1,47 @@
+import { SearchIcon } from 'lucide-react';
+import { EmptyState } from '@konfigyr/components/ui/empty';
+import { Card, CardContent } from '@konfigyr/components/ui/card';
+import { ItemGroup } from '@konfigyr/components/ui/item';
+import { PageResponsePagination } from '@konfigyr/components/ui/pagination';
+import { NoMatchingPropertiesTitle } from './messages';
+import { PropertyItem } from './property-item';
+
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+import type { PropertyDefinition } from '@konfigyr/hooks/artifactory/types';
+import type { PropertyVariant } from './property-item';
+
+export type PropertyTableProps = {
+  properties: PageResponse<PropertyDefinition>,
+  variant?: PropertyVariant,
+  page?: number;
+  size?: number;
+};
+
+export function PropertyTable({ properties, variant = 'default', page, size }: PropertyTableProps) {
+  return (
+    <>
+      <Card className="border">
+        <CardContent>
+          {properties.data.length === 0 && (
+            <EmptyState
+              icon={<SearchIcon size="2rem"/>}
+              title={<NoMatchingPropertiesTitle/>}
+            />
+          )}
+
+          <ItemGroup>
+            {properties.data.map(property => (
+              <PropertyItem
+                key={property.id}
+                property={property}
+                variant={variant}
+              />
+            ))}
+          </ItemGroup>
+        </CardContent>
+      </Card>
+
+      <PageResponsePagination page={page} size={size} response={properties} className="mt-4" />
+    </>
+  );
+}

--- a/konfigyr-frontend/src/components/artifactory/transfers/transfer-table.tsx
+++ b/konfigyr-frontend/src/components/artifactory/transfers/transfer-table.tsx
@@ -11,15 +11,7 @@ import { ErrorState } from '@konfigyr/components/error';
 import { buttonVariants } from '@konfigyr/components/ui/button';
 import { Card, CardContent } from '@konfigyr/components/ui/card';
 import { EmptyState } from '@konfigyr/components/ui/empty';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  PaginationRange,
-} from '@konfigyr/components/ui/pagination';
+import { PageResponsePagination } from '@konfigyr/components/ui/pagination';
 import { Skeleton } from '@konfigyr/components/ui/skeleton';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@konfigyr/components/ui/table';
 import { GroupIdLabel, StateLabel } from '@konfigyr/components/artifactory/transfers/messages';
@@ -81,52 +73,6 @@ function TransferSkeleton () {
       <TableCell><Skeleton className="h-5 w-24"/></TableCell>
       <TableCell><Skeleton className="h-5 w-24 ml-auto"/></TableCell>
     </TableRow>
-  );
-}
-
-function TransferPagination ({ page = 1, size = 20, data }: {
-  page?: number;
-  size?: number;
-  data?: PageResponse<ArtifactOwnershipTransfer>;
-}) {
-  const pages = data?.metadata.pages || 1;
-  const total = data?.metadata.total || 0;
-
-  if (pages < 2) {
-    return null;
-  }
-
-  return (
-    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationPrevious
-            render={(
-              <Link to="." search={search => ({ ...search, page: page - 1 })}/>
-            )}
-          />
-        </PaginationItem>
-        <PaginationRange>
-          {(state) => (
-            <PaginationLink
-              isActive={state.active}
-              render={(
-                <Link to="." search={search => ({ ...search, page: state.page })}>
-                  {state.page}
-                </Link>
-              )}
-            />
-          )}
-        </PaginationRange>
-        <PaginationItem>
-          <PaginationNext
-            render={(
-              <Link to="." search={search => ({ ...search, page: page + 1 })}/>
-            )}
-          />
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
   );
 }
 
@@ -211,7 +157,7 @@ export function TransferTable ({ namespace, direction, data, error, isPending, p
         </CardContent>
       </Card>
 
-      <TransferPagination page={page} size={size} data={data}/>
+      <PageResponsePagination page={page} size={size} response={data} className="mt-4"/>
     </>
   );
 }

--- a/konfigyr-frontend/src/components/namespace/members/invitations.tsx
+++ b/konfigyr-frontend/src/components/namespace/members/invitations.tsx
@@ -1,20 +1,11 @@
 import { FormattedDate, FormattedMessage } from 'react-intl';
 import { Link2OffIcon } from 'lucide-react';
-import { Link } from '@tanstack/react-router';
 import { useGetNamespaceInvitations } from '@konfigyr/hooks';
 import { ErrorState } from '@konfigyr/components/error';
 import { NamespaceRoleBadge } from '@konfigyr/components/namespace/role';
 import { Card, CardContent } from '@konfigyr/components/ui/card';
 import { EmptyState } from '@konfigyr/components/ui/empty';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  PaginationRange,
-} from '@konfigyr/components/ui/pagination';
+import { PageResponsePagination } from '@konfigyr/components/ui/pagination';
 import { Skeleton } from '@konfigyr/components/ui/skeleton';
 import {
   Table,
@@ -25,53 +16,7 @@ import {
   TableRow,
 } from '@konfigyr/components/ui/table';
 
-import type { Invitation, Namespace, PageResponse, Pageable } from '@konfigyr/hooks/types';
-
-function InvitationPagination({ page = 1, size = 20, data }: {
-  page?: number;
-  size?: number;
-  data?: PageResponse<Invitation>;
-}) {
-  const pages = data?.metadata.pages || 1;
-  const total = data?.metadata.total || 0;
-
-  if (pages < 2) {
-    return null;
-  }
-
-  return (
-    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationPrevious
-            render={(
-              <Link to="." search={search => ({ ...search, page: page - 1 })} />
-            )}
-          />
-        </PaginationItem>
-        <PaginationRange>
-          {(state) => (
-            <PaginationLink
-              isActive={state.active}
-              render={(
-                <Link to="." search={search => ({ ...search, page: state.page })}>
-                  {state.page}
-                </Link>
-              )}
-            />
-          )}
-        </PaginationRange>
-        <PaginationItem>
-          <PaginationNext
-            render={(
-              <Link to="." search={search => ({ ...search, page: page + 1 })} />
-            )}
-          />
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
-  );
-}
+import type { Namespace, Pageable } from '@konfigyr/hooks/types';
 
 export function Invitations({ namespace, pageable }: { namespace: Namespace, pageable?: Pageable }) {
   const { data: invitations, error, isError, isPending } = useGetNamespaceInvitations(namespace, pageable);
@@ -182,10 +127,11 @@ export function Invitations({ namespace, pageable }: { namespace: Namespace, pag
         </CardContent>
       </Card>
 
-      <InvitationPagination
+      <PageResponsePagination
         page={pageable?.page}
         size={pageable?.size}
-        data={invitations}
+        response={invitations}
+        className="mt-4"
       />
     </>
   );

--- a/konfigyr-frontend/src/components/namespace/navigation/artifactory.tsx
+++ b/konfigyr-frontend/src/components/namespace/navigation/artifactory.tsx
@@ -1,5 +1,4 @@
 import { PackageIcon } from 'lucide-react';
-import { FormattedMessage } from 'react-intl';
 import {
   SidebarGroup,
   SidebarGroupContent,
@@ -9,6 +8,10 @@ import {
   SidebarMenuItem,
 } from '@konfigyr/components/ui/sidebar';
 import { Link } from '@tanstack/react-router';
+import { GroupClaimsLabel } from '@konfigyr/components/artifactory/groups/messages';
+import { RegistryLabel } from '@konfigyr/components/artifactory/registry/messages';
+import { PropertySearchLabel } from '@konfigyr/components/artifactory/search/messages';
+import { TransfersLabel } from '@konfigyr/components/artifactory/transfers/messages';
 
 import type { Namespace } from '@konfigyr/hooks/types';
 
@@ -23,17 +26,40 @@ export function NamespaceArtifactoryNavigationMenu({ namespace }: { namespace: N
           <SidebarMenuItem>
             <SidebarMenuButton render={
               <Link
+                to="/namespace/$namespace/artifactory/registry"
+                params={{ namespace: namespace.slug }}
+                className="truncate"
+                activeProps={{ 'data-active': true }}
+              >
+                <RegistryLabel />
+              </Link>
+            } />
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton render={
+              <Link
+                to="/namespace/$namespace/artifactory/search"
+                params={{ namespace: namespace.slug }}
+                className="truncate"
+                activeProps={{ 'data-active': true }}
+              >
+                <PropertySearchLabel />
+              </Link>
+            } />
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <SidebarMenuButton render={
+              <Link
                 to="/namespace/$namespace/artifactory/groups"
                 params={{ namespace: namespace.slug }}
                 className="truncate"
                 activeProps={{ 'data-active': true }}
               >
-                <FormattedMessage
-                  defaultMessage="Group verifications"
-                  description="Label for the Group verifications page"
-                />
+                <GroupClaimsLabel />
               </Link>
             } />
+          </SidebarMenuItem>
+          <SidebarMenuItem>
             <SidebarMenuButton render={
               <Link
                 to="/namespace/$namespace/artifactory/transfers"
@@ -41,28 +67,9 @@ export function NamespaceArtifactoryNavigationMenu({ namespace }: { namespace: N
                 className="truncate"
                 activeProps={{ 'data-active': true }}
               >
-                <FormattedMessage
-                  defaultMessage="Ownership transfers"
-                  description="Label for the Ownership transfers page"
-                />
+                <TransfersLabel />
               </Link>
             } />
-            <SidebarMenuButton render={
-              <Link
-                to="/namespace/$namespace/artifactory/registry"
-                params={{ namespace: namespace.slug }}
-                className="truncate"
-                activeProps={{ 'data-active': true }}
-              >
-                <FormattedMessage
-                  defaultMessage="Artifact registry"
-                  description="Label for the Artifact registry page"
-                />
-              </Link>
-            } />
-            <SidebarMenuButton disabled>
-              <span className="truncate">Property search</span>
-            </SidebarMenuButton>
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarGroupContent>

--- a/konfigyr-frontend/src/components/ui/pagination.tsx
+++ b/konfigyr-frontend/src/components/ui/pagination.tsx
@@ -5,6 +5,7 @@ import {
   useMemo,
 } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { Link } from '@tanstack/react-router';
 import { mergeProps } from '@base-ui/react/merge-props';
 import { useRender } from '@base-ui/react/use-render';
 import {
@@ -17,6 +18,7 @@ import { buttonVariants } from '@konfigyr/components/ui/button';
 
 import type { ComponentProps, ReactNode } from 'react';
 import type { Button } from '@konfigyr/components/ui/button';
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
 
 export type PaginationProps = {
   /**
@@ -325,5 +327,51 @@ export function PaginationEllipsis({
         />
       </span>
     </span>
+  );
+}
+
+export function PageResponsePagination<T>({ page = 1, size = 20, response, ...props }: {
+  page?: number;
+  size?: number;
+  response?: PageResponse<T>;
+} & ComponentProps<'nav'>) {
+  const pages = response?.metadata.pages || 1;
+  const total = response?.metadata.total || 0;
+
+  if (pages < 2) {
+    return null;
+  }
+
+  return (
+    <Pagination page={page} pages={pages} total={total} size={size} {...props}>
+      <PaginationContent>
+        <PaginationItem>
+          <PaginationPrevious
+            render={(
+              <Link to="." search={search => ({ ...search, page: page - 1 })}/>
+            )}
+          />
+        </PaginationItem>
+        <PaginationRange>
+          {(state) => (
+            <PaginationLink
+              isActive={state.active}
+              render={(
+                <Link to="." search={search => ({ ...search, page: state.page })}>
+                  {state.page}
+                </Link>
+              )}
+            />
+          )}
+        </PaginationRange>
+        <PaginationItem>
+          <PaginationNext
+            render={(
+              <Link to="." search={search => ({ ...search, page: page + 1 })}/>
+            )}
+          />
+        </PaginationItem>
+      </PaginationContent>
+    </Pagination>
   );
 }

--- a/konfigyr-frontend/src/components/vault/change-request/change-request-list.tsx
+++ b/konfigyr-frontend/src/components/vault/change-request/change-request-list.tsx
@@ -15,15 +15,7 @@ import {
   ItemMedia,
   ItemTitle,
 } from '@konfigyr/components/ui/item';
-import {
-  Pagination,
-  PaginationContent,
-  PaginationItem,
-  PaginationLink,
-  PaginationNext,
-  PaginationPrevious,
-  PaginationRange,
-} from '@konfigyr/components/ui/pagination';
+import { PageResponsePagination } from '@konfigyr/components/ui/pagination';
 import { ChangeRequestFilters } from './change-request-filters';
 import { ChangeRequestStateIcon } from './change-request-state';
 
@@ -128,52 +120,6 @@ function ChangeRequestItemGroup({ namespace, service, data, error, isPending = f
   );
 }
 
-function ChangeRequestPagination({ page = 1, size = 20, data }: {
-  page?: number;
-  size?: number;
-  data?: PageResponse<ChangeRequest>;
-}) {
-  const pages = data?.metadata.pages || 1;
-  const total = data?.metadata.total || 0;
-
-  if (pages < 2) {
-    return null;
-  }
-
-  return (
-    <Pagination page={page} pages={pages} total={total} size={size} className="mt-4">
-      <PaginationContent>
-        <PaginationItem>
-          <PaginationPrevious
-            render={
-              <Link to="." search={search => ({ ...search, page: page - 1 })} />
-            }
-          />
-        </PaginationItem>
-        <PaginationRange>
-          {state => (
-            <PaginationLink
-              isActive={state.active}
-              render={
-                <Link to="." search={search => ({ ...search, page: state.page })}>
-                  {state.page}
-                </Link>
-              }
-            />
-          )}
-        </PaginationRange>
-        <PaginationItem>
-          <PaginationNext
-            render={
-              <Link to="." search={search => ({ ...search, page: page + 1 })} />
-            }
-          />
-        </PaginationItem>
-      </PaginationContent>
-    </Pagination>
-  );
-}
-
 export function ChangeRequestList({ namespace, service, query, onQueryChange }: {
   namespace: Namespace;
   service: Service;
@@ -199,10 +145,11 @@ export function ChangeRequestList({ namespace, service, query, onQueryChange }: 
         isPending={isPending}
       />
 
-      <ChangeRequestPagination
+      <PageResponsePagination
         page={query.page}
         size={query.size}
-        data={data}
+        response={data}
+        className="mt-4"
       />
     </>
   );

--- a/konfigyr-frontend/src/hooks/artifactory/query.ts
+++ b/konfigyr-frontend/src/hooks/artifactory/query.ts
@@ -7,7 +7,7 @@ import type {
   ArtifactQuery,
   ArtifactVersionQuery,
   ChangeArtifactVisibilityPayload,
-  PropertyDescriptor,
+  PropertyDefinition,
   PropertySearchQuery,
   VersionedArtifact,
 } from './types';
@@ -73,12 +73,11 @@ export const getArtifactVersion = (namespace: string, groupId: string, artifactI
 export const searchArtifactProperties = (namespace: string, query: PropertySearchQuery) => {
   return queryOptions({
     queryKey: registryKeys.properties(namespace, query),
-    queryFn: async ({ signal }): Promise<PageResponse<PropertyDescriptor>> => {
+    queryFn: async ({ signal }): Promise<PageResponse<PropertyDefinition>> => {
       return await request
         .get(`api/namespaces/${namespace}/artifacts/search`, { signal, searchParams: { ...query } })
         .json();
     },
-    enabled: query.term.trim().length > 0,
     placeholderData: previousData => previousData,
   });
 };

--- a/konfigyr-frontend/src/hooks/artifactory/types.ts
+++ b/konfigyr-frontend/src/hooks/artifactory/types.ts
@@ -48,10 +48,10 @@ export interface ArtifactVersionQuery extends Pageable {
 }
 
 export interface PropertySearchQuery extends Pageable {
-  groupId: string;
-  artifactId: string;
+  groupId?: string;
+  artifactId?: string;
   version?: string;
-  term: string;
+  term?: string;
 }
 
 export interface ChangeArtifactVisibilityPayload {
@@ -109,4 +109,14 @@ export interface PropertyDescriptor {
   description?: string;
   deprecation?: PropertyDeprecation;
   defaultValue?: string;
+}
+
+export interface PropertyDefinition extends PropertyDescriptor {
+  id: string;
+  key: string;
+  owner: { id: string, slug: string },
+  checksum: string,
+  occurrences: number,
+  firstSeen?: string,
+  lastSeen?: string,
 }

--- a/konfigyr-frontend/src/routeTree.gen.ts
+++ b/konfigyr-frontend/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as AuthenticatedNamespaceNamespaceApplicationsIdRouteImport } fro
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceRouteRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/route'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceIndexRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/index'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/transfers/index'
+import { Route as AuthenticatedNamespaceNamespaceArtifactorySearchIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/search/index'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/registry/index'
 import { Route as AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRouteImport } from './routes/_authenticated/namespace/$namespace/artifactory/groups/index'
 import { Route as AuthenticatedNamespaceNamespaceServicesServiceSettingsRouteImport } from './routes/_authenticated/namespace/$namespace/services/$service/settings'
@@ -205,6 +206,12 @@ const AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute =
   AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRouteImport.update({
     id: '/artifactory/transfers/',
     path: '/artifactory/transfers/',
+    getParentRoute: () => AuthenticatedNamespaceNamespaceRouteRoute,
+  } as any)
+const AuthenticatedNamespaceNamespaceArtifactorySearchIndexRoute =
+  AuthenticatedNamespaceNamespaceArtifactorySearchIndexRouteImport.update({
+    id: '/artifactory/search/',
+    path: '/artifactory/search/',
     getParentRoute: () => AuthenticatedNamespaceNamespaceRouteRoute,
   } as any)
 const AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute =
@@ -422,6 +429,7 @@ export interface FileRoutesByFullPath {
   '/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/namespace/$namespace/artifactory/groups/': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
   '/namespace/$namespace/artifactory/registry/': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute
+  '/namespace/$namespace/artifactory/search/': typeof AuthenticatedNamespaceNamespaceArtifactorySearchIndexRoute
   '/namespace/$namespace/artifactory/transfers/': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/namespace/$namespace/services/$service/': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
   '/namespace/$namespace/artifactory/registry/$groupId/$artifactId': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteWithChildren
@@ -464,6 +472,7 @@ export interface FileRoutesByTo {
   '/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/namespace/$namespace/artifactory/groups': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
   '/namespace/$namespace/artifactory/registry': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute
+  '/namespace/$namespace/artifactory/search': typeof AuthenticatedNamespaceNamespaceArtifactorySearchIndexRoute
   '/namespace/$namespace/artifactory/transfers': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/namespace/$namespace/services/$service': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
   '/namespace/$namespace/artifactory/groups/$groupId/edit': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsGroupIdEditRoute
@@ -513,6 +522,7 @@ export interface FileRoutesById {
   '/_authenticated/namespace/$namespace/services/$service/settings': typeof AuthenticatedNamespaceNamespaceServicesServiceSettingsRoute
   '/_authenticated/namespace/$namespace/artifactory/groups/': typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
   '/_authenticated/namespace/$namespace/artifactory/registry/': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute
+  '/_authenticated/namespace/$namespace/artifactory/search/': typeof AuthenticatedNamespaceNamespaceArtifactorySearchIndexRoute
   '/_authenticated/namespace/$namespace/artifactory/transfers/': typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   '/_authenticated/namespace/$namespace/services/$service/': typeof AuthenticatedNamespaceNamespaceServicesServiceIndexRoute
   '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId': typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteWithChildren
@@ -564,6 +574,7 @@ export interface FileRouteTypes {
     | '/namespace/$namespace/services/$service/settings'
     | '/namespace/$namespace/artifactory/groups/'
     | '/namespace/$namespace/artifactory/registry/'
+    | '/namespace/$namespace/artifactory/search/'
     | '/namespace/$namespace/artifactory/transfers/'
     | '/namespace/$namespace/services/$service/'
     | '/namespace/$namespace/artifactory/registry/$groupId/$artifactId'
@@ -606,6 +617,7 @@ export interface FileRouteTypes {
     | '/namespace/$namespace/services/$service/settings'
     | '/namespace/$namespace/artifactory/groups'
     | '/namespace/$namespace/artifactory/registry'
+    | '/namespace/$namespace/artifactory/search'
     | '/namespace/$namespace/artifactory/transfers'
     | '/namespace/$namespace/services/$service'
     | '/namespace/$namespace/artifactory/groups/$groupId/edit'
@@ -654,6 +666,7 @@ export interface FileRouteTypes {
     | '/_authenticated/namespace/$namespace/services/$service/settings'
     | '/_authenticated/namespace/$namespace/artifactory/groups/'
     | '/_authenticated/namespace/$namespace/artifactory/registry/'
+    | '/_authenticated/namespace/$namespace/artifactory/search/'
     | '/_authenticated/namespace/$namespace/artifactory/transfers/'
     | '/_authenticated/namespace/$namespace/services/$service/'
     | '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId'
@@ -861,6 +874,13 @@ declare module '@tanstack/react-router' {
       path: '/artifactory/transfers'
       fullPath: '/namespace/$namespace/artifactory/transfers/'
       preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRouteImport
+      parentRoute: typeof AuthenticatedNamespaceNamespaceRouteRoute
+    }
+    '/_authenticated/namespace/$namespace/artifactory/search/': {
+      id: '/_authenticated/namespace/$namespace/artifactory/search/'
+      path: '/artifactory/search'
+      fullPath: '/namespace/$namespace/artifactory/search/'
+      preLoaderRoute: typeof AuthenticatedNamespaceNamespaceArtifactorySearchIndexRouteImport
       parentRoute: typeof AuthenticatedNamespaceNamespaceRouteRoute
     }
     '/_authenticated/namespace/$namespace/artifactory/registry/': {
@@ -1197,6 +1217,7 @@ interface AuthenticatedNamespaceNamespaceRouteRouteChildren {
   AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersCreateRoute
   AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute
   AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute
+  AuthenticatedNamespaceNamespaceArtifactorySearchIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactorySearchIndexRoute
   AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute
   AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute: typeof AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRouteWithChildren
 }
@@ -1231,6 +1252,8 @@ const AuthenticatedNamespaceNamespaceRouteRouteChildren: AuthenticatedNamespaceN
       AuthenticatedNamespaceNamespaceArtifactoryGroupsIndexRoute,
     AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute:
       AuthenticatedNamespaceNamespaceArtifactoryRegistryIndexRoute,
+    AuthenticatedNamespaceNamespaceArtifactorySearchIndexRoute:
+      AuthenticatedNamespaceNamespaceArtifactorySearchIndexRoute,
     AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute:
       AuthenticatedNamespaceNamespaceArtifactoryTransfersIndexRoute,
     AuthenticatedNamespaceNamespaceArtifactoryRegistryGroupIdArtifactIdRouteRoute:

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/index.tsx
@@ -1,5 +1,6 @@
-import { FormattedMessage } from 'react-intl';
+import { z } from 'zod';
 import { TagIcon } from 'lucide-react';
+import { FormattedMessage } from 'react-intl';
 import { Link, createFileRoute } from '@tanstack/react-router';
 import { useGetArtifactVersion, useNamespace } from '@konfigyr/hooks';
 import { ErrorState } from '@konfigyr/components/error';
@@ -8,14 +9,23 @@ import { EmptyState } from '@konfigyr/components/ui/empty';
 import { RegistryBreadcrumbs } from '@konfigyr/components/artifactory/registry/breadcrumbs';
 import { VersionDetail } from '@konfigyr/components/artifactory/registry/version-detail';
 
+const searchQuerySchema = z.object({
+  term: z.string().min(2).optional().catch(undefined),
+  page: z.number().optional().catch(undefined),
+  size: z.number().optional().catch(undefined),
+});
+
 export const Route = createFileRoute(
   '/_authenticated/namespace/$namespace/artifactory/registry/$groupId/$artifactId/$version/',
 )({
+  validateSearch: searchQuerySchema,
   component: RouteComponent,
 });
 
 function RouteComponent () {
   const namespace = useNamespace();
+  const navigate = Route.useNavigate();
+  const { term, page, size } = Route.useSearch();
   const { groupId, artifactId, version } = Route.useParams();
 
   const { data: artifactVersion, error, isError, isPending } = useGetArtifactVersion(namespace.slug, groupId, artifactId, version);
@@ -63,7 +73,14 @@ function RouteComponent () {
         )}
 
         {artifactVersion && (
-          <VersionDetail namespace={namespace.slug} version={artifactVersion}/>
+          <VersionDetail
+            namespace={namespace.slug}
+            version={artifactVersion}
+            term={term}
+            page={page}
+            size={size}
+            onTermChange={value => navigate({ search: current => ({ ...current, term: value, page: 1 }) })}
+          />
         )}
       </div>
     </>

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/search/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/artifactory/search/index.tsx
@@ -1,0 +1,78 @@
+import { z } from 'zod';
+import { useCallback } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useNamespace, useSearchArtifactProperties } from '@konfigyr/hooks';
+import { ErrorState } from '@konfigyr/components/error';
+import { LayoutContent, LayoutNavbar } from '@konfigyr/components/layout';
+import { PropertySearchLabel } from '@konfigyr/components/artifactory/search/messages';
+import { PropertyFilters } from '@konfigyr/components/artifactory/search/property-filters';
+import { PropertySkeleton } from '@konfigyr/components/artifactory/search/property-item';
+import { PropertyTable } from '@konfigyr/components/artifactory/search/property-table';
+
+import type { PropertySearchQuery } from '@konfigyr/hooks/artifactory/types';
+
+const searchQuerySchema = z.object({
+  term: z.string().min(2).optional().catch(undefined),
+  page: z.number().optional().catch(undefined),
+  size: z.number().optional().catch(undefined),
+});
+
+export const Route = createFileRoute(
+  '/_authenticated/namespace/$namespace/artifactory/search/',
+)({
+  validateSearch: searchQuerySchema,
+  component: RouteComponent,
+});
+
+function RouteComponent() {
+  const namespace = useNamespace();
+  const query: PropertySearchQuery = Route.useSearch();
+  const navigate = useNavigate({ from: Route.fullPath });
+  const { data, isPending, error } = useSearchArtifactProperties(namespace.slug, query);
+
+  const onQueryChange = useCallback(async (value: PropertySearchQuery) => {
+    await navigate({
+      search: current => ({ ...current, ...value, page: 1 }),
+      viewTransition: false,
+    });
+  }, []);
+
+  return (
+    <LayoutContent>
+      <LayoutNavbar title={( <PropertySearchLabel/> )}/>
+
+      <div className="w-full lg:w-4/5 xl:w-2/3 space-y-6 px-4 mx-auto">
+        <p className="text-sm text-muted-foreground max-w-2xl">
+          <FormattedMessage
+            defaultMessage="Search property names and descriptions across every public artifact on the platform, plus your own private ones, never another namespace's private artifacts."
+            description="Description of the artifact property search page."
+          />
+        </p>
+
+        <div className="flex justify-between items-center gap-4">
+          <PropertyFilters
+            query={query}
+            onQueryChange={onQueryChange}
+          />
+        </div>
+
+        {isPending && (
+          <PropertySkeleton />
+        )}
+
+        {error && (
+          <ErrorState error={error} className="border-none"/>
+        )}
+
+        {data && (
+          <PropertyTable
+            properties={data}
+            page={query.page}
+            size={query.size}
+          />
+        )}
+      </div>
+    </LayoutContent>
+  );
+}

--- a/konfigyr-frontend/test/components/artifactory/registry/version-detail.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/registry/version-detail.test.tsx
@@ -1,47 +1,85 @@
-import { afterEach, describe, expect, test } from 'vitest';
+import { useState } from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { cleanup, waitFor } from '@testing-library/react';
 import userEvents from '@testing-library/user-event';
 import { renderWithQueryClient } from '@konfigyr/test/helpers/query-client';
 import { artifacts, namespaces } from '@konfigyr/test/helpers/mocks';
 import { VersionDetail } from '@konfigyr/components/artifactory/registry/version-detail';
 
+function Harness({ initialTerm }: { initialTerm?: string }) {
+  const [term, setTerm] = useState(initialTerm);
+
+  return (
+    <VersionDetail
+      namespace={namespaces.konfigyr.slug}
+      version={artifacts.publicArtifactVersionTwo}
+      term={term}
+      onTermChange={setTerm}
+    />
+  );
+}
+
 describe('components | registry | <VersionDetail/>', () => {
   afterEach(() => cleanup());
 
-  test('should prompt for a search term before showing any properties', () => {
-    const { getByText, queryByText } = renderWithQueryClient(
-      <VersionDetail namespace={namespaces.konfigyr.slug} version={artifacts.publicArtifactVersionTwo}/>,
-    );
+  test('should show every property of the version without requiring a search term', async () => {
+    const { getByText } = renderWithQueryClient(<Harness/>);
 
-    expect(getByText('Search this version\'s properties')).toBeInTheDocument();
-    expect(queryByText('example.timeout')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(getByText('example.timeout')).toBeInTheDocument();
+      expect(getByText('example.retries')).toBeInTheDocument();
+    });
   });
 
-  test('should show matching properties once a search term is entered', async () => {
+  test('should narrow to matching properties once a search term is entered', async () => {
     const user = userEvents.setup();
 
-    const { getByRole, getByText } = renderWithQueryClient(
-      <VersionDetail namespace={namespaces.konfigyr.slug} version={artifacts.publicArtifactVersionTwo}/>,
-    );
+    const { getByRole, getByText, queryByText } = renderWithQueryClient(<Harness/>);
+
+    await waitFor(() => expect(getByText('example.retries')).toBeInTheDocument());
 
     await user.type(getByRole('searchbox'), 'timeout');
 
     await waitFor(() => {
       expect(getByText('example.timeout')).toBeInTheDocument();
+      expect(queryByText('example.retries')).not.toBeInTheDocument();
     });
   });
 
   test('should show an empty state when no properties match the search term', async () => {
     const user = userEvents.setup();
 
-    const { getByRole, getByText } = renderWithQueryClient(
-      <VersionDetail namespace={namespaces.konfigyr.slug} version={artifacts.publicArtifactVersionTwo}/>,
-    );
+    const { getByRole, getByText } = renderWithQueryClient(<Harness/>);
 
     await user.type(getByRole('searchbox'), 'no-such-property');
 
     await waitFor(() => {
       expect(getByText('No matching properties found')).toBeInTheDocument();
     });
+  });
+
+  test('should not show which artifact or namespace owns the property', async () => {
+    const { getByText, queryByText } = renderWithQueryClient(<Harness/>);
+
+    await waitFor(() => expect(getByText('example.timeout')).toBeInTheDocument());
+
+    expect(queryByText(/Owned by/)).not.toBeInTheDocument();
+  });
+
+  test('should call onTermChange when the search field changes', async () => {
+    const user = userEvents.setup();
+    const onTermChange = vi.fn();
+
+    const { getByRole } = renderWithQueryClient(
+      <VersionDetail
+        namespace={namespaces.konfigyr.slug}
+        version={artifacts.publicArtifactVersionTwo}
+        onTermChange={onTermChange}
+      />,
+    );
+
+    await user.type(getByRole('searchbox'), 'timeout');
+
+    await waitFor(() => expect(onTermChange).toHaveBeenCalledWith('timeout'));
   });
 });

--- a/konfigyr-frontend/test/components/artifactory/search/property-item.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/search/property-item.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { renderWithMessageProvider } from '@konfigyr/test/helpers/messages';
+import { PropertyItem } from '@konfigyr/components/artifactory/search/property-item';
+
+import type { PropertyDefinition } from '@konfigyr/hooks/artifactory/types';
+
+const property: PropertyDefinition = {
+  id: 'property-example-timeout',
+  key: 'com.example:public-service',
+  owner: { id: '2', slug: 'konfigyr' },
+  checksum: 'checksum-example-timeout',
+  occurrences: 2,
+  firstSeen: '1.0.0',
+  lastSeen: '2.0.0',
+  name: 'example.timeout',
+  typeName: 'java.time.Duration',
+  schema: { type: 'string', format: 'duration' },
+  description: 'Timeout duration for example service calls.',
+  defaultValue: '30s',
+};
+
+describe('components | search | <PropertyItem/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render the property name, type and description', () => {
+    const { getByText } = renderWithMessageProvider(<PropertyItem property={property}/>);
+
+    expect(getByText('example.timeout')).toBeInTheDocument();
+    expect(getByText('java.time.Duration')).toBeInTheDocument();
+    expect(getByText('Timeout duration for example service calls.')).toBeInTheDocument();
+  });
+
+  test('should show the owning artifact coordinates and namespace as plain text, not a link', () => {
+    const { getByText, queryByRole } = renderWithMessageProvider(<PropertyItem property={property}/>);
+
+    expect(getByText('com.example:public-service')).toBeInTheDocument();
+    expect(getByText('konfigyr')).toBeInTheDocument();
+    expect(queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  test('should hide the owning artifact and owner attribution in the version variant', () => {
+    const { queryByText } = renderWithMessageProvider(<PropertyItem property={property} variant="version"/>);
+
+    expect(queryByText('com.example:public-service')).not.toBeInTheDocument();
+    expect(queryByText('konfigyr')).not.toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/artifactory/search/property-table.test.tsx
+++ b/konfigyr-frontend/test/components/artifactory/search/property-table.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup } from '@testing-library/react';
+import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
+import { PropertyTable } from '@konfigyr/components/artifactory/search/property-table';
+
+import type { PropertyDefinition } from '@konfigyr/hooks/artifactory/types';
+import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
+
+function page(data: Array<PropertyDefinition>, overrides: Partial<PageResponse<PropertyDefinition>['metadata']> = {}): PageResponse<PropertyDefinition> {
+  return { data, metadata: { number: 1, size: 20, total: data.length, pages: 1, ...overrides } };
+}
+
+const timeout: PropertyDefinition = {
+  id: 'property-example-timeout',
+  key: 'com.example:public-service',
+  owner: { id: '2', slug: 'konfigyr' },
+  checksum: 'checksum-example-timeout',
+  occurrences: 2,
+  firstSeen: '1.0.0',
+  lastSeen: '2.0.0',
+  name: 'example.timeout',
+  typeName: 'java.time.Duration',
+  schema: { type: 'string', format: 'duration' },
+  description: 'Timeout duration for example service calls.',
+  defaultValue: '30s',
+};
+
+// A different artifact defining a property with the same name, to guard against duplicate list keys
+// (PropertyTable keys list items by `id`, not `name`, since names collide across artifacts).
+const otherArtifactTimeout: PropertyDefinition = {
+  ...timeout,
+  id: 'property-other-timeout',
+  key: 'io.johndoe:notes-service',
+  owner: { id: '1', slug: 'john-doe' },
+};
+
+describe('components | search | <PropertyTable/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render every property in the response', () => {
+    const { getByText } = renderComponentWithRouter(
+      <PropertyTable properties={page([timeout, otherArtifactTimeout])}/>,
+    );
+
+    expect(getByText('com.example:public-service')).toBeInTheDocument();
+    expect(getByText('io.johndoe:notes-service')).toBeInTheDocument();
+  });
+
+  test('should render an empty state when no properties are found', () => {
+    const { getByText } = renderComponentWithRouter(
+      <PropertyTable properties={page([])}/>,
+    );
+
+    expect(getByText('No matching properties found')).toBeInTheDocument();
+  });
+
+  test('should not render pagination controls for a single page of results', () => {
+    const { queryByRole } = renderComponentWithRouter(
+      <PropertyTable properties={page([timeout])}/>,
+    );
+
+    expect(queryByRole('navigation')).not.toBeInTheDocument();
+  });
+
+  test('should render pagination controls when there is more than one page of results', () => {
+    const { getByRole } = renderComponentWithRouter(
+      <PropertyTable properties={page([timeout], { pages: 3, total: 45 })} page={1} size={20}/>,
+    );
+
+    expect(getByRole('navigation')).toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/namespace/navigation/artifactory.test.tsx
+++ b/konfigyr-frontend/test/components/namespace/navigation/artifactory.test.tsx
@@ -19,16 +19,27 @@ describe('components | namespace | navigation | <NamespaceArtifactoryNavigationM
       .toBe('/namespace/konfigyr/artifactory/registry');
   });
 
-  test('should render the group verifications and ownership transfers links', () => {
+  test('should render the group claims and ownership transfers links', () => {
     const { getByRole } = renderComponentWithRouter(
       <Layout>
         <NamespaceArtifactoryNavigationMenu namespace={namespaces.konfigyr}/>
       </Layout>,
     );
 
-    expect(getByRole('link', { name: 'Group verifications' }).getAttribute('href'))
+    expect(getByRole('link', { name: 'Group claims' }).getAttribute('href'))
       .toBe('/namespace/konfigyr/artifactory/groups');
     expect(getByRole('link', { name: 'Ownership transfers' }).getAttribute('href'))
       .toBe('/namespace/konfigyr/artifactory/transfers');
+  });
+
+  test('should render a link to the property search page', () => {
+    const { getByRole } = renderComponentWithRouter(
+      <Layout>
+        <NamespaceArtifactoryNavigationMenu namespace={namespaces.konfigyr}/>
+      </Layout>,
+    );
+
+    expect(getByRole('link', { name: 'Property search' }).getAttribute('href'))
+      .toBe('/namespace/konfigyr/artifactory/search');
   });
 });

--- a/konfigyr-frontend/test/helpers/mocks/artifacts.ts
+++ b/konfigyr-frontend/test/helpers/mocks/artifacts.ts
@@ -1,4 +1,6 @@
-import type { ArtifactDefinition, PropertyDescriptor, VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
+import { johnDoe, konfigyr } from './namespace';
+
+import type { ArtifactDefinition, ArtifactVisibility, PropertyDefinition, VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
 
 export const publicArtifact: ArtifactDefinition = {
   id: 'artifact-public',
@@ -63,16 +65,113 @@ export const singleVersion: VersionedArtifact = {
   publishedAt: '2026-06-06T00:00:00Z',
 };
 
-export const publicArtifactProperties: Array<PropertyDescriptor> = [{
+export const publicArtifactProperties: Array<PropertyDefinition> = [{
+  id: 'property-example-timeout',
+  key: `${publicArtifact.groupId}:${publicArtifact.artifactId}`,
+  owner: { id: konfigyr.id, slug: konfigyr.slug },
+  checksum: 'checksum-example-timeout',
+  occurrences: 2,
+  firstSeen: publicArtifactVersionOne.version,
+  lastSeen: publicArtifactVersionTwo.version,
   name: 'example.timeout',
   typeName: 'java.time.Duration',
   schema: { type: 'string', format: 'duration' },
   description: 'Timeout duration for example service calls.',
   defaultValue: '30s',
 }, {
+  id: 'property-example-retries',
+  key: `${publicArtifact.groupId}:${publicArtifact.artifactId}`,
+  owner: { id: konfigyr.id, slug: konfigyr.slug },
+  checksum: 'checksum-example-retries',
+  occurrences: 2,
+  firstSeen: publicArtifactVersionOne.version,
+  lastSeen: publicArtifactVersionTwo.version,
   name: 'example.retries',
   typeName: 'java.lang.Integer',
   schema: { type: 'integer' },
   description: 'Number of retries before failing.',
   defaultValue: '3',
+}];
+
+export const otherNamespacePublicArtifact: ArtifactDefinition = {
+  id: 'artifact-other-public',
+  groupId: 'io.johndoe',
+  artifactId: 'notes-service',
+  visibility: 'PUBLIC',
+  name: 'Notes Service',
+  description: 'A public artifact owned by a different namespace.',
+  createdAt: '2026-05-01T00:00:00Z',
+  updatedAt: '2026-05-01T00:00:00Z',
+};
+
+export const otherNamespacePrivateArtifact: ArtifactDefinition = {
+  id: 'artifact-other-private',
+  groupId: 'io.johndoe',
+  artifactId: 'secret-service',
+  visibility: 'PRIVATE',
+  name: 'Secret Service',
+  description: 'A private artifact owned by a different namespace.',
+  createdAt: '2026-05-02T00:00:00Z',
+  updatedAt: '2026-05-02T00:00:00Z',
+};
+
+/**
+ * Fixtures for the platform-wide property search endpoint. `visibility` is not part of the
+ * `PropertyDefinition` API contract itself, it exists here only so the MSW `search` handler
+ * can apply the same visibility rule the real backend enforces (PUBLIC everywhere, PRIVATE only
+ * to its owning namespace).
+ */
+export const platformSearchProperties: Array<PropertyDefinition & { visibility: ArtifactVisibility }> = [{
+  id: 'property-platform-own-public',
+  key: `${publicArtifact.groupId}:${publicArtifact.artifactId}`,
+  owner: { id: konfigyr.id, slug: konfigyr.slug },
+  visibility: 'PUBLIC',
+  checksum: 'checksum-platform-own-public',
+  occurrences: 1,
+  firstSeen: publicArtifactVersionOne.version,
+  lastSeen: publicArtifactVersionTwo.version,
+  name: 'example.timeout',
+  typeName: 'java.time.Duration',
+  schema: { type: 'string', format: 'duration' },
+  description: 'Timeout duration for example service calls.',
+  defaultValue: '30s',
+}, {
+  id: 'property-platform-own-private',
+  key: `${privateArtifact.groupId}:${privateArtifact.artifactId}`,
+  owner: { id: konfigyr.id, slug: konfigyr.slug },
+  visibility: 'PRIVATE',
+  checksum: 'checksum-platform-own-private',
+  occurrences: 1,
+  firstSeen: '1.0.0',
+  lastSeen: '1.0.0',
+  name: 'internal.secret.rotation-interval',
+  typeName: 'java.time.Duration',
+  schema: { type: 'string', format: 'duration' },
+  description: 'How often internal secrets rotate.',
+}, {
+  id: 'property-platform-other-public',
+  key: `${otherNamespacePublicArtifact.groupId}:${otherNamespacePublicArtifact.artifactId}`,
+  owner: { id: johnDoe.id, slug: johnDoe.slug },
+  visibility: 'PUBLIC',
+  checksum: 'checksum-platform-other-public',
+  occurrences: 1,
+  firstSeen: '1.0.0',
+  lastSeen: '1.0.0',
+  name: 'notes.storage.path',
+  typeName: 'java.lang.String',
+  schema: { type: 'string' },
+  description: 'Filesystem path where notes are stored.',
+}, {
+  id: 'property-platform-other-private',
+  key: `${otherNamespacePrivateArtifact.groupId}:${otherNamespacePrivateArtifact.artifactId}`,
+  owner: { id: johnDoe.id, slug: johnDoe.slug },
+  visibility: 'PRIVATE',
+  checksum: 'checksum-platform-other-private',
+  occurrences: 1,
+  firstSeen: '1.0.0',
+  lastSeen: '1.0.0',
+  name: 'secret.internal.token',
+  typeName: 'java.lang.String',
+  schema: { type: 'string' },
+  description: 'Internal token, must never leak to other namespaces.',
 }];

--- a/konfigyr-frontend/test/helpers/server/namespace/artifacts.ts
+++ b/konfigyr-frontend/test/helpers/server/namespace/artifacts.ts
@@ -1,6 +1,7 @@
 import { HttpResponse, http } from 'msw';
 import { namespaces } from '../../mocks';
 import {
+  platformSearchProperties,
   privateArtifact,
   publicArtifact,
   publicArtifactProperties,
@@ -11,7 +12,7 @@ import {
 } from '../../mocks/artifacts';
 
 import type { PageResponse } from '@konfigyr/hooks/hateoas/types';
-import type { ArtifactDefinition, VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
+import type { ArtifactDefinition, PropertyDefinition, VersionedArtifact } from '@konfigyr/hooks/artifactory/types';
 
 const artifacts = new Map<string, ArtifactDefinition>([
   [`${publicArtifact.groupId}:${publicArtifact.artifactId}`, publicArtifact],
@@ -108,19 +109,32 @@ const changeVisibility = http.put('http://localhost/api/namespaces/:slug/artifac
   return new HttpResponse(null, { status: 204 });
 });
 
-const search = http.get('http://localhost/api/namespaces/:slug/artifacts/search', ({ request }) => {
+const matchesPropertyTerm = (property: { name: string; description?: string }, term: string | null) => (
+  !term || term.trim().length === 0
+  || property.name.toLowerCase().includes(term.toLowerCase())
+  || (property.description?.toLowerCase().includes(term.toLowerCase()) ?? false)
+);
+
+const search = http.get('http://localhost/api/namespaces/:slug/artifacts/search', ({ params, request }) => {
+  const { slug } = params;
   const url = new URL(request.url);
   const term = url.searchParams.get('term');
   const groupId = url.searchParams.get('groupId');
   const artifactId = url.searchParams.get('artifactId');
   const version = url.searchParams.get('version');
 
-  if (!term || term.trim().length === 0) {
-    return HttpResponse.json({
-      status: 400,
-      title: 'Bad request',
-      detail: 'The term query parameter must not be blank.',
-    }, { status: 400 });
+  if (!groupId && !artifactId) {
+    const data: Array<PropertyDefinition> = platformSearchProperties
+      .filter(property => property.visibility === 'PUBLIC' || property.owner.slug === slug)
+      .filter(property => matchesPropertyTerm(property, term))
+      .map(({ visibility: _visibility, ...property }) => property);
+
+    const response: PageResponse<PropertyDefinition> = {
+      data,
+      metadata: { number: 1, size: 20, total: data.length, pages: 1 },
+    };
+
+    return HttpResponse.json(response);
   }
 
   let data = groupId === publicArtifact.groupId && artifactId === publicArtifact.artifactId
@@ -128,12 +142,9 @@ const search = http.get('http://localhost/api/namespaces/:slug/artifacts/search'
     ? publicArtifactProperties
     : [];
 
-  data = data.filter(property => (
-    property.name.toLowerCase().includes(term.toLowerCase())
-    || (property.description?.toLowerCase().includes(term.toLowerCase()) ?? false)
-  ));
+  data = data.filter(property => matchesPropertyTerm(property, term));
 
-  const response: PageResponse<typeof publicArtifactProperties[number]> = {
+  const response: PageResponse<PropertyDefinition> = {
     data,
     metadata: { number: 1, size: 20, total: data.length, pages: 1 },
   };

--- a/konfigyr-frontend/test/routes/namespace/artifactory/search/index.test.tsx
+++ b/konfigyr-frontend/test/routes/namespace/artifactory/search/index.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import userEvents from '@testing-library/user-event';
+import { renderWithRouter } from '@konfigyr/test/helpers/router';
+
+describe('routes | namespace | artifactory | search', () => {
+  afterEach(() => cleanup());
+
+  test('should show every visible property by default, without requiring a search term', async () => {
+    const { findByText, queryByText } = renderWithRouter('/namespace/konfigyr/artifactory/search');
+
+    expect(await findByText('example.timeout')).toBeInTheDocument();
+    expect(await findByText('internal.secret.rotation-interval')).toBeInTheDocument();
+    expect(await findByText('notes.storage.path')).toBeInTheDocument();
+    expect(queryByText('secret.internal.token')).not.toBeInTheDocument();
+  });
+
+  test('should never show a private property owned by a different namespace', async () => {
+    const { findByText, queryByText } = renderWithRouter('/namespace/john-doe/artifactory/search');
+
+    expect(await findByText('notes.storage.path')).toBeInTheDocument();
+    expect(await findByText('secret.internal.token')).toBeInTheDocument();
+    expect(await findByText('example.timeout')).toBeInTheDocument();
+    expect(queryByText('internal.secret.rotation-interval')).not.toBeInTheDocument();
+  });
+
+  test('should narrow results down to a matching search term', async () => {
+    const user = userEvents.setup();
+
+    const { findByRole, findByText, queryByText } = renderWithRouter('/namespace/konfigyr/artifactory/search');
+
+    await findByText('notes.storage.path');
+
+    await user.type(await findByRole('searchbox'), 'internal');
+
+    await waitFor(() => {
+      expect(queryByText('notes.storage.path')).not.toBeInTheDocument();
+    });
+
+    expect(await findByText('internal.secret.rotation-interval')).toBeInTheDocument();
+    expect(queryByText('example.timeout')).not.toBeInTheDocument();
+  });
+
+  test('should sync the search term to the URL', async () => {
+    const user = userEvents.setup();
+
+    const { findByRole, router } = renderWithRouter('/namespace/konfigyr/artifactory/search');
+
+    await user.type(await findByRole('searchbox'), 'internal');
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({ term: 'internal', page: 1 });
+    });
+  });
+
+  test('should show a "no results" state when nothing matches the search term', async () => {
+    const user = userEvents.setup();
+
+    const { findByRole, findByText } = renderWithRouter('/namespace/konfigyr/artifactory/search');
+
+    await user.type(await findByRole('searchbox'), 'no-such-property');
+
+    expect(await findByText('No matching properties found')).toBeInTheDocument();
+  });
+
+  test('should show a result\'s owning artifact coordinates and namespace as plain text, not a link', async () => {
+    const { findByText, queryByRole } = renderWithRouter('/namespace/konfigyr/artifactory/search');
+
+    expect(await findByText('io.johndoe:notes-service')).toBeInTheDocument();
+    expect(queryByRole('link', { name: 'io.johndoe:notes-service' })).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Lets a namespace admin find a configuration property by name across every public artifact on the platform plus this namespace's own private ones, without needing to know which artifact defines it ahead of time. Results carry their owning artifact and namespace so a match on someone else's public artifact is still attributable.

- Adds a new Artifactory search page (`/namespace/:namespace/artifactory/search`) that lets a namespace admin find a configuration property by name across every public artifact on the platform, plus this namespace's own private artifacts, without needing to know which artifact defines it ahead of time. Each result carries its owning artifact and namespace for attribution.
- Relaxes `GET /namespaces/{namespace}/artifacts/search` to accept a blank or missing `term`, returning every property visible to the caller instead of rejecting the request with a 400. Visibility is unchanged: `PUBLIC` everywhere, `PRIVATE` only to the owning namespace.
- Shares the property list rendering (`PropertyTable`/`PropertyItem`/`PropertySearchField`) between the new search page and the existing version detail page, which now also browses all of a version's properties by default and narrows as you type, instead of requiring a search term first.
- Consolidates the repeated pagination markup used by the registry, transfers, groups, invitations, and change request lists into a single `PageResponsePagination` component.
