### PR TITLE
Add namespace dashboard summary endpoint

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceManagementAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/NamespaceManagementAutoConfiguration.java
@@ -3,7 +3,9 @@ package com.konfigyr.namespace;
 import com.konfigyr.artifactory.OwnerResolver;
 import com.konfigyr.feature.FeatureDefinition;
 import com.konfigyr.feature.FeatureDefinitionConfigurer;
+import com.konfigyr.feature.Features;
 import com.konfigyr.namespace.catalog.ServiceCatalogSource;
+import com.konfigyr.namespace.dashboard.Dashboards;
 import com.konfigyr.security.PasswordEncoders;
 import lombok.RequiredArgsConstructor;
 import org.jooq.DSLContext;
@@ -56,6 +58,11 @@ public class NamespaceManagementAutoConfiguration implements FeatureDefinitionCo
 	@Bean
 	OwnerResolver namespaceOwnerResolver(NamespaceManager namespaces) {
 		return new NamespaceOwnerResolver(namespaces);
+	}
+
+	@Bean
+	Dashboards namespaceDashboards(Features features) {
+		return new Dashboards(context, features);
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/DashboardController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/DashboardController.java
@@ -1,0 +1,37 @@
+package com.konfigyr.namespace.controller;
+
+import com.konfigyr.namespace.Namespace;
+import com.konfigyr.namespace.NamespaceManager;
+import com.konfigyr.namespace.NamespaceNotFoundException;
+import com.konfigyr.namespace.dashboard.DashboardSummary;
+import com.konfigyr.namespace.dashboard.Dashboards;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.security.oauth.RequiresScope;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@NullMarked
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/namespaces/{slug}")
+class DashboardController {
+
+	private final NamespaceManager namespaces;
+	private final Dashboards dashboards;
+
+	@GetMapping("/dashboard")
+	@PreAuthorize("isMember(#slug)")
+	@RequiresScope(OAuthScope.READ_NAMESPACES)
+	DashboardSummary get(@PathVariable String slug) {
+		final Namespace namespace = namespaces.findBySlug(slug)
+				.orElseThrow(() -> new NamespaceNotFoundException(slug));
+
+		return dashboards.summary(namespace);
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/dashboard/DashboardSummary.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/dashboard/DashboardSummary.java
@@ -1,0 +1,47 @@
+package com.konfigyr.namespace.dashboard;
+
+import org.jmolecules.ddd.annotation.ValueObject;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+import java.io.Serial;
+import java.io.Serializable;
+
+/**
+ * Rolled-up counts for a namespace, powering the namespace overview page with a single request
+ * instead of one call per module.
+ *
+ * @param activeServices number of services managed by the namespace
+ * @param members member count and, when the namespace's plan enforces one, the member limit
+ * @param openChangeRequests number of open change requests across all the namespace's services
+ * @param activeConfigurations number of currently active configuration properties across all the namespace's services
+ * @param artifactsOwned number of artifacts owned by the namespace
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@NullMarked
+@ValueObject
+public record DashboardSummary(
+		long activeServices,
+		Members members,
+		long openChangeRequests,
+		long activeConfigurations,
+		long artifactsOwned
+) implements Serializable {
+
+	@Serial
+	private static final long serialVersionUID = 3050927164630017341L;
+
+	/**
+	 * Member count and, when the namespace's plan enforces one, the member limit.
+	 *
+	 * @param count number of members currently in the namespace
+	 * @param limit maximum number of members allowed by the namespace's plan, or {@literal null} when unlimited
+	 */
+	public record Members(long count, @Nullable Long limit) implements Serializable {
+
+		@Serial
+		private static final long serialVersionUID = 8318084617731072072L;
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/dashboard/Dashboards.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/dashboard/Dashboards.java
@@ -1,0 +1,106 @@
+package com.konfigyr.namespace.dashboard;
+
+import com.konfigyr.feature.Features;
+import com.konfigyr.feature.LimitedFeatureValue;
+import com.konfigyr.namespace.Namespace;
+import com.konfigyr.namespace.NamespaceFeatures;
+import lombok.RequiredArgsConstructor;
+import org.jooq.*;
+import org.jooq.Record;
+import org.jooq.impl.DSL;
+import org.jspecify.annotations.NullMarked;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.konfigyr.data.tables.Artifacts.ARTIFACTS;
+import static com.konfigyr.data.tables.NamespaceMembers.NAMESPACE_MEMBERS;
+import static com.konfigyr.data.tables.Services.SERVICES;
+import static com.konfigyr.data.tables.VaultChangeRequests.VAULT_CHANGE_REQUESTS;
+import static com.konfigyr.data.tables.VaultProperties.VAULT_PROPERTIES;
+
+/**
+ * Computes the {@link DashboardSummary rolled-up counts} shown on a namespace's overview page.
+ * <p>
+ * Reads state directly via jOOQ against the tables owned by other modules rather than depending on
+ * their manager or repository interfaces, thus becoming a single place where namespace-wide count is
+ * retrieved without introducing a dependency on those modules.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@NullMarked
+@RequiredArgsConstructor
+public class Dashboards {
+
+	static final Field<Long> COUNT = DSL.countLarge();
+
+	private final DSLContext context;
+	private final Features features;
+
+	/**
+	 * Computes the {@link DashboardSummary} for the given {@link Namespace}.
+	 *
+	 * @param namespace the namespace for which the summary is computed, can't be {@literal null}
+	 * @return the computed dashboard summary, never {@literal null}
+	 */
+	@Transactional(readOnly = true, label = "namespace.dashboard-summary")
+	public DashboardSummary summary(Namespace namespace) {
+		final long id = namespace.id().get();
+
+		return new DashboardSummary(
+				countServices(id),
+				memberSummary(namespace),
+				countOpenChangeRequests(id),
+				countActiveProperties(id),
+				countArtifacts(id)
+		);
+	}
+
+	private long countServices(long namespaceId) {
+		return selectCount(SERVICES, SERVICES.NAMESPACE_ID.eq(namespaceId));
+	}
+
+	private DashboardSummary.Members memberSummary(Namespace namespace) {
+		final long count = selectCount(NAMESPACE_MEMBERS, NAMESPACE_MEMBERS.NAMESPACE_ID.eq(namespace.id().get()));
+
+		final Long limit = features.get(namespace.slug(), NamespaceFeatures.MEMBERS_COUNT)
+				.filter(LimitedFeatureValue::isLimited)
+				.map(LimitedFeatureValue::get)
+				.orElse(null);
+
+		return new DashboardSummary.Members(count, limit);
+	}
+
+	private long countOpenChangeRequests(long namespaceId) {
+		// "OPEN" mirrors the persisted name of com.konfigyr.vault.ChangeRequestState.OPEN; the literal is
+		// used here instead of the enum to avoid a namespace -> vault module dependency for a single value.
+		return selectCountFrom(VAULT_CHANGE_REQUESTS)
+				.innerJoin(SERVICES)
+				.on(SERVICES.ID.eq(VAULT_CHANGE_REQUESTS.SERVICE_ID))
+				.where(
+						SERVICES.NAMESPACE_ID.eq(namespaceId),
+						VAULT_CHANGE_REQUESTS.STATE.eq("OPEN")
+				)
+				.fetchOptional(COUNT)
+				.orElse(0L);
+	}
+
+	private long countActiveProperties(long namespaceId) {
+		return selectCount(VAULT_PROPERTIES, VAULT_PROPERTIES.NAMESPACE_ID.eq(namespaceId));
+	}
+
+	private long countArtifacts(long namespaceId) {
+		return selectCount(ARTIFACTS, ARTIFACTS.NAMESPACE_ID.eq(namespaceId));
+	}
+
+	private SelectJoinStep<? extends Record> selectCountFrom(Table<?> table) {
+		return context.select(COUNT).from(table);
+	}
+
+	private long selectCount(Table<?> table, Condition condition) {
+		return selectCountFrom(table)
+				.where(condition)
+				.fetchOptional(COUNT)
+				.orElse(0L);
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/DashboardControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/DashboardControllerTest.java
@@ -1,0 +1,209 @@
+package com.konfigyr.namespace.controller;
+
+import com.konfigyr.feature.FeatureValue;
+import com.konfigyr.namespace.NamespaceFeatures;
+import com.konfigyr.namespace.dashboard.DashboardSummary;
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.test.AbstractControllerTest;
+import com.konfigyr.test.TestPrincipals;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static com.konfigyr.data.tables.VaultChangeRequests.VAULT_CHANGE_REQUESTS;
+import static com.konfigyr.data.tables.VaultProfiles.VAULT_PROFILES;
+import static com.konfigyr.data.tables.VaultProperties.VAULT_PROPERTIES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+
+class DashboardControllerTest extends AbstractControllerTest {
+
+	@Autowired
+	DSLContext context;
+
+	@Test
+	@Transactional
+	@DisplayName("should return dashboard summary for a namespace with a limited member plan")
+	void shouldReturnDashboardSummary() {
+		given(features.get("konfigyr", NamespaceFeatures.MEMBERS_COUNT))
+				.willReturn(Optional.of(FeatureValue.limited(10)));
+
+		insertActiveProperty(1, "dashboard-test.logging.level");
+		insertActiveProperty(1, "dashboard-test.server.port");
+		insertActiveProperty(2, "dashboard-test.server.port");
+
+		mvc.get().uri("/namespaces/{slug}/dashboard", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.hasContentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+				.bodyJson()
+				.convertTo(DashboardSummary.class)
+				// namespace owns services 2 and 3, see data/services.sql
+				.returns(2L, DashboardSummary::activeServices)
+				// change requests 2, 3 and 4 are OPEN for service 2, see data/vault.sql
+				.returns(3L, DashboardSummary::openChangeRequests)
+				// the configuration properties should be aggregated accross profiles or services
+				.returns(3L, DashboardSummary::activeConfigurations)
+				// artifacts 2 through 12 and 14 are owned by namespace_id 2, see data/artifactory.sql
+				.returns(12L, DashboardSummary::artifactsOwned)
+				.satisfies(summary -> assertThat(summary.members())
+						// namespace has 2 members: john (ADMIN) and jane (USER), see data/namespace-members.sql
+						.returns(2L, DashboardSummary.Members::count)
+						.returns(10L, DashboardSummary.Members::limit)
+				);
+	}
+
+	@Test
+	@DisplayName("should return a null member limit when the namespace has an unlimited member plan")
+	void shouldReturnNullMemberLimitForUnlimitedPlan() {
+		given(features.get("konfigyr", NamespaceFeatures.MEMBERS_COUNT))
+				.willReturn(Optional.of(FeatureValue.unlimited()));
+
+		mvc.get().uri("/namespaces/{slug}/dashboard", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(DashboardSummary.class)
+				.satisfies(summary -> assertThat(summary.members())
+						.returns(2L, DashboardSummary.Members::count)
+						.returns(null, DashboardSummary.Members::limit)
+				);
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should count open change requests spread across multiple services via a single joined query")
+	void shouldCountOpenChangeRequestsAcrossServices() {
+		given(features.get("konfigyr", NamespaceFeatures.MEMBERS_COUNT))
+				.willReturn(Optional.of(FeatureValue.unlimited()));
+
+		// service 3 ("konfigyr-api") belongs to the same "konfigyr" namespace as service 2, but has no
+		// change requests of its own in data/vault.sql; seed one here to prove the count is a single
+		// query joined across every service in the namespace, not a per-service fan-out.
+		context.insertInto(VAULT_PROFILES)
+				.set(VAULT_PROFILES.ID, 999L)
+				.set(VAULT_PROFILES.SERVICE_ID, 3L)
+				.set(VAULT_PROFILES.SLUG, "extra")
+				.set(VAULT_PROFILES.NAME, "Extra")
+				.set(VAULT_PROFILES.STATE, "ACTIVE")
+				.set(VAULT_PROFILES.POLICY, "UNPROTECTED")
+				.execute();
+
+		context.insertInto(VAULT_CHANGE_REQUESTS)
+				.set(VAULT_CHANGE_REQUESTS.ID, 999L)
+				.set(VAULT_CHANGE_REQUESTS.SERVICE_ID, 3L)
+				.set(VAULT_CHANGE_REQUESTS.PROFILE_ID, 999L)
+				.set(VAULT_CHANGE_REQUESTS.NUMBER, 1L)
+				.set(VAULT_CHANGE_REQUESTS.STATE, "OPEN")
+				.set(VAULT_CHANGE_REQUESTS.MERGE_STATUS, "NOT_APPROVED")
+				.set(VAULT_CHANGE_REQUESTS.CHANGE_COUNT, 1)
+				.set(VAULT_CHANGE_REQUESTS.BRANCH_NAME, "refs/cr/999")
+				.set(VAULT_CHANGE_REQUESTS.BASE_REVISION, "rev-x1")
+				.set(VAULT_CHANGE_REQUESTS.HEAD_REVISION, "rev-x2")
+				.set(VAULT_CHANGE_REQUESTS.SUBJECT, "Extra change")
+				.set(VAULT_CHANGE_REQUESTS.CREATED_BY, "Test User")
+				.execute();
+
+		mvc.get().uri("/namespaces/{slug}/dashboard", "konfigyr")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(DashboardSummary.class)
+				// 3 pre-existing OPEN requests for service 2, plus the one just added for service 3
+				.returns(4L, DashboardSummary::openChangeRequests);
+	}
+
+	@Test
+	@DisplayName("should return zero counts for a namespace with no services, change requests or properties")
+	void shouldReturnZeroCountsForNamespaceWithNoActivity() {
+		mvc.get().uri("/namespaces/{slug}/dashboard", "ebf")
+				.with(authentication(TestPrincipals.max(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(DashboardSummary.class)
+				.returns(0L, DashboardSummary::activeServices)
+				.returns(0L, DashboardSummary::openChangeRequests)
+				.returns(0L, DashboardSummary::activeConfigurations)
+				// artifacts 16 and 17 are owned by namespace_id 3, see data/artifact-ownership-transfers.sql
+				.returns(2L, DashboardSummary::artifactsOwned)
+				.satisfies(summary -> assertThat(summary.members())
+						.returns(1L, DashboardSummary.Members::count)
+				);
+	}
+
+	@Test
+	@DisplayName("should return not found for an unknown namespace")
+	void shouldReturnNotFoundForUnknownNamespace() {
+		mvc.get().uri("/namespaces/{slug}/dashboard", "unknown")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(namespaceNotFound("unknown"));
+	}
+
+	@Test
+	@DisplayName("should deny access when user is not a namespace member")
+	void shouldDenyAccessForNonMembers() {
+		mvc.get().uri("/namespaces/{slug}/dashboard", "john-doe")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should deny access when namespaces:read scope is missing")
+	void shouldDenyAccessWithoutScope() {
+		mvc.get().uri("/namespaces/{slug}/dashboard", "konfigyr")
+				.with(authentication(TestPrincipals.john()))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.READ_NAMESPACES));
+	}
+
+	@Test
+	@DisplayName("should deny access for unauthenticated requests")
+	void shouldDenyUnauthenticatedAccess() {
+		mvc.get().uri("/namespaces/{slug}/dashboard", "konfigyr")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(unauthorized());
+	}
+
+	private void insertActiveProperty(long profileId, String name) {
+		context.insertInto(VAULT_PROPERTIES)
+				.set(VAULT_PROPERTIES.NAMESPACE_ID, 2L)
+				.set(VAULT_PROPERTIES.SERVICE_ID, 2L)
+				.set(VAULT_PROPERTIES.PROFILE_ID, profileId)
+				.set(VAULT_PROPERTIES.NAME, name)
+				.set(VAULT_PROPERTIES.REVISION, "dashboard-test-revision")
+				.set(VAULT_PROPERTIES.CHECKSUM, "checksum")
+				.set(VAULT_PROPERTIES.AUTHOR_ID, "john.doe@konfigyr.com")
+				.set(VAULT_PROPERTIES.AUTHOR_TYPE, "USER")
+				.set(VAULT_PROPERTIES.AUTHOR_NAME, "John Doe")
+				.execute();
+	}
+
+}


### PR DESCRIPTION
Adds `GET /namespaces/{slug}/dashboard`, the first cross-module aggregation endpoint in the codebase, returning rolled-up counts for a namespace's overview page in a single request:

- `activeServices`: number of services owned by the namespace
- `members`: member count and, when the plan enforces one, the member limit (`null` when unlimited)
- `openChangeRequests`: open change requests across every service in the namespace, via a single joined query
- `activeConfigurations`: currently active configuration properties across all of the namespace's services
- `artifactsOwned`: artifacts owned by the namespace
