### PR TITLE
Split service release endpoints by audience

### DIFF
--- a/.claude/skills/backend/spring-security-oauth2/SKILL.md
+++ b/.claude/skills/backend/spring-security-oauth2/SKILL.md
@@ -21,7 +21,7 @@ The Identity Provider is an **identity broker**: it accepts authentication from 
 
 **Machine token flow (namespace OAuth2 clients):**
 1. CI/CD pipeline or build plugin authenticates via Client Credentials with konfigyr-identity
-2. konfigyr-identity issues PS256 JWT with `scope` claim and `kfg_namespace` claim
+2. konfigyr-identity issues PS256 JWT with `scope` claim and `namespace` claim
 3. Plugin/pipeline includes token in `Authorization: Bearer <token>` header
 4. Same scope enforcement applies
 
@@ -31,12 +31,14 @@ There are two distinct token personas. Code that reads JWT claims must account f
 
 | Claim | User token | Namespace client token |
 |-------|-----------|----------------------|
-| `sub` | Konfigyr Account ID (internal, **not** the external provider's UID) | OAuth2 client ID |
+| `sub` | Konfigyr Account ID (internal, **not** the external provider's UID) | OAuth2 client ID (starts with `kfg-`) |
 | `email` | User's email address | not present |
-| `scope` | User's granted scopes | Client's granted scopes (e.g. `metadata:upload`) |
-| `kfg_namespace` | not present | Namespace `EntityId` — use this to identify which namespace the client belongs to |
+| `scope` | User's granted scopes | Client's granted scopes (e.g. `namespaces:publish-releases`) |
+| `namespace` (`KonfigyrClaimNames.NAMESPACE`) | not present | Namespace `EntityId` (serialized) — identifies which namespace the client belongs to |
 
 > `sub` is always a Konfigyr-internal identifier. It will never be a GitHub username or external UID — the broker normalises all external identities before issuing the token.
+>
+> The `namespace` claim name is defined by the `KonfigyrClaimNames.NAMESPACE` constant (`konfigyr-core`) — always reference the constant, never the raw string literal.
 
 ---
 
@@ -91,32 +93,43 @@ class NamespaceController {
 @RequiresScope("read:namespaces")
 ```
 
-**Common scopes:**
+**Scopes** (`OAuthScope` enum, `konfigyr-core`):
+- `OPENID` — OIDC identity verification
 - `READ_NAMESPACES` — Read namespace metadata
-- `WRITE_NAMESPACES` — Create/update namespaces
-- `DELETE_NAMESPACES` — Delete namespaces
-- `READ_VAULT` — Read vault entries
-- `WRITE_VAULT` — Write vault entries
-- `READ_AUDIT` — Read audit logs
-- `MANAGE_KMS` — Manage encryption keys
-- `MANAGE_MEMBERS` — Invite/remove members
+- `WRITE_NAMESPACES` — Create/update namespaces (implies `READ_NAMESPACES`)
+- `DELETE_NAMESPACES` — Delete namespaces (implies `WRITE_NAMESPACES`)
+- `INVITE_MEMBERS` — Create and manage invitations (implies `READ_NAMESPACES`)
+- `PUBLISH_RELEASES` — Resolve, upload to, and complete service releases (implies `READ_NAMESPACES`)
+- `NAMESPACES` — Aggregate: all of the above namespace scopes
+- `READ_ARTIFACTS` — Read Artifactory artifacts and their property definitions
+- `PUBLISH_ARTIFACTS` — Publish new artifact versions (implies `READ_ARTIFACTS`)
+- `READ_PROFILES` — Read service profiles
+- `WRITE_PROFILES` — Write service profiles (implies `READ_PROFILES`)
+- `DELETE_PROFILES` — Delete service profiles (implies `WRITE_PROFILES`)
+- `PROFILES` — Aggregate: all of the above profile scopes
 
 ---
 
 ## Scope Hierarchy
 
-Scopes form a hierarchy—broader scopes imply narrower ones:
+Scopes form a hierarchy—broader scopes imply narrower ones. Each `OAuthScope` enum constant declares its included scopes directly (see `OAuthScope#getIncluded()`), rather than following one blanket READ → WRITE → DELETE rule:
 
 ```
-WRITE implies READ
-DELETE is independent
-MANAGE_* scopes don't imply READ/WRITE
+DELETE_NAMESPACES implies WRITE_NAMESPACES implies READ_NAMESPACES
+INVITE_MEMBERS implies READ_NAMESPACES
+PUBLISH_RELEASES implies READ_NAMESPACES
+NAMESPACES implies all of the above namespace scopes
+
+PUBLISH_ARTIFACTS implies READ_ARTIFACTS
+
+DELETE_PROFILES implies WRITE_PROFILES implies READ_PROFILES
+PROFILES implies all of the above profile scopes
 ```
 
 **Examples:**
 - Client with `WRITE_NAMESPACES` can also call `READ_NAMESPACES` endpoints
-- Client with `DELETE_NAMESPACES` can only delete (must separately grant READ or WRITE)
-- `MANAGE_KMS` doesn't grant READ/WRITE to other resources
+- Client with `PUBLISH_RELEASES` can also call `READ_NAMESPACES` endpoints, but not `WRITE_NAMESPACES` ones
+- Scopes across different resource families never imply one another — `PUBLISH_ARTIFACTS` doesn't grant anything in the `NAMESPACES` or `PROFILES` families
 
 ---
 
@@ -292,10 +305,10 @@ Apply same scope to all methods in a controller:
 
 ```java
 @RestController
-@RequestMapping("/vault")
-@RequiresScope(OAuthScope.READ_VAULT)
-class VaultController {
-    // All methods require READ_VAULT or higher
+@RequestMapping("/namespaces/{namespace}/services")
+@RequiresScope(OAuthScope.READ_NAMESPACES)
+class ServicesController {
+    // All methods require READ_NAMESPACES or higher
 }
 ```
 
@@ -304,12 +317,49 @@ class VaultController {
 If endpoint requires multiple scopes, list them:
 
 ```java
-@PostMapping("/entries")
-@RequiresScope({OAuthScope.WRITE_VAULT, OAuthScope.ADMIN})
-ResponseEntity<Void> createEntry(@RequestBody VaultEntry entry) {
-    // Accepts if client has WRITE_VAULT OR ADMIN
+@PostMapping("/{slug}/trusted-issuers")
+@RequiresScope({OAuthScope.WRITE_NAMESPACES, OAuthScope.INVITE_MEMBERS})
+ResponseEntity<Void> createTrustedIssuer(@RequestBody NamespaceTrustedIssuerDefinition definition) {
+    // Accepts if client has WRITE_NAMESPACES OR INVITE_MEMBERS
 }
 ```
+
+### Machine Client: Resolving the Namespace from the Token Claim
+
+Namespace-scoped OAuth2 clients (e.g. build plugins with `PUBLISH_RELEASES`) never pass their namespace
+as a path variable — resolve it from the trusted `namespace` JWT claim instead, via `NamespacedPrincipal`:
+
+```java
+@PostMapping
+@RequiresScope(OAuthScope.PUBLISH_RELEASES)
+EntityModel<ServiceRelease> resolve(@RequestBody List<ServiceReleaseCandidate> candidates) {
+    final Namespace ns = currentNamespace();
+    // ...
+}
+
+@NonNull
+private Namespace currentNamespace() {
+    final AuthenticatedPrincipal principal = AuthenticatedPrincipal.resolve();
+
+    if (!(principal instanceof NamespacedPrincipal namespaced)) {
+        throw new AccessDeniedException("Authenticated principal is not scoped to a namespace");
+    }
+
+    final EntityId id = namespaced.getNamespaceId().orElseThrow(
+            () -> new AccessDeniedException("Authenticated principal is missing its namespace claim")
+    );
+
+    return namespaces.findById(id).orElseThrow(
+            () -> new AccessDeniedException("Authenticated principal's namespace claim does not match a known namespace")
+    );
+}
+```
+
+Treat every failure to resolve a namespace this way as an authorization failure (`AccessDeniedException`,
+403), not a not-found or server error: a token that reaches the endpoint without a resolvable namespace
+claim isn't entitled to act on any namespace, regardless of the reason. `AccessDeniedException`'s detail
+message is replaced app-wide by a generic message (see `problem-detail.properties`), so it's safe to
+describe the failure reason in the exception message without leaking it to the client.
 
 ### Accessing Token Claims
 
@@ -454,7 +504,7 @@ String getData(@RequestParam String scope) {
 }
 
 // ✓ Correct: Use authenticated token
-@RequiresScope(OAuthScope.ADMIN)
+@RequiresScope(OAuthScope.NAMESPACES)
 String getData() { ... }
 ```
 
@@ -465,12 +515,11 @@ String getData() { ... }
 ### Be Specific
 
 ```java
-// ✗ Too broad: One scope for everything
-@RequiresScope(OAuthScope.ADMIN)
+// ✗ Too broad: One aggregate scope for a narrow operation
+@RequiresScope(OAuthScope.NAMESPACES)
 
-// ✓ Specific: Granular scopes
-@RequiresScope(OAuthScope.READ_AUDIT)
-@RequiresScope(OAuthScope.WRITE_VAULT)
+// ✓ Specific: Granular scope for what the endpoint actually needs
+@RequiresScope(OAuthScope.PUBLISH_RELEASES)
 ```
 
 ### Follow Hierarchy

--- a/.claude/skills/shared/project-overview/SKILL.md
+++ b/.claude/skills/shared/project-overview/SKILL.md
@@ -351,6 +351,36 @@ PUT      /namespaces/{namespace}/kms/{id}/keys/{key}/{deactivate|reactivate|comp
 POST     /namespaces/{namespace}/kms/{id}/{encrypt|decrypt|sign|verify}   isMember, @RequiresScope(WRITE_NAMESPACES)
 ```
 
+### Service Manifest / Release Endpoints
+
+Split by audience into two controllers, each with a different auth model — there is no shared
+namespace-scoped `/releases` path used by both:
+
+`ServiceManifestController` — plugin-only, namespace-free. Authenticated as a namespace OAuth2 client
+(`NamespaceClientId`, `kfg-` prefixed `client_id`); the owning namespace is resolved from the `namespace`
+JWT claim (`KonfigyrClaimNames.NAMESPACE`) via `NamespacedPrincipal`, never from a path variable. No
+`isMember`/`isAdmin` check — namespace isolation comes from the trusted claim plus `Services.get(ns, slug)`
+scoping the service lookup to that namespace.
+
+```
+POST   /releases/{service}                  @RequiresScope(PUBLISH_RELEASES)   resolve/open a release
+GET    /releases/{service}/{id}             @RequiresScope(PUBLISH_RELEASES)
+POST   /releases/{service}/{id}/artifacts   @RequiresScope(PUBLISH_RELEASES)   upload artifact metadata
+POST   /releases/{service}/{id}/complete    @RequiresScope(PUBLISH_RELEASES)
+```
+
+`ServicesController` — UI-only, namespace-path-scoped, session-authenticated, unchanged `isMember` +
+`READ_NAMESPACES` pattern used by the rest of this controller. Read-only: no resolve/upload/complete.
+
+```
+GET    /namespaces/{namespace}/services/{slug}/manifest        isMember, @RequiresScope(READ_NAMESPACES)
+GET    /namespaces/{namespace}/services/{slug}/releases/{id}   isMember, @RequiresScope(READ_NAMESPACES)
+```
+
+Root is `/releases`, matching the `ServiceRelease` aggregate — deliberately not `/publish` (reserved for
+the Artifactory bounded context: `PublicationsController`/`Publications`) and not nested under a generic
+`/services` wrapper.
+
 ## Frontend Routes
 
 File-based TanStack Start routing under `konfigyr-frontend/src/routes`. Most app routes sit under a

--- a/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/artifactory/controller/ArtifactoryController.java
@@ -21,7 +21,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.util.StringUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
@@ -123,7 +123,7 @@ class ArtifactoryController {
 			@RequestBody @Validated ArtifactPublication publication,
 			BindingResult errors
 	) throws BindException {
-		final Owner owner = resolveOwner().orElseThrow(() -> new AuthenticationCredentialsNotFoundException(
+		final Owner owner = resolveOwner().orElseThrow(() -> new AccessDeniedException(
 				"Could not extract namespace identifier from the current authenticated principal"
 		));
 
@@ -151,7 +151,7 @@ class ArtifactoryController {
 			@PathVariable String artifactId,
 			@RequestBody @Validated ChangeVisibilityRequest request
 	) {
-		final Owner owner = resolveOwner().orElseThrow(() -> new AuthenticationCredentialsNotFoundException(
+		final Owner owner = resolveOwner().orElseThrow(() -> new AccessDeniedException(
 				"Could not extract namespace identifier from the current authenticated principal"
 		));
 

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/Assemblers.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/Assemblers.java
@@ -33,19 +33,21 @@ interface Assemblers {
 	static RepresentationModelAssembler<Service, EntityModel<Service>> service(Namespace namespace) {
 		return service -> EntityModel.of(service, linkBuilder(namespace, service).selfRel())
 				.add(linkBuilder(namespace, service).path("manifest").rel("manifest"))
-				.add(linkBuilder(namespace, service).method(HttpMethod.POST).path("manifest").rel("release"))
 				.add(linkBuilder(namespace, service).method(HttpMethod.DELETE).rel("delete"));
 	}
 
 	static RepresentationModelAssembler<Manifest, EntityModel<Manifest>> manifest(Namespace namespace, Service service) {
-		return manifest -> EntityModel.of(manifest, linkBuilder(namespace, service).path("manifest").selfRel())
-				.add(linkBuilder(namespace, service).path("manifest").method(HttpMethod.POST).rel("release"));
+		return manifest -> EntityModel.of(manifest, linkBuilder(namespace, service).path("manifest").selfRel());
 	}
 
 	static RepresentationModelAssembler<ServiceRelease, EntityModel<ServiceRelease>> release(Namespace namespace, Service service) {
-		return release -> EntityModel.of(release, linkBuilder(namespace, service, release).selfRel())
-				.add(linkBuilder(namespace, service, release).path("artifacts").method(HttpMethod.POST).rel("upload artifact metadata"))
-				.add(linkBuilder(namespace, service, release).path("complete").method(HttpMethod.POST).rel("complete service release"));
+		return release -> EntityModel.of(release, linkBuilder(namespace, service, release).selfRel());
+	}
+
+	static RepresentationModelAssembler<ServiceRelease, EntityModel<ServiceRelease>> release(Service service) {
+		return release -> EntityModel.of(release, linkBuilder(service, release).selfRel())
+				.add(linkBuilder(service, release).path("artifacts").method(HttpMethod.POST).rel("upload artifact metadata"))
+				.add(linkBuilder(service, release).path("complete").method(HttpMethod.POST).rel("complete service release"));
 	}
 
 	static RepresentationModelAssembler<ServiceCatalog, EntityModel<ServiceCatalog>> catalog(Namespace namespace) {
@@ -97,6 +99,12 @@ interface Assemblers {
 	static LinkBuilder linkBuilder(Namespace namespace, Service service, ServiceRelease release) {
 		return linkBuilder(namespace, service)
 				.path("releases")
+				.path(release.id());
+	}
+
+	static LinkBuilder linkBuilder(Service service, ServiceRelease release) {
+		return Link.builder().path("releases")
+				.path(service.slug())
 				.path(release.id());
 	}
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
@@ -27,6 +27,9 @@ import java.util.List;
  * Controller used by build plugins to resolve, upload artifacts to, and complete a {@link Service}
  * release. Endpoints are namespace-free: the owning {@link Namespace} is resolved from the namespace
  * claim carried by the authenticated namespace client's OAuth2 token rather than a URL path variable.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
  */
 @RestController
 @RequiredArgsConstructor
@@ -105,6 +108,8 @@ class ServiceManifestController {
 	 * Any failure to establish this namespace context is treated as an authorization failure rather
 	 * than a not-found or server error: a token that reaches this endpoint without a resolvable
 	 * namespace claim is not entitled to act on any namespace, regardless of the reason.
+	 *
+	 * @return the owning namespace resolved from the current authentication, never {@literal null}
 	 */
 	@NonNull
 	private Namespace currentNamespace() {

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServiceManifestController.java
@@ -5,121 +5,122 @@ import com.konfigyr.entity.EntityId;
 import com.konfigyr.hateoas.EntityModel;
 import com.konfigyr.namespace.Namespace;
 import com.konfigyr.namespace.NamespaceManager;
-import com.konfigyr.namespace.NamespaceNotFoundException;
 import com.konfigyr.namespace.Service;
 import com.konfigyr.namespace.ServiceNotFoundException;
 import com.konfigyr.namespace.Services;
 import com.konfigyr.namespace.manifest.ReleaseNotFoundException;
 import com.konfigyr.namespace.manifest.ServiceManifests;
+import com.konfigyr.security.AuthenticatedPrincipal;
+import com.konfigyr.security.NamespacedPrincipal;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+/**
+ * Controller used by build plugins to resolve, upload artifacts to, and complete a {@link Service}
+ * release. Endpoints are namespace-free: the owning {@link Namespace} is resolved from the namespace
+ * claim carried by the authenticated namespace client's OAuth2 token rather than a URL path variable.
+ */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/namespaces/{namespace}/services/{slug}")
+@RequestMapping("/releases/{service}")
 class ServiceManifestController {
 
 	private final NamespaceManager namespaces;
 	private final Services services;
 	private final ServiceManifests manifests;
 
-	@GetMapping("manifest")
-	@PreAuthorize("isMember(#namespace)")
-	@RequiresScope(OAuthScope.READ_NAMESPACES)
-	EntityModel<Manifest> manifest(@PathVariable @NonNull String namespace, @PathVariable @NonNull String slug) {
-		final Namespace ns = lookupNamespace(namespace);
-		final Service service = services.get(ns, slug).orElseThrow(
-				() -> new ServiceNotFoundException(namespace, slug)
-		);
-
-		return Assemblers.manifest(ns, service).assemble(manifests.get(service));
-	}
-
-	@PostMapping("releases")
-	@PreAuthorize("isMember(#namespace)")
+	@PostMapping
 	@RequiresScope(OAuthScope.PUBLISH_RELEASES)
 	EntityModel<ServiceRelease> resolve(
-			@PathVariable String namespace,
-			@PathVariable String slug,
+			@PathVariable String service,
 			@RequestBody List<ServiceReleaseCandidate> candidates
 	) {
-		final Namespace ns = lookupNamespace(namespace);
-		final Service service = services.get(ns, slug).orElseThrow(
-				() -> new ServiceNotFoundException(namespace, slug)
-		);
+		final Service svc = lookupService(service);
 
-		return Assemblers.release(ns, service).assemble(manifests.open(service, candidates));
+		return Assemblers.release(svc).assemble(manifests.open(svc, candidates));
 	}
 
-	@GetMapping("/releases/{id}")
-	@PreAuthorize("isMember(#namespace)")
+	@GetMapping("/{id}")
 	@RequiresScope(OAuthScope.PUBLISH_RELEASES)
 	EntityModel<ServiceRelease> release(
-			@PathVariable String namespace,
-			@PathVariable String slug,
+			@PathVariable String service,
 			@PathVariable EntityId id
 	) {
-		final Namespace ns = lookupNamespace(namespace);
-		final Service service = services.get(ns, slug).orElseThrow(
-				() -> new ServiceNotFoundException(namespace, slug)
-		);
+		final Service svc = lookupService(service);
 
-		final ServiceRelease release = manifests.get(service, id).orElseThrow(
+		final ServiceRelease release = manifests.get(svc, id).orElseThrow(
 				() -> new ReleaseNotFoundException(id)
 		);
 
-		return Assemblers.release(ns, service).assemble(release);
+		return Assemblers.release(svc).assemble(release);
 	}
 
-	@PostMapping("/releases/{id}/artifacts")
+	@PostMapping("/{id}/artifacts")
 	@ResponseStatus(HttpStatus.NO_CONTENT)
-	@PreAuthorize("isMember(#namespace)")
 	@RequiresScope(OAuthScope.PUBLISH_RELEASES)
 	void upload(
-			@PathVariable String namespace,
-			@PathVariable String slug,
+			@PathVariable String service,
 			@PathVariable EntityId id,
 			@RequestBody ArtifactMetadata metadata
 	) {
-		final Namespace ns = lookupNamespace(namespace);
-		final Service service = services.get(ns, slug).orElseThrow(
-				() -> new ServiceNotFoundException(namespace, slug)
-		);
-
-		manifests.upload(service, id, metadata);
+		manifests.upload(lookupService(service), id, metadata);
 	}
 
-	@PostMapping("/releases/{id}/complete")
-	@PreAuthorize("isMember(#namespace)")
+	@PostMapping("/{id}/complete")
 	@RequiresScope(OAuthScope.PUBLISH_RELEASES)
 	ResponseEntity<EntityModel<ServiceRelease>> complete(
-			@PathVariable String namespace,
-			@PathVariable String slug,
+			@PathVariable String service,
 			@PathVariable EntityId id
 	) {
-		final Namespace ns = lookupNamespace(namespace);
-		final Service service = services.get(ns, slug).orElseThrow(
-				() -> new ServiceNotFoundException(namespace, slug)
-		);
+		final Service svc = lookupService(service);
 
-		final ServiceRelease release = manifests.complete(service, id);
+		final ServiceRelease release = manifests.complete(svc, id);
 		final HttpStatus status = release.state() == ReleaseState.FAILED ? HttpStatus.CONFLICT : HttpStatus.OK;
 
 		return ResponseEntity.status(status)
-				.body(Assemblers.release(ns, service).assemble(release));
+				.body(Assemblers.release(svc).assemble(release));
 	}
 
 	@NonNull
-	Namespace lookupNamespace(@NonNull String slug) {
-		return namespaces.findBySlug(slug).orElseThrow(() -> new NamespaceNotFoundException(slug));
+	private Service lookupService(@NonNull String slug) {
+		final Namespace namespace = currentNamespace();
+
+		return services.get(namespace, slug).orElseThrow(
+				() -> new ServiceNotFoundException(namespace.slug(), slug)
+		);
+	}
+
+	/**
+	 * Resolves the {@link Namespace} that owns the authenticated namespace client, using the
+	 * namespace claim carried by its OAuth2 token rather than a URL path variable.
+	 * <p>
+	 * Any failure to establish this namespace context is treated as an authorization failure rather
+	 * than a not-found or server error: a token that reaches this endpoint without a resolvable
+	 * namespace claim is not entitled to act on any namespace, regardless of the reason.
+	 */
+	@NonNull
+	private Namespace currentNamespace() {
+		final AuthenticatedPrincipal principal = AuthenticatedPrincipal.resolve();
+
+		if (!(principal instanceof NamespacedPrincipal namespaced)) {
+			throw new AccessDeniedException("Authenticated principal is not scoped to a namespace");
+		}
+
+		final EntityId id = namespaced.getNamespaceId().orElseThrow(
+				() -> new AccessDeniedException("Authenticated principal is missing its namespace claim")
+		);
+
+		return namespaces.findById(id).orElseThrow(
+				() -> new AccessDeniedException("Authenticated principal's namespace claim does not match a known namespace")
+		);
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServicesController.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/namespace/controller/ServicesController.java
@@ -1,9 +1,14 @@
 package com.konfigyr.namespace.controller;
 
+import com.konfigyr.artifactory.Manifest;
 import com.konfigyr.artifactory.PropertyDescriptor;
+import com.konfigyr.artifactory.ServiceRelease;
+import com.konfigyr.entity.EntityId;
 import com.konfigyr.hateoas.EntityModel;
 import com.konfigyr.hateoas.PagedModel;
 import com.konfigyr.namespace.*;
+import com.konfigyr.namespace.manifest.ReleaseNotFoundException;
+import com.konfigyr.namespace.manifest.ServiceManifests;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.security.oauth.RequiresScope;
 import com.konfigyr.support.SearchQuery;
@@ -26,6 +31,7 @@ class ServicesController {
 
 	private final Services services;
 	private final NamespaceManager namespaces;
+	private final ServiceManifests manifests;
 
 	@GetMapping
 	@PreAuthorize("isMember(#namespace)")
@@ -93,6 +99,36 @@ class ServicesController {
 	@ResponseStatus(HttpStatus.NO_CONTENT)
 	void delete(@PathVariable @NonNull String namespace, @PathVariable @NonNull String slug) {
 		services.delete(lookupNamespace(namespace), slug);
+	}
+
+	@GetMapping("{slug}/manifest")
+	@PreAuthorize("isMember(#namespace)")
+	EntityModel<Manifest> manifest(@PathVariable @NonNull String namespace, @PathVariable @NonNull String slug) {
+		final Namespace ns = lookupNamespace(namespace);
+		final Service service = services.get(ns, slug).orElseThrow(
+				() -> new ServiceNotFoundException(namespace, slug)
+		);
+
+		return Assemblers.manifest(ns, service).assemble(manifests.get(service));
+	}
+
+	@GetMapping("{slug}/releases/{id}")
+	@PreAuthorize("isMember(#namespace)")
+	EntityModel<ServiceRelease> release(
+			@PathVariable @NonNull String namespace,
+			@PathVariable @NonNull String slug,
+			@PathVariable EntityId id
+	) {
+		final Namespace ns = lookupNamespace(namespace);
+		final Service service = services.get(ns, slug).orElseThrow(
+				() -> new ServiceNotFoundException(namespace, slug)
+		);
+
+		final ServiceRelease release = manifests.get(service, id).orElseThrow(
+				() -> new ReleaseNotFoundException(id)
+		);
+
+		return Assemblers.release(ns, service).assemble(release);
 	}
 
 	@GetMapping("{slug}/catalog")

--- a/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactoryControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/artifactory/controller/ArtifactoryControllerTest.java
@@ -526,6 +526,26 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@DisplayName("should fail to publish an artifact when the principal carries no namespace claim")
+	void uploadArtifactWithoutNamespaceClaim() {
+		final var coordinates = ArtifactCoordinates.of("com.konfigyr", "konfigyr-api", "3.0.0");
+		final var metadata = TestArtifacts.metadata(coordinates);
+
+		mvc.post().uri(uriForArtifact(coordinates).toUri())
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_ARTIFACTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(metadata))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+
+		assertThat(store.get(coordinates))
+				.as("Should not store property descriptor when the principal has no namespace claim")
+				.isEmpty();
+	}
+
+	@Test
 	@Transactional
 	@DisplayName("should change the visibility of an owned artifact")
 	void shouldChangeArtifactVisibility() {
@@ -610,6 +630,19 @@ class ArtifactoryControllerTest extends AbstractControllerTest {
 				.assertThat()
 				.apply(log())
 				.satisfies(forbidden(OAuthScope.PUBLISH_ARTIFACTS));
+	}
+
+	@Test
+	@DisplayName("should fail to change visibility when the principal carries no namespace claim")
+	void shouldRejectChangeArtifactVisibilityWithoutNamespaceClaim() {
+		mvc.put().uri(uriForVisibility("com.konfigyr", "konfigyr-internal-secrets").toUri())
+				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_ARTIFACTS))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(new ArtifactoryController.ChangeVisibilityRequest(ArtifactVisibility.PUBLIC)))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServiceManifestControllerTest.java
@@ -3,7 +3,9 @@ package com.konfigyr.namespace.controller;
 import com.konfigyr.artifactory.*;
 import com.konfigyr.entity.EntityId;
 import com.konfigyr.io.ByteArray;
+import com.konfigyr.security.KonfigyrClaimNames;
 import com.konfigyr.security.OAuthScope;
+import com.konfigyr.security.OAuthScopes;
 import com.konfigyr.test.AbstractControllerTest;
 import com.konfigyr.test.TestPrincipals;
 import org.assertj.core.api.InstanceOfAssertFactories;
@@ -17,217 +19,34 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.test.web.servlet.assertj.MvcTestResultAssert;
+import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 import static com.konfigyr.data.tables.ServiceArtifacts.SERVICE_ARTIFACTS;
 import static com.konfigyr.data.tables.ServiceConfigurationCatalog.SERVICE_CONFIGURATION_CATALOG;
 import static com.konfigyr.data.tables.ServiceReleases.SERVICE_RELEASES;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.within;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 
 class ServiceManifestControllerTest extends AbstractControllerTest {
 
-	// matches the checksum seeded for artifact_versions rows referenced by konfigyr-id's manifest, see artifactory.sql
-	private static final String EXISTING_ARTIFACT_VERSION_CHECKSUM = "ec54eb43a2f17d3fecf5062c987c794ea025da258de0b6ea6483542ef79e3f8a";
+	private static final EntityId JOHN_DOE_NAMESPACE = EntityId.from(1);
+	private static final EntityId KONFIGYR_NAMESPACE = EntityId.from(2);
+	private static final String JOHN_DOE_BLOG_SERVICE = "john-doe-blog";
 
 	static Artifact konfigyrArtifactoryArtifact = Artifact.of("com.konfigyr", "konfigyr-artifactory", "1.2.0");
 	static Artifact konfigyrCryptoApiArtifact = Artifact.of("com.konfigyr", "konfigyr-crypto-api", "1.1.0");
 
 	@Autowired
 	DSLContext context;
-
-	@Test
-	@DisplayName("should retrieve the latest namespace service manifest")
-	void retrieveServiceManifest() {
-		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(Manifest.class)
-				.returns(EntityId.from(1).serialize(), Manifest::id)
-				.returns("Konfigyr ID", Manifest::name)
-				.satisfies(it -> assertThat(it.artifacts())
-						.hasSize(8)
-						.usingRecursiveFieldByFieldElementComparatorIgnoringFields("resolvedAt")
-						.containsExactly(
-								ManifestEntry.builder()
-										.groupId("com.acme")
-										.artifactId("spring-boot-service")
-										.version("1.0.0")
-										.name("Acme Spring Boot service")
-										.description("Spring Boot service")
-										.website("https://acme.com/service")
-										.repository("https://github.com/acme/service")
-										.checksum("6QRgbo04ZnpKhc3o5yZckptP+61bzEBhwNibipufooU=")
-										.source(ArtifactSource.LOCAL)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot")
-										.version("4.0.4")
-										.name("Spring Boot")
-										.description("Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot-actuator")
-										.version("4.0.4")
-										.name("Spring Boot Actuator")
-										.description("Spring Boot Actuator")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot-autoconfigure")
-										.version("4.0.4")
-										.name("Spring Boot AutoConfigure")
-										.description("Spring Boot auto-configuration attempts to automatically configure your Spring applications")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot-jooq")
-										.version("4.0.4")
-										.name("Spring Boot jOOQ")
-										.description("Spring Boot jOOQ support")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.boot")
-										.artifactId("spring-boot-liquibase")
-										.version("4.0.4")
-										.name("Spring Boot Liquibase")
-										.description("Spring Boot Liquibase support")
-										.website("https://spring.io/projects/spring-boot")
-										.repository("https://github.com/spring-projects/spring-boot")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.modulith")
-										.artifactId("spring-modulith-core")
-										.version("2.0.3")
-										.name("Spring Modulith Core")
-										.description("Modular monoliths with Spring Boot")
-										.website("https://spring.io/projects/spring-modulith/spring-modulith-core")
-										.repository("https://github.com/spring-projects-experimental/spring-modulith")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build(),
-								ManifestEntry.builder()
-										.groupId("org.springframework.modulith")
-										.artifactId("spring-modulith-moments")
-										.version("2.0.3")
-										.name("Spring Modulith Moments")
-										.description("Modular monoliths with Spring Boot")
-										.website("https://spring.io/projects/spring-modulith/spring-modulith-moments")
-										.repository("https://github.com/spring-projects-experimental/spring-modulith")
-										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
-										.source(ArtifactSource.ARTIFACTORY)
-										.resolvedAt(Instant.EPOCH)
-										.build()
-						)
-				)
-				.satisfies(it -> assertThat(it.createdAt())
-						.isCloseTo(Instant.now().minus(3, ChronoUnit.DAYS), within(1, ChronoUnit.HOURS))
-				);
-	}
-
-	@Test
-	@DisplayName("should retrieve an empty manifest for service that was not yet released")
-	void retrieveManifestForUnreleasedService() {
-		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatusOk()
-				.bodyJson()
-				.convertTo(Manifest.class)
-				.returns(EntityId.from(1).serialize(), Manifest::id)
-				.returns("John Doe Blog", Manifest::name)
-				.returns(List.of(), Manifest::artifacts)
-				.satisfies(it -> assertThat(it.createdAt())
-						.isCloseTo(Instant.now(), within(5, ChronoUnit.MINUTES))
-				);
-	}
-
-	@Test
-	@DisplayName("should fail to retrieve manifest for unknown service")
-	void retrieveManifestForUnknownService() {
-		mvc.get().uri("/namespaces/konfigyr/services/unknown-service/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(serviceNotFound("unknown-service"));
-	}
-
-	@Test
-	@DisplayName("should not retrieve a service manifest for an unknown namespace")
-	void retrieveManifestForUnknownNamespace() {
-		mvc.get().uri("/namespaces/unknown-namespace/services/unknown-service/manifest")
-				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.hasStatus(HttpStatus.NOT_FOUND)
-				.satisfies(namespaceNotFound("unknown-namespace"));
-	}
-
-	@Test
-	@DisplayName("should not retrieve service manifest when namespaces:read scope is not present")
-	void retrieveManifestWithoutScope() {
-		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
-				.with(authentication(TestPrincipals.jane()))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(forbidden(OAuthScope.READ_NAMESPACES));
-	}
-
-	@Test
-	@DisplayName("should not retrieve service manifest when user is not a member of a namespace")
-	void retrieveManifestWithoutMembership() {
-		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
-				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(forbidden());
-	}
 
 	@Test
 	@Transactional
@@ -522,8 +341,8 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 				.returns(ReleaseState.PENDING, ServiceRelease::state)
 				.actual();
 
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", release.id())
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		mvc.post().uri("/releases/{service}/{id}/artifacts", JOHN_DOE_BLOG_SERVICE, release.id())
+				.with(namespaceClient(JOHN_DOE_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("{not-valid-json")
 				.exchange()
@@ -537,8 +356,8 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	void shouldRejectUnknownServiceForArtifactUpload() {
 		final var metadata = metadata(konfigyrCryptoApiArtifact, "crypto-checksum");
 
-		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases/{id}/artifacts", EntityId.from(999).serialize())
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		mvc.post().uri("/releases/{service}/{id}/artifacts", "unknown-service", EntityId.from(999).serialize())
+				.with(namespaceClient(KONFIGYR_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(metadata))
 				.exchange()
@@ -634,8 +453,8 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Test
 	@DisplayName("should fail to complete a release for an unknown service")
 	void shouldRejectCompleteForUnknownService() {
-		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases/{id}/complete", EntityId.from(999).serialize())
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		mvc.post().uri("/releases/{service}/{id}/complete", "unknown-service", EntityId.from(999).serialize())
+				.with(namespaceClient(KONFIGYR_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.exchange()
 				.assertThat()
 				.apply(log())
@@ -727,8 +546,8 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Test
 	@DisplayName("should fail to retrieve a release for an unknown service")
 	void shouldRejectRetrieveForUnknownService() {
-		mvc.get().uri("/namespaces/konfigyr/services/unknown-service/releases/{id}", EntityId.from(999).serialize())
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		mvc.get().uri("/releases/{service}/{id}", "unknown-service", EntityId.from(999).serialize())
+				.with(namespaceClient(KONFIGYR_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.exchange()
 				.assertThat()
 				.apply(log())
@@ -736,21 +555,10 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
-	@DisplayName("should not retrieve a release when user is not a member of the namespace")
-	void shouldRejectRetrieveWhenNotAMember() {
-		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}", EntityId.from(999).serialize())
-				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_RELEASES))
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(forbidden());
-	}
-
-	@Test
 	@DisplayName("should not retrieve a release when the publish-releases scope is not present")
 	void shouldRejectRetrieveWithoutScope() {
-		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/releases/{id}", EntityId.from(999).serialize())
-				.with(authentication(TestPrincipals.john()))
+		mvc.get().uri("/releases/{service}/{id}", "konfigyr-id", EntityId.from(999).serialize())
+				.with(namespaceClient(KONFIGYR_NAMESPACE))
 				.exchange()
 				.assertThat()
 				.apply(log())
@@ -758,23 +566,10 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
-	@DisplayName("should not resolve a release when user is not a member of the namespace")
-	void shouldRejectWhenNotAMember() {
-		mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.jane(), OAuthScope.PUBLISH_RELEASES))
-				.contentType(MediaType.APPLICATION_JSON)
-				.content("[]")
-				.exchange()
-				.assertThat()
-				.apply(log())
-				.satisfies(forbidden());
-	}
-
-	@Test
 	@DisplayName("should not resolve a release when the publish-releases scope is not present")
 	void shouldRejectWithoutScope() {
-		mvc.post().uri("/namespaces/konfigyr/services/konfigyr-id/releases")
-				.with(authentication(TestPrincipals.john()))
+		mvc.post().uri("/releases/{service}", "konfigyr-id")
+				.with(namespaceClient(KONFIGYR_NAMESPACE))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("[]")
 				.exchange()
@@ -786,8 +581,8 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	@Test
 	@DisplayName("should fail to resolve a release for an unknown service")
 	void shouldRejectUnknownService() {
-		mvc.post().uri("/namespaces/konfigyr/services/unknown-service/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		mvc.post().uri("/releases/{service}", "unknown-service")
+				.with(namespaceClient(KONFIGYR_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("[]")
 				.exchange()
@@ -797,16 +592,62 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	}
 
 	@Test
-	@DisplayName("should fail to resolve a release for an unknown namespace")
-	void shouldRejectUnknownNamespace() {
-		mvc.post().uri("/namespaces/unknown-namespace/services/unknown-service/releases")
+	@DisplayName("should reject a namespace client token that is missing its namespace claim")
+	void shouldRejectMissingNamespaceClaim() {
+		// a human account token can carry the publish-releases scope (e.g. via the aggregate
+		// "namespaces" scope) without ever being scoped to a namespace by a claim
+		mvc.post().uri("/releases/{service}", JOHN_DOE_BLOG_SERVICE)
 				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("[]")
 				.exchange()
 				.assertThat()
 				.apply(log())
-				.satisfies(namespaceNotFound("unknown-namespace"));
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@DisplayName("should reject a namespace client token whose namespace claim does not match a known namespace")
+	void shouldRejectUnknownNamespaceClaim() {
+		mvc.post().uri("/releases/{service}", JOHN_DOE_BLOG_SERVICE)
+				.with(namespaceClient(EntityId.from(999_999), OAuthScope.PUBLISH_RELEASES))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("[]")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should not allow a namespace client to read a release for a service owned by another namespace")
+	void shouldRejectCrossNamespaceRetrieve() {
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(konfigyrArtifactoryArtifact, "checksum")).actual();
+
+		mvc.get().uri("/releases/{service}/{id}", JOHN_DOE_BLOG_SERVICE, release.id())
+				.with(namespaceClient(KONFIGYR_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound(JOHN_DOE_BLOG_SERVICE));
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should not allow a namespace client to upload artifacts for a release owned by another namespace")
+	void shouldRejectCrossNamespaceUpload() {
+		final var metadata = metadata(konfigyrArtifactoryArtifact, "checksum");
+		final var release = assertThatRelease(ServiceReleaseCandidate.of(metadata)).actual();
+
+		mvc.post().uri("/releases/{service}/{id}/artifacts", JOHN_DOE_BLOG_SERVICE, release.id())
+				.with(namespaceClient(KONFIGYR_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(jsonMapper.writeValueAsBytes(metadata))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound(JOHN_DOE_BLOG_SERVICE));
 	}
 
 	private ObjectAssert<ServiceRelease> assertThatRelease(ServiceReleaseCandidate... candidates) {
@@ -814,8 +655,8 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	}
 
 	private ObjectAssert<ServiceRelease> assertThatRelease(List<ServiceReleaseCandidate> candidates) {
-		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases")
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		return mvc.post().uri("/releases/{service}", JOHN_DOE_BLOG_SERVICE)
+				.with(namespaceClient(JOHN_DOE_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(candidates))
 				.exchange()
@@ -828,16 +669,16 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	}
 
 	private MvcTestResultAssert assertThatRelease(String id) {
-		return mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}", id)
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		return mvc.get().uri("/releases/{service}/{id}", JOHN_DOE_BLOG_SERVICE, id)
+				.with(namespaceClient(JOHN_DOE_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.exchange()
 				.assertThat()
 				.apply(log());
 	}
 
 	private MvcTestResultAssert assertThatUpload(String id, ArtifactMetadata metadata) {
-		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/artifacts", id)
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		return mvc.post().uri("/releases/{service}/{id}/artifacts", JOHN_DOE_BLOG_SERVICE, id)
+				.with(namespaceClient(JOHN_DOE_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(jsonMapper.writeValueAsBytes(metadata))
 				.exchange()
@@ -846,11 +687,19 @@ class ServiceManifestControllerTest extends AbstractControllerTest {
 	}
 
 	private MvcTestResultAssert assertThatComplete(String id) {
-		return mvc.post().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}/complete", id)
-				.with(authentication(TestPrincipals.john(), OAuthScope.PUBLISH_RELEASES))
+		return mvc.post().uri("/releases/{service}/{id}/complete", JOHN_DOE_BLOG_SERVICE, id)
+				.with(namespaceClient(JOHN_DOE_NAMESPACE, OAuthScope.PUBLISH_RELEASES))
 				.exchange()
 				.assertThat()
 				.apply(log());
+	}
+
+	private static RequestPostProcessor namespaceClient(EntityId namespace, OAuthScope... scopes) {
+		return authentication(claims -> claims
+				.subject("kfg-test-client")
+				.claim(KonfigyrClaimNames.NAMESPACE, namespace.serialize())
+				.claim(OAuth2ParameterNames.SCOPE, OAuthScopes.of(scopes).toString())
+		);
 	}
 
 	private static ArtifactMetadata metadata(Artifact artifact, String checksum) {

--- a/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServicesControllerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/namespace/controller/ServicesControllerTest.java
@@ -6,28 +6,44 @@ import com.konfigyr.hateoas.CollectionModel;
 import com.konfigyr.hateoas.Link;
 import com.konfigyr.hateoas.LinkRelation;
 import com.konfigyr.hateoas.PagedModel;
+import com.konfigyr.namespace.Namespace;
+import com.konfigyr.namespace.NamespaceManager;
 import com.konfigyr.namespace.Service;
 import com.konfigyr.namespace.ServiceCatalog;
+import com.konfigyr.namespace.Services;
+import com.konfigyr.namespace.manifest.ServiceManifests;
 import com.konfigyr.security.OAuthScope;
 import com.konfigyr.test.AbstractControllerTest;
 import com.konfigyr.test.TestPrincipals;
 import org.assertj.core.api.InstanceOfAssertFactories;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.within;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
 
-class ServiceControllerTest extends AbstractControllerTest {
+class ServicesControllerTest extends AbstractControllerTest {
+
+	@Autowired
+	private Services services;
+
+	@Autowired
+	private NamespaceManager namespaces;
+
+	@Autowired
+	private ServiceManifests manifests;
 
 	@Test
 	@DisplayName("should retrieve all available services for Konfigyr namespace")
@@ -477,6 +493,262 @@ class ServiceControllerTest extends AbstractControllerTest {
 	@DisplayName("should fail to delete namespace service when user is not an admin member of a namespace")
 	void deleteServiceWithoutMembership() {
 		mvc.delete().uri("/namespaces/konfigyr/services/konfigyr-id")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	private static final String EXISTING_ARTIFACT_VERSION_CHECKSUM = "ec54eb43a2f17d3fecf5062c987c794ea025da258de0b6ea6483542ef79e3f8a";
+
+	@Test
+	@DisplayName("should retrieve the latest namespace service manifest")
+	void retrieveServiceManifest() {
+		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(Manifest.class)
+				.returns(EntityId.from(1).serialize(), Manifest::id)
+				.returns("Konfigyr ID", Manifest::name)
+				.satisfies(it -> assertThat(it.artifacts())
+						.hasSize(8)
+						.usingRecursiveFieldByFieldElementComparatorIgnoringFields("resolvedAt")
+						.containsExactly(
+								ManifestEntry.builder()
+										.groupId("com.acme")
+										.artifactId("spring-boot-service")
+										.version("1.0.0")
+										.name("Acme Spring Boot service")
+										.description("Spring Boot service")
+										.website("https://acme.com/service")
+										.repository("https://github.com/acme/service")
+										.checksum("6QRgbo04ZnpKhc3o5yZckptP+61bzEBhwNibipufooU=")
+										.source(ArtifactSource.LOCAL)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot")
+										.version("4.0.4")
+										.name("Spring Boot")
+										.description("Spring Boot makes it easy to create stand-alone, production-grade Spring based Applications")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot-actuator")
+										.version("4.0.4")
+										.name("Spring Boot Actuator")
+										.description("Spring Boot Actuator")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot-autoconfigure")
+										.version("4.0.4")
+										.name("Spring Boot AutoConfigure")
+										.description("Spring Boot auto-configuration attempts to automatically configure your Spring applications")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot-jooq")
+										.version("4.0.4")
+										.name("Spring Boot jOOQ")
+										.description("Spring Boot jOOQ support")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.boot")
+										.artifactId("spring-boot-liquibase")
+										.version("4.0.4")
+										.name("Spring Boot Liquibase")
+										.description("Spring Boot Liquibase support")
+										.website("https://spring.io/projects/spring-boot")
+										.repository("https://github.com/spring-projects/spring-boot")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.modulith")
+										.artifactId("spring-modulith-core")
+										.version("2.0.3")
+										.name("Spring Modulith Core")
+										.description("Modular monoliths with Spring Boot")
+										.website("https://spring.io/projects/spring-modulith/spring-modulith-core")
+										.repository("https://github.com/spring-projects-experimental/spring-modulith")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build(),
+								ManifestEntry.builder()
+										.groupId("org.springframework.modulith")
+										.artifactId("spring-modulith-moments")
+										.version("2.0.3")
+										.name("Spring Modulith Moments")
+										.description("Modular monoliths with Spring Boot")
+										.website("https://spring.io/projects/spring-modulith/spring-modulith-moments")
+										.repository("https://github.com/spring-projects-experimental/spring-modulith")
+										.checksum(EXISTING_ARTIFACT_VERSION_CHECKSUM)
+										.source(ArtifactSource.ARTIFACTORY)
+										.resolvedAt(Instant.EPOCH)
+										.build()
+						)
+				)
+				.satisfies(it -> assertThat(it.createdAt())
+						.isCloseTo(Instant.now().minus(3, ChronoUnit.DAYS), within(1, ChronoUnit.HOURS))
+				);
+	}
+
+	@Test
+	@DisplayName("should retrieve an empty manifest for service that was not yet released")
+	void retrieveManifestForUnreleasedService() {
+		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(Manifest.class)
+				.returns(EntityId.from(1).serialize(), Manifest::id)
+				.returns("John Doe Blog", Manifest::name)
+				.returns(List.of(), Manifest::artifacts)
+				.satisfies(it -> assertThat(it.createdAt())
+						.isCloseTo(Instant.now(), within(5, ChronoUnit.MINUTES))
+				);
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve manifest for unknown service")
+	void retrieveManifestForUnknownService() {
+		mvc.get().uri("/namespaces/konfigyr/services/unknown-service/manifest")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound("unknown-service"));
+	}
+
+	@Test
+	@DisplayName("should not retrieve a service manifest for an unknown namespace")
+	void retrieveManifestForUnknownNamespace() {
+		mvc.get().uri("/namespaces/unknown-namespace/services/unknown-service/manifest")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.NOT_FOUND)
+				.satisfies(namespaceNotFound("unknown-namespace"));
+	}
+
+	@Test
+	@DisplayName("should not retrieve service manifest when namespaces:read scope is not present")
+	void retrieveManifestWithoutScope() {
+		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/manifest")
+				.with(authentication(TestPrincipals.jane()))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.READ_NAMESPACES));
+	}
+
+	@Test
+	@DisplayName("should not retrieve service manifest when user is not a member of a namespace")
+	void retrieveManifestWithoutMembership() {
+		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/manifest")
+				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden());
+	}
+
+	@Test
+	@Transactional
+	@DisplayName("should retrieve a namespace service release by identifier")
+	void retrieveServiceRelease() {
+		final Namespace namespace = namespaces.findBySlug("john-doe").orElseThrow();
+		final Service service = services.get(namespace, "john-doe-blog").orElseThrow();
+
+		final ServiceRelease release = manifests.open(service, List.of(
+				ServiceReleaseCandidate.of("com.konfigyr", "konfigyr-crypto-api", "1.0.0", "checksum")
+		));
+
+		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}", release.id())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.convertTo(ServiceRelease.class)
+				.returns(release.id(), ServiceRelease::id)
+				.returns(ReleaseState.PENDING, ServiceRelease::state);
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve an unknown service release")
+	void retrieveUnknownServiceRelease() {
+		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/releases/{id}", EntityId.from(999).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(problemDetailFor(HttpStatus.NOT_FOUND, problem -> problem
+						.hasTitle("Release not found")
+						.hasDetailContaining("Could not find a release with the following identifier")
+				));
+	}
+
+	@Test
+	@DisplayName("should fail to retrieve a service release for an unknown service")
+	void retrieveServiceReleaseForUnknownService() {
+		mvc.get().uri("/namespaces/konfigyr/services/unknown-service/releases/{id}", EntityId.from(999).serialize())
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(serviceNotFound("unknown-service"));
+	}
+
+	@Test
+	@DisplayName("should not retrieve a service release when namespaces:read scope is not present")
+	void retrieveServiceReleaseWithoutScope() {
+		mvc.get().uri("/namespaces/konfigyr/services/konfigyr-id/releases/{id}", EntityId.from(1).serialize())
+				.with(authentication(TestPrincipals.jane()))
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.READ_NAMESPACES));
+	}
+
+	@Test
+	@DisplayName("should not retrieve a service release when user is not a member of a namespace")
+	void retrieveServiceReleaseWithoutMembership() {
+		mvc.get().uri("/namespaces/john-doe/services/john-doe-blog/releases/{id}", EntityId.from(1).serialize())
 				.with(authentication(TestPrincipals.jane(), OAuthScope.READ_NAMESPACES))
 				.exchange()
 				.assertThat()


### PR DESCRIPTION
Splits the plugin-facing and UI-facing service release APIs, which previously lived together in `ServiceManifestController` under a single namespace-path-scoped URL shape.

- Plugin clients (Gradle/Maven build plugins, authenticated as a namespace OAuth2 client) now hit a namespace-free `/releases/{service}` root. The owning namespace is resolved from the namespace JWT claim instead of a path variable. A plugin token never needs to know or pass its namespace. Any failure to resolve a usable namespace from the principal (wrong principal type, missing claim, or a claim pointing at a namespace that no longer exists) is treated as a 403 (AccessDeniedException), not a 404 or 500 — it's an authorization gap, not a resource lookup.
- UI clients keep the existing session-authenticated, `isMember`-checked, namespace-path-scoped shape on `ServicesController`: the manifest endpoint moved there unchanged, and a new read-only `releases/{id}` endpoint was added, reusing `READ_NAMESPACES` (the same scope as its sibling read endpoints) rather than the plugin's `PUBLISH_RELEASES`.
- Fixed a stale HATEOAS "release" link (`POST .../manifest`) left over in `Assemblers` that pointed at an endpoint shape that no longer exists.
- Aligned `ArtifactoryController`'s namespace-claim resolution failure (`publish, changeVisibility`) to the same 403 semantics as the new release endpoints, replacing the previous 401, a token that can't be resolved to a namespace shouldn't look like a missing-credentials error.
- Updated the `spring-security-oauth2` and project-overview skill docs: fixed the JWT claim name (`kfg_namespace → namespace / KonfigyrClaimNames.NAMESPACE`), replaced the stale scope list with the real `OAuthScope` enum, and documented the new endpoint split.

### Endpoint shapes

```
# Plugin-only (namespace-free)
POST   /releases/{service}
GET    /releases/{service}/{id}
POST   /releases/{service}/{id}/artifacts
POST   /releases/{service}/{id}/complete

# UI-only (namespace-path-scoped, unchanged manifest URL)
GET    /namespaces/{namespace}/services/{slug}/manifest
GET    /namespaces/{namespace}/services/{slug}/releases/{id}
```