### PR TITLE
Add vault_properties table to track current active property state

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/KonfigyrApplication.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/KonfigyrApplication.java
@@ -5,6 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
 import org.springframework.modulith.Modulith;
+import org.springframework.retry.annotation.EnableRetry;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
  * @since 1.0.0
  **/
 @EnableAsync
+@EnableRetry
 @EnableCaching
 @SpringBootApplication
 @EnableTransactionManagement

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/history/ChangeHistoryListener.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/history/ChangeHistoryListener.java
@@ -1,8 +1,10 @@
 package com.konfigyr.vault.history;
 
+import com.konfigyr.vault.ProfileNotFoundException;
 import com.konfigyr.vault.VaultEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 
@@ -16,6 +18,13 @@ class ChangeHistoryListener {
 	@EventListener(id = "vault-change-history-listener", value = VaultEvent.ChangesApplied.class)
 	void createChangeHistory(VaultEvent.ChangesApplied event) {
 		service.commit(event.id(), event.result());
+	}
+
+	@Async
+	@Retryable(noRetryFor = ProfileNotFoundException.class)
+	@EventListener(id = "vault-properties-listener", value = VaultEvent.ChangesApplied.class)
+	void syncProperties(VaultEvent.ChangesApplied event) {
+		service.synchronize(event.id(), event.result());
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/vault/history/ChangeHistoryService.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/vault/history/ChangeHistoryService.java
@@ -22,9 +22,11 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.OffsetDateTime;
 import java.util.*;
 
+import static com.konfigyr.data.Keys.VAULT_PROPERTIES_PKEY;
 import static com.konfigyr.data.tables.Services.SERVICES;
 import static com.konfigyr.data.tables.VaultChangeHistory.VAULT_CHANGE_HISTORY;
 import static com.konfigyr.data.tables.VaultProfiles.VAULT_PROFILES;
+import static com.konfigyr.data.tables.VaultProperties.VAULT_PROPERTIES;
 import static com.konfigyr.data.tables.VaultPropertyHistory.VAULT_PROPERTY_HISTORY;
 
 @Slf4j
@@ -76,7 +78,7 @@ public class ChangeHistoryService implements VaultChronicle {
 	 */
 	@Transactional(label = "vault.commit-change-history")
 	void commit(EntityId profile, ApplyResult result) {
-		final ChangeHistoryOwnership ownership = lookupOwnership(profile);
+		final VaultOwnership ownership = lookupOwnership(profile);
 		final AuthenticatedPrincipal author = result.author();
 		final MarkdownContents description = MarkdownContents.ofNullable(result.description());
 
@@ -100,7 +102,6 @@ public class ChangeHistoryService implements VaultChronicle {
 				)
 				.returning(VAULT_CHANGE_HISTORY.ID)
 				.fetchOne(VAULT_CHANGE_HISTORY.ID);
-
 
 		InsertValuesStepN<Record> insert = context.insertInto(VAULT_PROPERTY_HISTORY)
 				.columns(List.of(
@@ -133,6 +134,42 @@ public class ChangeHistoryService implements VaultChronicle {
 		}
 
 		insert.execute();
+
+		log.info("Successfully committed change history for: [namespace={}, service={}, profile={}, revision={}]",
+				ownership.namespace(), ownership.service(), ownership.profile(), result.revision());
+	}
+
+	/**
+	 * Synchronizes the currently active property state for a {@link Profile} to reflect the
+	 * {@link PropertyTransition transitions} contained within the given {@link ApplyResult}.
+	 * <p>
+	 * Added or updated properties are upserted with a fresh checksum, timestamp and author. Removed
+	 * properties are deleted outright. Unlike {@link #commit(EntityId, ApplyResult)}, the underlying
+	 * table never retains historical rows, it always reflects the current state only.
+	 *
+	 * @param profile the entity identifier of the profile whose properties should be synchronized, must not be {@code null}
+	 * @param result the changes applied to the profile's configuration state, must not be {@code null}
+	 */
+	@Transactional(label = "vault.sync-properties")
+	void synchronize(EntityId profile, ApplyResult result) {
+		final VaultOwnership ownership = lookupOwnership(profile);
+
+		final List<String> removed = new ArrayList<>();
+		final List<PropertyTransition> upserts = new ArrayList<>();
+
+		for (PropertyTransition transition : result) {
+			if (transition.type() == PropertyTransitionType.REMOVED) {
+				removed.add(transition.name());
+			} else {
+				upserts.add(transition);
+			}
+		}
+
+		final long removedCount = removePropertiesFromIndex(ownership, removed);
+		final long upsertedCount = updatePropertiesIndex(ownership, result, upserts);
+
+		log.info("Successfully updated Vault property state for [namespace={}, service={}, profile={}, revision={}, removed={}, upserted={}]",
+				ownership.namespace(), ownership.service(), ownership.profile(), result.revision(), removedCount, upsertedCount);
 	}
 
 	@Override
@@ -304,6 +341,68 @@ public class ChangeHistoryService implements VaultChronicle {
 		Routines.createPropertyHistoryPartition(context.configuration(), tomorrow);
 	}
 
+	private long removePropertiesFromIndex(VaultOwnership ownership, Collection<String> propertyNames) {
+		if (propertyNames.isEmpty()) {
+			return 0;
+		}
+
+		return context.deleteFrom(VAULT_PROPERTIES)
+				.where(
+						VAULT_PROPERTIES.PROFILE_ID.eq(ownership.profile()),
+						VAULT_PROPERTIES.NAME.in(propertyNames)
+				)
+				.executeLarge();
+	}
+
+	private long updatePropertiesIndex(VaultOwnership ownership, ApplyResult result, Collection<PropertyTransition> transitions) {
+		if (transitions.isEmpty()) {
+			return 0;
+		}
+
+		final AuthenticatedPrincipal author = result.author();
+
+		InsertValuesStepN<Record> insert = context.insertInto(VAULT_PROPERTIES)
+				.columns(List.of(
+						VAULT_PROPERTIES.NAMESPACE_ID,
+						VAULT_PROPERTIES.SERVICE_ID,
+						VAULT_PROPERTIES.PROFILE_ID,
+						VAULT_PROPERTIES.NAME,
+						VAULT_PROPERTIES.REVISION,
+						VAULT_PROPERTIES.CHECKSUM,
+						VAULT_PROPERTIES.CREATED_AT,
+						VAULT_PROPERTIES.UPDATED_AT,
+						VAULT_PROPERTIES.AUTHOR_ID,
+						VAULT_PROPERTIES.AUTHOR_TYPE,
+						VAULT_PROPERTIES.AUTHOR_NAME
+				));
+
+		for (PropertyTransition transition : transitions) {
+			insert = insert.values(
+					ownership.namespace(),
+					ownership.service(),
+					ownership.profile(),
+					transition.name(),
+					result.revision(),
+					transition.to().checksum().encodeHex(),
+					result.timestamp(),
+					result.timestamp(),
+					author.get(),
+					author.getType().name(),
+					author.getDisplayName().orElse(null)
+			);
+		}
+
+		return insert.onConflictOnConstraint(VAULT_PROPERTIES_PKEY)
+				.doUpdate()
+				.set(VAULT_PROPERTIES.REVISION, DSL.excluded(VAULT_PROPERTIES.REVISION))
+				.set(VAULT_PROPERTIES.CHECKSUM, DSL.excluded(VAULT_PROPERTIES.CHECKSUM))
+				.set(VAULT_PROPERTIES.UPDATED_AT, DSL.excluded(VAULT_PROPERTIES.UPDATED_AT))
+				.set(VAULT_PROPERTIES.AUTHOR_ID, DSL.excluded(VAULT_PROPERTIES.AUTHOR_ID))
+				.set(VAULT_PROPERTIES.AUTHOR_TYPE, DSL.excluded(VAULT_PROPERTIES.AUTHOR_TYPE))
+				.set(VAULT_PROPERTIES.AUTHOR_NAME, DSL.excluded(VAULT_PROPERTIES.AUTHOR_NAME))
+				.executeLarge();
+	}
+
 	private SelectConditionStep<Record> createChangeHistoryQuery(Condition condition) {
 		return context.select(CHANGE_HISTORY_FIELDS)
 				.from(VAULT_CHANGE_HISTORY)
@@ -318,13 +417,13 @@ public class ChangeHistoryService implements VaultChronicle {
 				.where(condition);
 	}
 
-	private ChangeHistoryOwnership lookupOwnership(EntityId profile) {
+	private VaultOwnership lookupOwnership(EntityId profile) {
 		return context.select(SERVICES.NAMESPACE_ID, SERVICES.ID, VAULT_PROFILES.ID)
 				.from(VAULT_PROFILES)
 				.innerJoin(SERVICES)
 				.on(SERVICES.ID.eq(VAULT_PROFILES.SERVICE_ID))
 				.where(VAULT_PROFILES.ID.eq(profile.get()))
-				.fetchOptional(ChangeHistoryOwnership::new)
+				.fetchOptional(VaultOwnership::new)
 				.orElseThrow(() -> new ProfileNotFoundException(profile));
 	}
 
@@ -389,8 +488,8 @@ public class ChangeHistoryService implements VaultChronicle {
 		return PropertyValue.sealed(cipher, checksum);
 	}
 
-	private record ChangeHistoryOwnership(long namespace, long service, long profile) {
-		private ChangeHistoryOwnership(Record record) {
+	private record VaultOwnership(long namespace, long service, long profile) {
+		private VaultOwnership(Record record) {
 			this(
 					record.get(SERVICES.NAMESPACE_ID),
 					record.get(SERVICES.ID),

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/history/ChangeHistoryListenerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/history/ChangeHistoryListenerTest.java
@@ -1,0 +1,58 @@
+package com.konfigyr.vault.history;
+
+import com.konfigyr.vault.ApplyResult;
+import com.konfigyr.vault.Profile;
+import com.konfigyr.vault.ProfilePolicy;
+import com.konfigyr.vault.VaultEvent;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChangeHistoryListenerTest {
+
+	static Profile profile = Profile.builder()
+			.id(45867635L)
+			.service(145682578)
+			.slug("test-profile")
+			.name("Test profile")
+			.policy(ProfilePolicy.IMMUTABLE)
+			.build();
+
+	@Mock
+	ChangeHistoryService service;
+
+	@Mock
+	ApplyResult result;
+
+	ChangeHistoryListener listener;
+
+	@BeforeEach
+	void setup() {
+		listener = new ChangeHistoryListener(service);
+	}
+
+	@Test
+	@DisplayName("should commit the applied changes for the profile to build the property change history")
+	void commitAppliedChanges() {
+		final var event = new VaultEvent.ChangesApplied(profile, result);
+		assertThatNoException().isThrownBy(() -> listener.createChangeHistory(event));
+
+		verify(service).commit(profile.id(), result);
+	}
+
+	@Test
+	@DisplayName("should synchronize the applied changes for the profile to build the property index")
+	void syncAppliedChanges() {
+		final var event = new VaultEvent.ChangesApplied(profile, result);
+		assertThatNoException().isThrownBy(() -> listener.syncProperties(event));
+
+		verify(service).synchronize(profile.id(), result);
+	}
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/vault/history/ChangeHistoryServiceTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/vault/history/ChangeHistoryServiceTest.java
@@ -9,6 +9,8 @@ import com.konfigyr.security.AuthenticatedPrincipal;
 import com.konfigyr.test.AbstractIntegrationTest;
 import com.konfigyr.test.TestPrincipals;
 import com.konfigyr.vault.*;
+import org.jooq.DSLContext;
+import org.jooq.Record;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -17,11 +19,16 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Set;
 
+import static com.konfigyr.data.tables.VaultProperties.VAULT_PROPERTIES;
 import static org.assertj.core.api.Assertions.*;
 
 class ChangeHistoryServiceTest extends AbstractIntegrationTest {
+
+	@Autowired
+	DSLContext context;
 
 	@Autowired
 	ProfileManager profiles;
@@ -368,6 +375,147 @@ class ChangeHistoryServiceTest extends AbstractIntegrationTest {
 	@DisplayName("should create partitions for change and property history tables")
 	void createTablePartitions() {
 		assertThatNoException().isThrownBy(chronicle::createPartitions);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should upsert added properties and update the checksum, timestamp and author on a later sync")
+	void synchronizeAddedAndUpdatedProperties() {
+		final var john = (AuthenticatedPrincipal) TestPrincipals.john().getPrincipal();
+
+		chronicle.synchronize(EntityId.from(1), applyResult("revision-1", john, Set.of(
+				PropertyTransition.added("sync-test.logging.level.root", value("info")),
+				PropertyTransition.added("sync-test.logging.level.web", value("debug")),
+				PropertyTransition.added("sync-test.server.port", value("8080"))
+		)));
+
+		assertThat(fetchProperties(1))
+				.extracting(r -> r.get(VAULT_PROPERTIES.NAME))
+				.contains("sync-test.logging.level.root", "sync-test.logging.level.web", "sync-test.server.port");
+
+		final String originalChecksum = fetchProperty(1, "sync-test.logging.level.root").get(VAULT_PROPERTIES.CHECKSUM);
+
+		final var jane = (AuthenticatedPrincipal) TestPrincipals.jane().getPrincipal();
+
+		chronicle.synchronize(EntityId.from(1), applyResult("revision-2", jane, Set.of(
+				PropertyTransition.updated("sync-test.logging.level.root", value("info"), value("warn"))
+		)));
+
+		assertThat(fetchProperty(1, "sync-test.logging.level.root"))
+				.returns("revision-2", r -> r.get(VAULT_PROPERTIES.REVISION))
+				.returns("Jane Doe", r -> r.get(VAULT_PROPERTIES.AUTHOR_NAME))
+				.returns("USER_ACCOUNT", r -> r.get(VAULT_PROPERTIES.AUTHOR_TYPE))
+				.returns(jane.get(), r -> r.get(VAULT_PROPERTIES.AUTHOR_ID))
+				.satisfies(r -> assertThat(r.get(VAULT_PROPERTIES.CHECKSUM)).isNotEqualTo(originalChecksum))
+				.satisfies(r -> assertThat(r.get(VAULT_PROPERTIES.UPDATED_AT))
+						.isCloseTo(OffsetDateTime.now(), within(1, ChronoUnit.SECONDS)));
+	}
+
+	@Test
+	@DisplayName("should fail to synchronize properties for unknown profile")
+	void synchronizePropertiesForUnknownProfile() {
+		assertThatExceptionOfType(ProfileNotFoundException.class)
+				.isThrownBy(() -> chronicle.synchronize(EntityId.from(9999), Mockito.mock(ApplyResult.class)));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should delete the property row when it is removed")
+	void synchronizeRemovedProperty() {
+		final var john = (AuthenticatedPrincipal) TestPrincipals.john().getPrincipal();
+
+		chronicle.synchronize(EntityId.from(2), applyResult(john, Set.of(
+				PropertyTransition.added("sync-test.application.name", value("service-a")),
+				PropertyTransition.added("sync-test.application.group", value("group-a")),
+				PropertyTransition.added("sync-test.server.port", value("8080"))
+		)));
+
+		chronicle.synchronize(EntityId.from(2), applyResult(john, Set.of(
+				PropertyTransition.removed("sync-test.server.port", value("8080"))
+		)));
+
+		assertThat(fetchProperties(2))
+				.extracting(r -> r.get(VAULT_PROPERTIES.NAME))
+				.contains("sync-test.application.name", "sync-test.application.group")
+				.doesNotContain("sync-test.server.port");
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should reflect only the net current state when a merge both adds and removes properties")
+	void synchronizeMixedAddAndRemove() {
+		final var john = (AuthenticatedPrincipal) TestPrincipals.john().getPrincipal();
+
+		chronicle.synchronize(EntityId.from(1), applyResult(john, Set.of(
+				PropertyTransition.added("sync-test.feature.toggle.a", value("true")),
+				PropertyTransition.added("sync-test.feature.toggle.b", value("true"))
+		)));
+
+		chronicle.synchronize(EntityId.from(1), applyResult(john, Set.of(
+				PropertyTransition.added("sync-test.feature.toggle.c", value("true")),
+				PropertyTransition.removed("sync-test.feature.toggle.a", value("true"))
+		)));
+
+		assertThat(fetchProperties(1))
+				.extracting(r -> r.get(VAULT_PROPERTIES.NAME))
+				.contains("sync-test.feature.toggle.b", "sync-test.feature.toggle.c")
+				.doesNotContain("sync-test.feature.toggle.a");
+	}
+
+	@Test
+	@DisplayName("should return zero rows for a profile that never had any properties synced")
+	void noPropertiesForUntouchedProfile() {
+		assertThat(fetchProperties(999999)).isEmpty();
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should isolate properties per profile even when property names overlap")
+	void synchronizeIsolatesPropertiesPerProfile() {
+		final var john = (AuthenticatedPrincipal) TestPrincipals.john().getPrincipal();
+
+		chronicle.synchronize(EntityId.from(1), applyResult(john, Set.of(
+				PropertyTransition.added("sync-test.application.name", value("service-a"))
+		)));
+
+		chronicle.synchronize(EntityId.from(2), applyResult(john, Set.of(
+				PropertyTransition.added("sync-test.application.name", value("service-b"))
+		)));
+
+		assertThat(fetchProperties(1))
+				.extracting(r -> r.get(VAULT_PROPERTIES.NAME))
+				.contains("sync-test.application.name");
+
+		assertThat(fetchProperties(2))
+				.extracting(r -> r.get(VAULT_PROPERTIES.NAME))
+				.contains("sync-test.application.name");
+
+		assertThat(fetchProperty(1, "sync-test.application.name").get(VAULT_PROPERTIES.CHECKSUM))
+				.isNotEqualTo(fetchProperty(2, "sync-test.application.name").get(VAULT_PROPERTIES.CHECKSUM));
+	}
+
+	private static PropertyValue value(String content) {
+		return PropertyValue.sealed(ByteArray.fromString(content), ByteArray.fromString(content));
+	}
+
+	private static ApplyResult applyResult(AuthenticatedPrincipal author, Set<PropertyTransition> changes) {
+		return applyResult("revision", author, changes);
+	}
+
+	private static ApplyResult applyResult(String revision, AuthenticatedPrincipal author, Set<PropertyTransition> changes) {
+		return new ApplyResult(revision, null, "Test changes", null, changes, author, OffsetDateTime.now());
+	}
+
+	private List<Record> fetchProperties(long profileId) {
+		return context.selectFrom(VAULT_PROPERTIES)
+				.where(VAULT_PROPERTIES.PROFILE_ID.eq(profileId))
+				.fetch();
+	}
+
+	private Record fetchProperty(long profileId, String name) {
+		return context.selectFrom(VAULT_PROPERTIES)
+				.where(VAULT_PROPERTIES.PROFILE_ID.eq(profileId), VAULT_PROPERTIES.NAME.eq(name))
+				.fetchOne();
 	}
 
 	private Profile profileFor(long id) {

--- a/konfigyr-data/src/main/resources/migrations/vault/vault-1.0.0.xml
+++ b/konfigyr-data/src/main/resources/migrations/vault/vault-1.0.0.xml
@@ -502,4 +502,95 @@
 				onDelete="CASCADE"
 		/>
 	</changeSet>
+
+	<changeSet author="vspasic" id="1.0.0-create-vault-properties-table" context="api">
+		<preConditions onFail="MARK_RAN">
+			<not>
+				<tableExists tableName="vault_properties" />
+			</not>
+		</preConditions>
+
+		<comment>Vault Properties table, stores the currently active property state per profile.</comment>
+
+		<createTable tableName="vault_properties" remarks="Stores the currently active property names for a profile.">
+			<column name="namespace_id" type="bigint">
+				<constraints nullable="false"/>
+			</column>
+
+			<column name="service_id" type="bigint">
+				<constraints nullable="false"/>
+			</column>
+
+			<column name="profile_id" type="bigint">
+				<constraints nullable="false" primaryKey="true"/>
+			</column>
+
+			<column name="name" type="varchar(255)">
+				<constraints nullable="false" primaryKey="true"/>
+			</column>
+
+			<column name="revision" type="varchar(64)">
+				<constraints nullable="false"/>
+			</column>
+
+			<column name="checksum" type="varchar(64)">
+				<constraints nullable="false"/>
+			</column>
+
+			<column name="created_at" type="timestamptz" defaultValue="NOW()">
+				<constraints nullable="false"/>
+			</column>
+
+			<column name="updated_at" type="timestamptz" defaultValue="NOW()">
+				<constraints nullable="false"/>
+			</column>
+
+			<column name="author_id" type="varchar(128)">
+				<constraints nullable="false"/>
+			</column>
+
+			<column name="author_type" type="varchar(32)">
+				<constraints nullable="false"/>
+			</column>
+
+			<column name="author_name" type="text">
+				<constraints nullable="false"/>
+			</column>
+		</createTable>
+
+		<addForeignKeyConstraint
+				baseTableName="vault_properties"
+				baseColumnNames="namespace_id"
+				constraintName="fk_vault_properties_namespace"
+				referencedTableName="namespaces"
+				referencedColumnNames="id"
+				onDelete="CASCADE"
+		/>
+
+		<addForeignKeyConstraint
+				baseTableName="vault_properties"
+				baseColumnNames="service_id"
+				constraintName="fk_vault_properties_service"
+				referencedTableName="services"
+				referencedColumnNames="id"
+				onDelete="CASCADE"
+		/>
+
+		<addForeignKeyConstraint
+				baseTableName="vault_properties"
+				baseColumnNames="profile_id"
+				constraintName="fk_vault_properties_profile"
+				referencedTableName="vault_profiles"
+				referencedColumnNames="id"
+				onDelete="CASCADE"
+		/>
+
+		<createIndex tableName="vault_properties" indexName="idx_vault_properties_lookup">
+			<column name="profile_id" />
+		</createIndex>
+
+		<createIndex tableName="vault_properties" indexName="idx_vault_properties_namespace_lookup">
+			<column name="namespace_id" />
+		</createIndex>
+	</changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
- Adds `vault_properties`, a queryable per-profile index of currently active property keys (name, checksum, revision, timestamps, author) no values, ever. Vault property *values* live in git, so there was previously no way to answer "which properties currently exist on this profile" without folding through event-sourced history.
- Denormalizes `namespace_id`/`service_id` onto each row (mirroring `vault_change_history`'s existing pattern) so namespace-level dashboard aggregation can count/filter without joining through `vault_profiles` → `services`.
- Kept in sync via a new `@Async @Retryable` listener method alongside the existing change-history recording, reacting to the same `VaultEvent.ChangesApplied` event, same event, same eventual-consistency posture, no new failure mode.
- Writes are batched: one multi-row `INSERT ... ON CONFLICT ... DO UPDATE` for all added/updated properties and one `DELETE ... WHERE name IN (...)` for all removals, per merge — not one statement per property, so an import applying hundreds of changes doesn't pay hundreds of round trips.
- Enables `@EnableRetry` globally (`KonfigyrApplication`), which was missing, the handful of other listeners already annotated `@Retryable` had never actually retried anything until now.
