### PR TITLE
Wire namespace overview dashboard to live data

### DIFF
--- a/konfigyr-frontend/src/components/reporting/activity-item.tsx
+++ b/konfigyr-frontend/src/components/reporting/activity-item.tsx
@@ -1,0 +1,95 @@
+import { FormattedMessage } from 'react-intl';
+import { useGetAuditRecords } from '@konfigyr/hooks';
+import { ErrorState } from '@konfigyr/components/error';
+import { RelativeDate } from '@konfigyr/components/messages/relative-date';
+import {
+  Item,
+  ItemContent,
+  ItemDescription,
+  ItemGroup,
+  ItemTitle,
+} from '@konfigyr/components/ui/item';
+import { Skeleton } from '@konfigyr/components/ui/skeleton';
+import { ActivityCardEmpty } from './activity';
+
+import type { AuditRecord, AuditRecordQuery, Namespace } from '@konfigyr/hooks/types';
+
+export const RECENT_ACTIVITY_QUERY: AuditRecordQuery = { size: 5 };
+
+function ActivityCardSkeleton() {
+  return (
+    <div data-slot="activity-item-skeleton" className="border-b-accent px-6 py-2">
+      <Skeleton className="h-4 w-96 mb-2"/>
+      <div className="flex items-center gap-2 mt-4">
+        <Skeleton className="h-4 w-36"/>
+        <Skeleton className="h-4 w-42"/>
+      </div>
+    </div>
+  );
+}
+
+function ActivityCardItem({ record }: { record: AuditRecord }) {
+  return (
+    <Item
+      size="sm"
+      role="listitem"
+      variant="list"
+      aria-label={record.message}
+    >
+      <ItemContent>
+        <ItemTitle>
+          {record.message}
+        </ItemTitle>
+        <ItemDescription>
+          <FormattedMessage
+            defaultMessage="{actor} · {date}"
+            description="Message used on the namespace overview activity item to display who performed the change and when. This message has an actor and a relative date property."
+            values={{
+              actor: (
+                <span className="font-medium text-foreground">
+                  {record.actor.name}
+                </span>
+              ),
+              date: (
+                <RelativeDate
+                  value={record.createdAt}
+                  className="font-medium text-foreground"
+                />
+              ),
+            }}
+          />
+        </ItemDescription>
+      </ItemContent>
+    </Item>
+  );
+}
+
+export function ActivityCardList({ namespace }: { namespace: Namespace }) {
+  const { data, error, isPending } = useGetAuditRecords(namespace, RECENT_ACTIVITY_QUERY);
+
+  if (error) {
+    return (
+      <ErrorState error={error} className="mx-6" />
+    );
+  }
+
+  if (isPending) {
+    return (
+      <ActivityCardSkeleton />
+    );
+  }
+
+  if (data.data.length === 0) {
+    return (
+      <ActivityCardEmpty title="No recent activity" />
+    );
+  }
+
+  return (
+    <ItemGroup size="xs" className="px-6">
+      {data.data.map(record => (
+        <ActivityCardItem key={record.id} record={record} />
+      ))}
+    </ItemGroup>
+  );
+}

--- a/konfigyr-frontend/src/components/reporting/dashboard-stats.tsx
+++ b/konfigyr-frontend/src/components/reporting/dashboard-stats.tsx
@@ -1,0 +1,138 @@
+import { FormattedMessage } from 'react-intl';
+import { ChevronRightIcon } from 'lucide-react';
+import { Link } from '@tanstack/react-router';
+import { useGetDashboard } from '@konfigyr/hooks';
+import { ErrorState } from '@konfigyr/components/error';
+import { Skeleton } from '@konfigyr/components/ui/skeleton';
+import { CounterStat, StatsCard } from './stats';
+
+import type { Namespace } from '@konfigyr/hooks/types';
+
+function SkeletonStat() {
+  return (
+    <div data-slot="skeleton-stat" className="col-span-1 flex flex-col gap-2 border-r last:border-none">
+      <Skeleton className="h-4 w-28" />
+      <Skeleton className="h-6 w-6" />
+    </div>
+  );
+}
+
+export function DashboardStats({ namespace }: { namespace: Namespace }) {
+  const { data, error, isPending } = useGetDashboard(namespace);
+
+  if (error) {
+    return (
+      <StatsCard>
+        <ErrorState error={error} className="col-span-full" />
+      </StatsCard>
+    );
+  }
+
+  if (isPending) {
+    return (
+      <StatsCard>
+        <SkeletonStat />
+        <SkeletonStat />
+        <SkeletonStat />
+        <SkeletonStat />
+        <SkeletonStat />
+      </StatsCard>
+    );
+  }
+
+  return (
+    <StatsCard>
+      <CounterStat
+        title={(
+          <FormattedMessage
+            defaultMessage="Active services"
+            description="Title of the active services stat tile on the namespace dashboard"
+          />
+        )}
+        counter={data.activeServices}
+        footer={(
+          <FormattedMessage
+            defaultMessage="Deployed here"
+            description="Footer label of the active services stat tile on the namespace dashboard"
+          />
+        )}
+      />
+      <CounterStat
+        title={(
+          <FormattedMessage
+            defaultMessage="Active configurations"
+            description="Title of the active configurations stat tile on the namespace dashboard"
+          />
+        )}
+        counter={data.activeConfigurations}
+        footer={(
+          <FormattedMessage
+            defaultMessage="{count, plural, =0 {No services created} one {Across # service} other {Across # services}}"
+            description="Footer label of the active configurations stat tile on the namespace dashboard"
+            values={{ count: data.activeServices }}
+          />
+        )}
+      />
+      <CounterStat
+        title={(
+          <FormattedMessage
+            defaultMessage="Open change requests"
+            description="Title of the open change requests stat tile on the namespace dashboard"
+          />
+        )}
+        counter={data.openChangeRequests}
+        footer={(
+          <FormattedMessage
+            defaultMessage="{count, plural, =0 {All caught up} other {Awaiting review}}"
+            description="Footer label of the open change requests stat tile on the namespace dashboard"
+            values={{ count: data.openChangeRequests }}
+          />
+        )}
+      />
+      <CounterStat
+        title={(
+          <FormattedMessage
+            defaultMessage="Artifacts owned"
+            description="Title of the artifacts owned stat tile on the namespace dashboard"
+          />
+        )}
+        counter={data.artifactsOwned}
+        cta={(
+          <Link
+            to="/namespace/$namespace/artifactory/registry"
+            params={{ namespace: namespace.slug }}
+            className="flex items-center justify-between gap-1"
+          >
+            <FormattedMessage
+              defaultMessage="Browse artifacts"
+              description="Link label in the artifacts owned stat tile on the namespace dashboard"
+            />
+            <ChevronRightIcon/>
+          </Link>
+        )}
+      />
+      <CounterStat
+        title={(
+          <FormattedMessage
+            defaultMessage="Active members"
+            description="Title of the active members stat tile on the namespace dashboard"
+          />
+        )}
+        counter={data.members.limit === null ? data.members.count : `${data.members.count} / ${data.members.limit}`}
+        cta={(
+          <Link
+            to="/namespace/$namespace/members"
+            params={{ namespace: namespace.slug }}
+            className="flex items-center justify-between gap-1"
+          >
+            <FormattedMessage
+              defaultMessage="Manage members"
+              description="Link label in the active members stat tile on the namespace dashboard"
+            />
+            <ChevronRightIcon />
+          </Link>
+        )}
+      />
+    </StatsCard>
+  );
+}

--- a/konfigyr-frontend/src/components/reporting/stats.tsx
+++ b/konfigyr-frontend/src/components/reporting/stats.tsx
@@ -2,15 +2,31 @@ import { cn } from '@konfigyr/components/utils';
 
 import type { ComponentProps, ReactNode } from 'react';
 
-export function CounterStat({ title, counter, className }: { title: string | ReactNode, counter: number, className?: string }) {
+export function CounterStat({ title, counter, cta, footer, className }: {
+  title: ReactNode;
+  counter: ReactNode;
+  cta?: ReactNode;
+  footer?: ReactNode;
+  className?: string;
+}) {
   return (
-    <div className={cn('border-r last:border-none', className)}>
+    <div className={cn('px-2 border-r last:border-none', className)}>
       <div className="font-medium text-xs text-report-card-foreground/70">
         {title}
       </div>
-      <div className="font-semibold text-lg text-report-card-accent-foreground py-1">
+      <div className="font-heading font-semibold text-3xl text-report-card-accent-foreground py-1">
         {counter}
       </div>
+      {cta && (
+        <div className="text-xs text-primary [&_svg]:size-4">
+          {cta}
+        </div>
+      )}
+      {footer && (
+        <div className="text-xs text-report-card-foreground/70">
+          {footer}
+        </div>
+      )}
     </div>
   );
 }
@@ -19,12 +35,12 @@ export function StatsCard({ className, children, ...props }: ComponentProps<'div
   return (
     <div
       data-slot="stats-card"
-      className={cn('bg-report-card text-report-card-foreground flex flex-col gap-4 rounded-xl shadow py-4', className)}
+      className={cn('bg-report-card text-report-card-foreground flex flex-col gap-2 rounded-xl shadow py-4', className)}
       {...props}
     >
       <div
         data-slot="stats-card-content"
-        className="grid grid-cols-2 md:grid-cols-4 gap-6 px-6"
+        className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4 px-6"
       >
         {children}
       </div>

--- a/konfigyr-frontend/src/hooks/index.ts
+++ b/konfigyr-frontend/src/hooks/index.ts
@@ -6,6 +6,7 @@ export * from './groups/query';
 export * from './kms/query';
 export * from './memberships/query';
 export * from './namespace/context';
+export * from './namespace/dashboard/query';
 export * from './namespace/query';
 export * from './transfers/query';
 export * from './vault/change-requests';

--- a/konfigyr-frontend/src/hooks/namespace/dashboard/query.ts
+++ b/konfigyr-frontend/src/hooks/namespace/dashboard/query.ts
@@ -1,0 +1,32 @@
+import { queryOptions, useQuery } from '@tanstack/react-query';
+import request from '@konfigyr/lib/http';
+
+import type { DashboardSummary } from './types';
+import type { Namespace } from '../types';
+
+/**
+ * Keys used to store the namespace dashboard summary in the query client.
+ */
+export const dashboardKeys = {
+  getDashboardSummary: (namespace: string) => ['namespace', namespace, 'dashboard'],
+};
+
+/**
+ * Attempts to retrieve the dashboard summary for the given namespace from the Konfigyr API server.
+ */
+export const getDashboardQuery = (namespace: Namespace) => {
+  return queryOptions({
+    queryKey: dashboardKeys.getDashboardSummary(namespace.slug),
+    queryFn: async ({ signal }): Promise<DashboardSummary> => {
+      return await request.get(`api/namespaces/${namespace.slug}/dashboard`, { signal }).json<DashboardSummary>();
+    },
+    staleTime: 30_000,
+  });
+};
+
+/**
+ * Hook that retrieves the dashboard summary for the given namespace from the Konfigyr API server.
+ */
+export const useGetDashboard = (namespace: Namespace) => {
+  return useQuery(getDashboardQuery(namespace));
+};

--- a/konfigyr-frontend/src/hooks/namespace/dashboard/types.ts
+++ b/konfigyr-frontend/src/hooks/namespace/dashboard/types.ts
@@ -1,0 +1,10 @@
+export interface DashboardSummary {
+  activeServices: number;
+  members: {
+    count: number;
+    limit: number | null;
+  };
+  openChangeRequests: number;
+  activeConfigurations: number;
+  artifactsOwned: number;
+}

--- a/konfigyr-frontend/src/hooks/types.ts
+++ b/konfigyr-frontend/src/hooks/types.ts
@@ -5,6 +5,7 @@ export type * from './groups/types';
 export type * from './hateoas/types';
 export type * from './kms/types';
 export type * from './memberships/types';
+export type * from './namespace/dashboard/types';
 export type * from './namespace/types';
 export type * from './transfers/types';
 export type * from './vault/types';

--- a/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/index.tsx
+++ b/konfigyr-frontend/src/routes/_authenticated/namespace/$namespace/index.tsx
@@ -1,35 +1,50 @@
+import { FormattedMessage } from 'react-intl';
 import {
   LayoutContent,
   LayoutNavbar,
 } from '@konfigyr/components/layout';
 import {
   ActivityCard,
-  ActivityCardEmpty,
   ActivityCardTitle,
 } from '@konfigyr/components/reporting/activity';
-import { CounterStat, StatsCard } from '@konfigyr/components/reporting/stats';
+import { ActivityCardList, RECENT_ACTIVITY_QUERY } from '@konfigyr/components/reporting/activity-item';
+import { DashboardStats } from '@konfigyr/components/reporting/dashboard-stats';
+import { getAuditRecordsQuery, getDashboardQuery, useNamespace } from '@konfigyr/hooks';
 import { createFileRoute } from '@tanstack/react-router';
 
+import type { Namespace } from '@konfigyr/hooks/types';
+
 export const Route = createFileRoute('/_authenticated/namespace/$namespace/')({
+  loader: async ({ context, parentMatchPromise }) => {
+    const match = await parentMatchPromise;
+    const namespace = match.loaderData as Namespace;
+
+    await Promise.all([
+      context.queryClient.prefetchQuery(getDashboardQuery(namespace)),
+      context.queryClient.prefetchQuery(getAuditRecordsQuery(namespace, RECENT_ACTIVITY_QUERY)),
+    ]);
+  },
   component: RouteComponent,
 });
 
 function RouteComponent() {
+  const namespace = useNamespace();
+
   return (
     <LayoutContent>
       <LayoutNavbar title="Overview"/>
 
       <div className="w-full lg:w-4/5 xl:w-2/3 space-y-6 px-4 mx-auto">
-        <StatsCard>
-          <CounterStat title="Active services" counter={1} />
-          <CounterStat title="Active configurations" counter={124} />
-          <CounterStat title="Active change requests" counter={4} />
-          <CounterStat title="Active members" counter={3} />
-        </StatsCard>
+        <DashboardStats namespace={namespace} />
 
         <ActivityCard>
-          <ActivityCardTitle>Recent activity</ActivityCardTitle>
-          <ActivityCardEmpty title="No recent activity" />
+          <ActivityCardTitle>
+            <FormattedMessage
+              defaultMessage="Recent activity"
+              description="Title of the recent activity card"
+            />
+          </ActivityCardTitle>
+          <ActivityCardList namespace={namespace} />
         </ActivityCard>
       </div>
     </LayoutContent>

--- a/konfigyr-frontend/test/components/reporting/activity-item.test.tsx
+++ b/konfigyr-frontend/test/components/reporting/activity-item.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor, within } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
+import { server } from '@konfigyr/test/helpers/server';
+import { audit, namespaces } from '@konfigyr/test/helpers/mocks';
+import { ActivityCardList } from '@konfigyr/components/reporting/activity-item';
+
+describe('components | reporting | <ActivityCardList/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render the empty state when the namespace has no recent activity', async () => {
+    const { getByText } = renderComponentWithRouter(
+      <ActivityCardList namespace={namespaces.johnDoe} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('No recent activity')).toBeInTheDocument();
+    });
+  });
+
+  test('should render each record with its actor, message and relative timestamp', async () => {
+    const { getByRole } = renderComponentWithRouter(
+      <ActivityCardList namespace={namespaces.konfigyr} />,
+    );
+
+    await waitFor(() => {
+      expect(getByRole('listitem', { name: audit.namespaceCreated.message })).toBeInTheDocument();
+    });
+
+    const namespaceItem = getByRole('listitem', { name: audit.namespaceCreated.message });
+    const serviceItem = getByRole('listitem', { name: audit.serviceCreated.message });
+
+    expect(within(namespaceItem).getByText(audit.namespaceCreated.actor.name)).toBeInTheDocument();
+    expect(namespaceItem.querySelector('time')).toBeInTheDocument();
+    expect(within(serviceItem).getByText(audit.serviceCreated.actor.name)).toBeInTheDocument();
+  });
+
+  test('should render an error state when the audit records request fails', async () => {
+    server.use(
+      http.get('http://localhost/api/namespaces/:slug/audit', () => (
+        HttpResponse.json({
+          status: 500,
+          title: 'Internal server error',
+          detail: 'Something went wrong while loading the recent activity.',
+        }, { status: 500 })
+      )),
+    );
+
+    const { getByText, queryByText } = renderComponentWithRouter(
+      <ActivityCardList namespace={namespaces.konfigyr} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('Internal server error')).toBeInTheDocument();
+    });
+
+    expect(queryByText('No recent activity')).not.toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/reporting/dashboard-stats.test.tsx
+++ b/konfigyr-frontend/test/components/reporting/dashboard-stats.test.tsx
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, test } from 'vitest';
+import { cleanup, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import { renderComponentWithRouter } from '@konfigyr/test/helpers/router';
+import { dashboard, namespaces } from '@konfigyr/test/helpers/mocks';
+import { server } from '@konfigyr/test/helpers/server';
+import { DashboardStats } from '@konfigyr/components/reporting/dashboard-stats';
+
+describe('components | reporting | <DashboardStats/>', () => {
+  afterEach(() => cleanup());
+
+  test('should render all 5 stat tiles with the members limit', async () => {
+    const { getByText, getByRole, queryByText } = renderComponentWithRouter(
+      <DashboardStats namespace={namespaces.konfigyr} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('Active services')).toBeInTheDocument();
+    });
+
+    expect(getByText('4')).toBeInTheDocument();
+    expect(getByText('128')).toBeInTheDocument();
+    expect(getByText('3')).toBeInTheDocument();
+    expect(getByText('12 / 25')).toBeInTheDocument();
+    expect(getByText('7')).toBeInTheDocument();
+    expect(getByText('Artifacts owned')).toBeInTheDocument();
+    expect(queryByText('12')).not.toBeInTheDocument();
+
+    expect(getByText('Deployed here')).toBeInTheDocument();
+    expect(getByText('Across 4 services')).toBeInTheDocument();
+    expect(getByText('Awaiting review')).toBeInTheDocument();
+
+    expect(getByRole('link', { name: /Browse artifacts/ }))
+      .toHaveAttribute('href', '/namespace/konfigyr/artifactory/registry');
+    expect(getByRole('link', { name: /Manage members/ }))
+      .toHaveAttribute('href', '/namespace/konfigyr/members');
+  });
+
+  test('should render the members tile without a limit for unlimited plans', async () => {
+    const { getByText, getByRole, queryByText } = renderComponentWithRouter(
+      <DashboardStats namespace={namespaces.johnDoe} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('5')).toBeInTheDocument();
+    });
+
+    expect(queryByText(/\//)).not.toBeInTheDocument();
+    expect(getByRole('link', { name: /Manage members/ }))
+      .toHaveAttribute('href', '/namespace/john-doe/members');
+  });
+
+  test('should show a positive message when there are no open change requests', async () => {
+    server.use(
+      http.get('http://localhost/api/namespaces/:slug/dashboard', () => (
+        HttpResponse.json({ ...dashboard.konfigyrSummary, openChangeRequests: 0 })
+      )),
+    );
+
+    const { getByText, queryByText } = renderComponentWithRouter(
+      <DashboardStats namespace={namespaces.konfigyr} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('All caught up')).toBeInTheDocument();
+    });
+
+    expect(queryByText('Awaiting review')).not.toBeInTheDocument();
+  });
+
+  test('should use singular grammar when there is exactly one active service', async () => {
+    server.use(
+      http.get('http://localhost/api/namespaces/:slug/dashboard', () => (
+        HttpResponse.json({ ...dashboard.konfigyrSummary, activeServices: 1 })
+      )),
+    );
+
+    const { getByText, queryByText } = renderComponentWithRouter(
+      <DashboardStats namespace={namespaces.konfigyr} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('Across 1 service')).toBeInTheDocument();
+    });
+
+    expect(queryByText('Across 1 services')).not.toBeInTheDocument();
+  });
+
+  test('should render an error state when the summary request fails', async () => {
+    server.use(
+      http.get('http://localhost/api/namespaces/:slug/dashboard', () => (
+        HttpResponse.json({
+          status: 500,
+          title: 'Internal server error',
+          detail: 'Something went wrong while loading the dashboard summary.',
+        }, { status: 500 })
+      )),
+    );
+
+    const { getByText, queryByText } = renderComponentWithRouter(
+      <DashboardStats namespace={namespaces.konfigyr} />,
+    );
+
+    await waitFor(() => {
+      expect(getByText('Internal server error')).toBeInTheDocument();
+    });
+
+    expect(queryByText('Active services')).not.toBeInTheDocument();
+  });
+});

--- a/konfigyr-frontend/test/components/reporting/stats.test.tsx
+++ b/konfigyr-frontend/test/components/reporting/stats.test.tsx
@@ -15,4 +15,20 @@ describe('components | reporting | <StatsCard/>', () => {
     expect(result.getByText('Counter')).toBeInTheDocument();
     expect(result.getByText('1234')).toBeInTheDocument();
   });
+
+  test('should render an optional cta and footer', () => {
+    const result = render(
+      <StatsCard>
+        <CounterStat
+          title="Counter"
+          counter={1234}
+          cta={<a href="/somewhere">Go</a>}
+          footer="Footer text"
+        />
+      </StatsCard>,
+    );
+
+    expect(result.getByRole('link', { name: 'Go' })).toBeInTheDocument();
+    expect(result.getByText('Footer text')).toBeInTheDocument();
+  });
 });

--- a/konfigyr-frontend/test/helpers/mocks.ts
+++ b/konfigyr-frontend/test/helpers/mocks.ts
@@ -11,6 +11,7 @@ export * as transfers from './mocks/transfers';
 export * as groupVerifications from './mocks/group-verifications';
 export * as changeRequests from './mocks/change-requests';
 export * as audit from './mocks/audit';
+export * as dashboard from './mocks/dashboard';
 
 export const isValidProfile = (slug?: string | unknown) => (
   slug === profiles.development.slug || slug === profiles.staging.slug || slug === profiles.deprecated.slug

--- a/konfigyr-frontend/test/helpers/mocks/dashboard.ts
+++ b/konfigyr-frontend/test/helpers/mocks/dashboard.ts
@@ -1,0 +1,23 @@
+import type { DashboardSummary } from '@konfigyr/hooks/types';
+
+export const konfigyrSummary: DashboardSummary = {
+  activeServices: 4,
+  members: {
+    count: 12,
+    limit: 25,
+  },
+  openChangeRequests: 3,
+  activeConfigurations: 128,
+  artifactsOwned: 7,
+};
+
+export const johnDoeSummary: DashboardSummary = {
+  activeServices: 9,
+  members: {
+    count: 5,
+    limit: null,
+  },
+  openChangeRequests: 2,
+  activeConfigurations: 41,
+  artifactsOwned: 6,
+};

--- a/konfigyr-frontend/test/helpers/server.ts
+++ b/konfigyr-frontend/test/helpers/server.ts
@@ -10,6 +10,7 @@ import groups from './server/namespace/groups';
 import invitations from './server/namespace/invitations';
 import transfers from './server/namespace/transfers';
 import audit from './server/audit';
+import dashboard from './server/dashboard';
 import oidc from './server/oidc';
 import proxy from './server/proxy';
 import services from './server/services';
@@ -27,6 +28,7 @@ export const handlers = [
   ...invitations,
   ...transfers,
   ...audit,
+  ...dashboard,
   ...oidc,
   ...proxy,
   ...services,

--- a/konfigyr-frontend/test/helpers/server/dashboard.ts
+++ b/konfigyr-frontend/test/helpers/server/dashboard.ts
@@ -1,0 +1,23 @@
+import { HttpResponse, http } from 'msw';
+import * as namespaces from '../mocks/namespace';
+import { johnDoeSummary, konfigyrSummary } from '../mocks/dashboard';
+
+const summary = http.get('http://localhost/api/namespaces/:slug/dashboard', ({ params }) => {
+  if (params.slug === namespaces.unknown.slug) {
+    return HttpResponse.json({
+      status: 404,
+      title: 'Not found',
+      detail: `Namespace with slug '${params.slug}' not found.`,
+    }, { status: 404 });
+  }
+
+  if (params.slug === namespaces.johnDoe.slug) {
+    return HttpResponse.json(johnDoeSummary);
+  }
+
+  return HttpResponse.json(konfigyrSummary);
+});
+
+export default [
+  summary,
+];


### PR DESCRIPTION
Replaces the hardcoded stat tiles and always-empty activity card on the namespace overview page (`/namespace/$namespace`) with live data.

- New `useGetDashboard` hook + `DashboardStats` component render the 5 stat tiles (active services, active configurations, open change requests, active members, artifacts owned) from the dashboard summary endpoint, including bespoke "X / Y" vs. unlimited formatting for the members tile, contextual footers, and CTA links to the artifact registry and members pages.
- New `ActivityCardList` component renders the 5 most recent audit records (actor, message, relative timestamp), falling back to the existing empty state when there's no recent activity.
- The route loader prefetches both the dashboard summary and audit records via `prefetchQuery` so there's no client-side loading flash on first render, while a failed summary or activity fetch shows a local error state scoped to that section instead of taking over the whole page.