### PR TITLE
Expose OAuth2 protected resource metadata on the REST API

### DIFF
--- a/konfigyr-api/src/main/java/com/konfigyr/hateoas/HateoasExceptionHandler.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/hateoas/HateoasExceptionHandler.java
@@ -30,9 +30,11 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -88,9 +90,7 @@ class HateoasExceptionHandler extends ResponseEntityExceptionHandler implements 
 			case InsufficientAuthenticationException exception -> handleException(
 					exception, HttpStatus.FORBIDDEN, headers, request
 			);
-			default -> handleException(
-					ex, HttpStatus.UNAUTHORIZED, headers, request
-			);
+			default -> handleUnauthorizedException(ex, headers, request);
 		};
 	}
 
@@ -117,6 +117,20 @@ class HateoasExceptionHandler extends ResponseEntityExceptionHandler implements 
 	) {
 		final ProblemDetail body = errorResponse.updateAndGetBody(getMessageSource(), LocaleContextHolder.getLocale());
 		return createResponseEntity(body, errorResponse.getHeaders(), errorResponse.getStatusCode(), request);
+	}
+
+	protected ResponseEntity<@NonNull Object> handleUnauthorizedException(
+			@NonNull AuthenticationException ex, @NonNull HttpHeaders headers, @NonNull WebRequest request
+	) {
+		if (request instanceof ServletWebRequest servletWebRequest) {
+			final String resourceMetadataUri = ServletUriComponentsBuilder.fromContextPath(servletWebRequest.getRequest())
+					.path("/.well-known/oauth-protected-resource")
+					.toUriString();
+
+			headers.add(HttpHeaders.WWW_AUTHENTICATE, "Bearer resource_metadata=" + resourceMetadataUri);
+		}
+
+		return handleException(ex, HttpStatus.UNAUTHORIZED, headers, request);
 	}
 
 	protected ResponseEntity<@NonNull Object> handleAuthorizationDeniedException(

--- a/konfigyr-api/src/main/java/com/konfigyr/hateoas/HateoasExceptionHandler.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/hateoas/HateoasExceptionHandler.java
@@ -17,7 +17,11 @@ import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.authorization.AuthorizationResult;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
 import org.springframework.security.web.authentication.rememberme.InvalidCookieException;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.BindException;
 import org.springframework.validation.Errors;
 import org.springframework.validation.FieldError;
@@ -122,14 +126,29 @@ class HateoasExceptionHandler extends ResponseEntityExceptionHandler implements 
 	protected ResponseEntity<@NonNull Object> handleUnauthorizedException(
 			@NonNull AuthenticationException ex, @NonNull HttpHeaders headers, @NonNull WebRequest request
 	) {
-		if (request instanceof ServletWebRequest servletWebRequest) {
-			final String resourceMetadataUri = ServletUriComponentsBuilder.fromContextPath(servletWebRequest.getRequest())
-					.path("/.well-known/oauth-protected-resource")
-					.toUriString();
+		final Map<String, String> parameters = new LinkedHashMap<>();
 
-			headers.add(HttpHeaders.WWW_AUTHENTICATE, "Bearer resource_metadata=" + resourceMetadataUri);
+		if (ex instanceof OAuth2AuthenticationException oauth) {
+			final OAuth2Error error = oauth.getError();
+
+			if (StringUtils.hasText(error.getErrorCode())) {
+				parameters.put(OAuth2ParameterNames.ERROR, error.getErrorCode());
+			}
+			if (StringUtils.hasText(error.getDescription())) {
+				parameters.put(OAuth2ParameterNames.ERROR_DESCRIPTION, error.getDescription());
+			}
+			if (StringUtils.hasText(error.getUri())) {
+				parameters.put(OAuth2ParameterNames.ERROR_URI, error.getUri());
+			}
 		}
 
+		if (request instanceof ServletWebRequest servletWebRequest) {
+			parameters.put("resource_metadata", ServletUriComponentsBuilder.fromContextPath(servletWebRequest.getRequest())
+					.path("/.well-known/oauth-protected-resource")
+					.toUriString());
+		}
+
+		headers.add(HttpHeaders.WWW_AUTHENTICATE, createBearerChallenge(parameters));
 		return handleException(ex, HttpStatus.UNAUTHORIZED, headers, request);
 	}
 
@@ -284,6 +303,16 @@ class HateoasExceptionHandler extends ResponseEntityExceptionHandler implements 
 
 	protected static String authoritiesToString(Collection<? extends GrantedAuthority> authorities) {
 		return authorities.stream().map(GrantedAuthority::getAuthority).collect(Collectors.joining(" "));
+	}
+
+	private static String createBearerChallenge(Map<String, String> parameters) {
+		if (parameters.isEmpty()) {
+			return "Bearer";
+		}
+
+		return parameters.entrySet().stream()
+				.map(entry -> entry.getKey() + "=\"" + entry.getValue() + "\"")
+				.collect(Collectors.joining(", ", "Bearer ", ""));
 	}
 
 }

--- a/konfigyr-api/src/main/java/com/konfigyr/security/ResourceServerScopes.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/ResourceServerScopes.java
@@ -1,0 +1,47 @@
+package com.konfigyr.security;
+
+import org.jspecify.annotations.NullMarked;
+
+import java.util.Collection;
+
+/**
+ * Registry of {@link OAuthScope OAuth scopes} that are supported and enforced by the Konfigyr
+ * REST API (OAuth2 Resource Server).
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see OAuthScope
+ * @see OAuthScopes
+ */
+@NullMarked
+public final class ResourceServerScopes {
+
+	private static final OAuthScopes scopes = OAuthScopes.of(
+			OAuthScope.NAMESPACES,
+			OAuthScope.PROFILES
+	);
+
+	private ResourceServerScopes() {
+		// this is a utility class
+	}
+
+	/**
+	 * Returns all the supported OAuth Scopes by the Konfigyr Resource Server.
+	 *
+	 * @return the supported OAuth Scopes, never {@literal null}
+	 */
+	public static OAuthScopes get() {
+		return scopes;
+	}
+
+	/**
+	 * Method that would register the Konfigyr Resource Server OAuth scopes by adding them to
+	 * the given collection of scopes.
+	 *
+	 * @param scopes collection of scopes to be customized, never {@literal null}
+	 */
+	public static void register(Collection<String> scopes) {
+		ResourceServerScopes.get().to(scopes, OAuthScope::getAuthority);
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/security/WebSecurityConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/WebSecurityConfiguration.java
@@ -3,11 +3,13 @@ package com.konfigyr.security;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import com.konfigyr.security.basic.NamespaceApplicationDetailsService;
 import com.konfigyr.security.oauth.AuthenticatedPrincipalAuthenticationToken;
+import com.konfigyr.security.oauth.OAuthProtectedResourceMetadataCustomizer;
 import com.konfigyr.security.oauth.RequestAttributeBearerTokenResolver;
 import com.konfigyr.web.WebExceptionHandler;
 import org.jooq.DSLContext;
 import org.jspecify.annotations.NonNull;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties;
 import org.springframework.cache.caffeine.CaffeineCache;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -89,7 +91,11 @@ public class WebSecurityConfiguration {
 
 	@Bean
 	@Order(2)
-	SecurityFilterChain konfigyrSecurityFilterChain(HttpSecurity http, ProblemDetailsAuthenticationExceptionHandler exceptionHandler) {
+	SecurityFilterChain konfigyrSecurityFilterChain(
+			HttpSecurity http,
+			OAuth2ResourceServerProperties properties,
+			ProblemDetailsAuthenticationExceptionHandler exceptionHandler
+	) {
 		final BearerTokenResolver bearerTokenResolver = new RequestAttributeBearerTokenResolver();
 
 		return http
@@ -108,6 +114,9 @@ public class WebSecurityConfiguration {
 				.oauth2ResourceServer(server -> server
 						.jwt(jwt -> jwt
 								.jwtAuthenticationConverter(AuthenticatedPrincipalAuthenticationToken::of)
+						)
+						.protectedResourceMetadata(metadata -> metadata
+								.protectedResourceMetadataCustomizer(new OAuthProtectedResourceMetadataCustomizer(properties))
 						)
 						.bearerTokenResolver(bearerTokenResolver)
 						.authenticationEntryPoint(exceptionHandler)

--- a/konfigyr-api/src/main/java/com/konfigyr/security/oauth/OAuthProtectedResourceMetadataCustomizer.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/oauth/OAuthProtectedResourceMetadataCustomizer.java
@@ -1,0 +1,42 @@
+package com.konfigyr.security.oauth;
+
+
+import com.konfigyr.security.ResourceServerScopes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.PropertyMapper;
+import org.springframework.boot.security.oauth2.server.resource.autoconfigure.OAuth2ResourceServerProperties;
+import org.springframework.security.oauth2.server.resource.OAuth2ProtectedResourceMetadata;
+
+import java.util.function.Consumer;
+
+/**
+ * Customizer that populates the {@link OAuth2ProtectedResourceMetadata} exposed by the Konfigyr
+ * REST API on the {@code /.well-known/oauth-protected-resource} endpoint with the resource name,
+ * the authorization server issuer and the supported OAuth scopes.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see ResourceServerScopes
+ */
+@RequiredArgsConstructor
+public final class OAuthProtectedResourceMetadataCustomizer implements
+		Consumer<OAuth2ProtectedResourceMetadata.Builder> {
+
+	private final PropertyMapper mapper = PropertyMapper.get();
+	private final OAuth2ResourceServerProperties properties;
+
+	/**
+	 * Customizes the given {@link OAuth2ProtectedResourceMetadata.Builder} with the Konfigyr
+	 * REST API resource name, the JWT issuer URI as the authorization server and the
+	 * {@link ResourceServerScopes supported OAuth scopes}.
+	 *
+	 * @param builder the protected resource metadata builder to customize, never {@literal null}
+	 */
+	@Override
+	public void accept(OAuth2ProtectedResourceMetadata.Builder builder) {
+		builder.resourceName("Konfigyr REST API");
+
+		mapper.from(properties.getJwt().getIssuerUri()).to(builder::authorizationServer);
+		builder.scopes(ResourceServerScopes::register);
+	}
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/hateoas/HateoasExceptionHandlerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/hateoas/HateoasExceptionHandlerTest.java
@@ -254,10 +254,10 @@ class HateoasExceptionHandlerTest {
 	@MethodSource("authentication")
 	@DisplayName("should handle authentication exceptions")
 	@ParameterizedTest(name = "should create error response for exception {0} with status code {1}")
-	void shouldHandleAuthenticationException(Class<? extends AuthenticationException> type, HttpStatusCode status) {
+	void shouldHandleAuthenticationException(Class<? extends AuthenticationException> type, HttpStatusCode status, HttpHeaders headers) {
 		final var ex = mock(type);
 
-		expectProblemDetail(ex, status)
+		expectProblemDetail(ex, status, headers)
 				.hasDefaultType()
 				.satisfies(it -> assertThat(it.getTitle())
 						.isNotBlank()
@@ -272,21 +272,28 @@ class HateoasExceptionHandlerTest {
 	}
 
 	static Stream<Arguments> authentication() {
+		final var headers = new HttpHeaders();
+		headers.set(HttpHeaders.WWW_AUTHENTICATE, "Bearer resource_metadata=http://localhost/.well-known/oauth-protected-resource");
+
 		return Stream.of(
-				Arguments.of(InternalAuthenticationServiceException.class, HttpStatus.INTERNAL_SERVER_ERROR),
-				Arguments.of(ProviderNotFoundException.class, HttpStatus.INTERNAL_SERVER_ERROR),
-				Arguments.of(InvalidCookieException.class, HttpStatus.INTERNAL_SERVER_ERROR),
-				Arguments.of(InsufficientAuthenticationException.class, HttpStatus.FORBIDDEN),
-				Arguments.of(AuthenticationCredentialsNotFoundException.class, HttpStatus.UNAUTHORIZED),
-				Arguments.of(BadCredentialsException.class, HttpStatus.UNAUTHORIZED)
+				Arguments.of(InternalAuthenticationServiceException.class, HttpStatus.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY),
+				Arguments.of(ProviderNotFoundException.class, HttpStatus.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY),
+				Arguments.of(InvalidCookieException.class, HttpStatus.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY),
+				Arguments.of(InsufficientAuthenticationException.class, HttpStatus.FORBIDDEN, HttpHeaders.EMPTY),
+				Arguments.of(AuthenticationCredentialsNotFoundException.class, HttpStatus.UNAUTHORIZED, headers),
+				Arguments.of(BadCredentialsException.class, HttpStatus.UNAUTHORIZED, headers)
 		);
 	}
 
 	ProblemDetailAssert expectProblemDetail(Exception ex, HttpStatusCode status) {
+		return expectProblemDetail(ex, status, HttpHeaders.EMPTY);
+	}
+
+	ProblemDetailAssert expectProblemDetail(Exception ex, HttpStatusCode status, HttpHeaders headers) {
 		return assertThat(handler.handle(request, response, ex))
 				.isNotNull()
 				.returns(status, ResponseEntity::getStatusCode)
-				.returns(HttpHeaders.EMPTY, HttpEntity::getHeaders)
+				.returns(headers, HttpEntity::getHeaders)
 				.extracting(HttpEntity::getBody)
 				.isInstanceOf(ProblemDetail.class)
 				.asInstanceOf(ProblemDetailAssert.factory())

--- a/konfigyr-api/src/test/java/com/konfigyr/hateoas/HateoasExceptionHandlerTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/hateoas/HateoasExceptionHandlerTest.java
@@ -28,6 +28,9 @@ import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.security.authorization.ExpressionAuthorizationDecision;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.security.web.authentication.rememberme.InvalidCookieException;
 import org.springframework.security.web.csrf.CsrfException;
 import org.springframework.security.web.csrf.InvalidCsrfTokenException;
@@ -273,7 +276,7 @@ class HateoasExceptionHandlerTest {
 
 	static Stream<Arguments> authentication() {
 		final var headers = new HttpHeaders();
-		headers.set(HttpHeaders.WWW_AUTHENTICATE, "Bearer resource_metadata=http://localhost/.well-known/oauth-protected-resource");
+		headers.set(HttpHeaders.WWW_AUTHENTICATE, "Bearer resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\"");
 
 		return Stream.of(
 				Arguments.of(InternalAuthenticationServiceException.class, HttpStatus.INTERNAL_SERVER_ERROR, HttpHeaders.EMPTY),
@@ -283,6 +286,18 @@ class HateoasExceptionHandlerTest {
 				Arguments.of(AuthenticationCredentialsNotFoundException.class, HttpStatus.UNAUTHORIZED, headers),
 				Arguments.of(BadCredentialsException.class, HttpStatus.UNAUTHORIZED, headers)
 		);
+	}
+
+	@Test
+	@DisplayName("should include OAuth2 error details in the WWW-Authenticate header")
+	void shouldHandleOAuth2AuthenticationException() {
+		final var error = new OAuth2Error(OAuth2ErrorCodes.INVALID_TOKEN, "The Jwt has expired", null);
+
+		final var headers = new HttpHeaders();
+		headers.set(HttpHeaders.WWW_AUTHENTICATE, "Bearer error=\"invalid_token\", error_description=\"The Jwt has expired\", " +
+				"resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\"");
+
+		expectProblemDetail(new OAuth2AuthenticationException(error), HttpStatus.UNAUTHORIZED, headers);
 	}
 
 	ProblemDetailAssert expectProblemDetail(Exception ex, HttpStatusCode status) {

--- a/konfigyr-api/src/test/java/com/konfigyr/security/SecurityIntegrationTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/security/SecurityIntegrationTest.java
@@ -190,7 +190,28 @@ public class SecurityIntegrationTest extends AbstractControllerTest {
 				.assertThat()
 				.apply(log())
 				.hasStatus(HttpStatus.UNAUTHORIZED)
-				.hasHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer resource_metadata=http://localhost/.well-known/oauth-protected-resource");
+				.hasHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\"");
+	}
+
+	@Test
+	@DisplayName("should return OAuth error and Protected Resource Metadata URI when access token is invalid")
+	void shouldExposeOAuthErrorAndProtectedResourceMetadataEndpoint() {
+		final String token = generateAccessToken(KeyGenerator.getInstance().generate(), claims -> claims
+				.issuer(wiremock.baseUrl())
+				.subject(TestPrincipals.john().getName())
+		);
+
+		assertThatRequest(token)
+				.hasStatus(HttpStatus.UNAUTHORIZED)
+				.matches(SecurityMockMvcResultMatchers.unauthenticated())
+				.headers()
+				.hasHeaderSatisfying(HttpHeaders.WWW_AUTHENTICATE, values -> Assertions.assertThat(values)
+						.singleElement(InstanceOfAssertFactories.STRING)
+						.startsWith("Bearer")
+						.contains("error=\"invalid_token\"")
+						.contains("error_description=\"")
+						.contains("error_uri=\"")
+						.contains("resource_metadata=\"http://localhost/.well-known/oauth-protected-resource\""));
 	}
 
 	@Test

--- a/konfigyr-api/src/test/java/com/konfigyr/security/SecurityIntegrationTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/security/SecurityIntegrationTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.oidc.StandardClaimNames;
 import org.springframework.security.test.web.servlet.response.SecurityMockMvcResultMatchers;
@@ -18,6 +19,7 @@ import org.springframework.test.web.servlet.ResultMatcher;
 import org.springframework.test.web.servlet.assertj.MvcTestResultAssert;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.function.Consumer;
@@ -178,6 +180,46 @@ public class SecurityIntegrationTest extends AbstractControllerTest {
 		assertThatRequest(token)
 				.hasStatus(HttpStatus.UNAUTHORIZED)
 				.matches(SecurityMockMvcResultMatchers.unauthenticated());
+	}
+
+	@Test
+	@DisplayName("should return OAuth 2.0 Protected Resource Metadata URI when unauthenticated")
+	void shouldExposeProtectedResourceMetadataEndpointWithoutAuthentication() {
+		mvc.get().uri("/namespaces")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.UNAUTHORIZED)
+				.hasHeader(HttpHeaders.WWW_AUTHENTICATE, "Bearer resource_metadata=http://localhost/.well-known/oauth-protected-resource");
+	}
+
+	@Test
+	@DisplayName("should expose OAuth 2.0 Protected Resource Metadata without authentication")
+	void shouldExposeProtectedResourceMetadata() {
+		mvc.get().uri("/.well-known/oauth-protected-resource")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.hasContentTypeCompatibleWith(MediaType.APPLICATION_JSON)
+				.bodyJson()
+				.hasPathSatisfying("$.resource", resource -> resource.assertThat()
+						.asString()
+						.isNotBlank())
+				.hasPathSatisfying("$.resource_name", name -> name.assertThat()
+						.asString()
+						.isEqualTo("Konfigyr REST API"))
+				.hasPathSatisfying("$.bearer_methods_supported", servers -> servers.assertThat()
+						.asArray()
+						.containsExactly("header"))
+				.hasPathSatisfying("$.authorization_servers", servers -> servers.assertThat()
+						.asArray()
+						.containsExactly(wiremock.baseUrl()))
+				.hasPathSatisfying("$.scopes_supported", servers -> servers.assertThat()
+						.asArray()
+						.containsExactlyInAnyOrderElementsOf(
+								ResourceServerScopes.get().to(new ArrayList<>(), OAuthScope::getAuthority)
+						));
 	}
 
 	static MvcTestResultAssert assertThatRequest(String token) {

--- a/konfigyr-core/src/main/java/com/konfigyr/security/OAuthScopes.java
+++ b/konfigyr-core/src/main/java/com/konfigyr/security/OAuthScopes.java
@@ -2,19 +2,20 @@ package com.konfigyr.security;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
-import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.oauth2.core.ClaimAccessor;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.util.function.SingletonSupplier;
 
 import java.io.Serializable;
 import java.util.*;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,14 +26,11 @@ import java.util.stream.Stream;
  * @since 1.0.0
  * @see OAuthScope
  */
-@EqualsAndHashCode
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class OAuthScopes implements Iterable<OAuthScope>, Serializable {
+@EqualsAndHashCode(of = "scopes")
+public final class OAuthScopes implements Iterable<OAuthScope>, Serializable {
 
 	private static final Set<String> SCOPE_NAMES = Set.of("scope", "scp");
 	private static final OAuthScopes EMPTY = new OAuthScopes(Collections.emptyList());
-
-	private final List<OAuthScope> scopes;
 
 	/**
 	 * Creates an empty {@link OAuthScopes OAuth scope set}.
@@ -112,6 +110,18 @@ public class OAuthScopes implements Iterable<OAuthScope>, Serializable {
 		return CollectionUtils.isEmpty(scopes) ? EMPTY : new OAuthScopes(collect(scopes.stream()));
 	}
 
+	private final List<OAuthScope> scopes;
+	private final Supplier<Set<GrantedAuthority>> authorities;
+
+	private OAuthScopes(List<OAuthScope> scopes) {
+		this.scopes = Collections.unmodifiableList(scopes);
+		this.authorities = SingletonSupplier.of(() -> scopes.stream()
+				.map(OAuthScope::aggregate)
+				.flatMap(Collection::stream)
+				.collect(Collectors.toUnmodifiableSet())
+		);
+	}
+
 	/**
 	 * Method that would return a collection of {@link GrantedAuthority granted authorities} out of
 	 * this {@link OAuthScopes OAuth scope set}.
@@ -119,10 +129,33 @@ public class OAuthScopes implements Iterable<OAuthScope>, Serializable {
 	 * @return granted authorities, never {@literal null}
 	 */
 	public Collection<? extends GrantedAuthority> toAuthorities() {
-		return scopes.stream()
-				.map(OAuthScope::aggregate)
-				.flatMap(Collection::stream)
-				.collect(Collectors.toUnmodifiableSet());
+		return authorities.get();
+	}
+
+	/**
+	 * Transfers the scopes contained within this {@link OAuthScopes OAuth scope set} to the given collection.
+	 *
+	 * @param target the target collection to transfer the scopes to, can't be {@literal null}
+	 * @return the target collection, never {@literal null}
+	 */
+	public Collection<OAuthScope> to(Collection<OAuthScope> target) {
+		return to(target, scope -> scope);
+	}
+
+	/**
+	 * Transfers the scopes contained within this {@link OAuthScopes OAuth scope set} to the given collection
+	 * by converting them using the given {@link Converter}.
+	 *
+	 * @param target the target collection to transfer the scopes to, can't be {@literal null}
+	 * @param converter the converter to use to convert the scopes, can't be {@literal null}
+	 * @param <T> the target collection type
+	 * @return the target collection, never {@literal null}
+	 */
+	public <T> Collection<T> to(Collection<T> target, Converter<OAuthScope, T> converter) {
+		for (OAuthScope scope : this) {
+			transfer(target, scope, converter);
+		}
+		return target;
 	}
 
 	/**
@@ -313,5 +346,17 @@ public class OAuthScopes implements Iterable<OAuthScope>, Serializable {
 
 	private static List<OAuthScope> collect(@NonNull Stream<OAuthScope> stream) {
 		return stream.filter(Objects::nonNull).sorted().toList();
+	}
+
+	private static <T> void transfer(Collection<T> target, OAuthScope scope, Converter<OAuthScope, T> converter) {
+		final T converted = converter.convert(scope);
+
+		if (target.contains(converted)) {
+			return;
+		}
+
+		target.add(converted);
+
+		scope.getIncluded().forEach(included -> transfer(target, included, converter));
 	}
 }

--- a/konfigyr-core/src/test/java/com/konfigyr/security/OAuthScopesTest.java
+++ b/konfigyr-core/src/test/java/com/konfigyr/security/OAuthScopesTest.java
@@ -15,10 +15,7 @@ import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.OAuth2ErrorCodes;
 import org.springframework.util.CollectionUtils;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.*;
@@ -205,8 +202,8 @@ class OAuthScopesTest {
 	@Test
 	@DisplayName("should parse granted authority")
 	void parseGrantedAuthority() {
-		assertThat(OAuthScopes.forGrantedAuthority(null, scope -> true)).isFalse();
-		assertThat(OAuthScopes.forGrantedAuthority(new SimpleGrantedAuthority("SCOPE_"), scope -> true)).isFalse();
+		assertThat(OAuthScopes.forGrantedAuthority(null, ignore -> true)).isFalse();
+		assertThat(OAuthScopes.forGrantedAuthority(new SimpleGrantedAuthority("SCOPE_"), ignore -> true)).isFalse();
 
 		assertThat(OAuthScopes.forGrantedAuthority(
 				OAuthScope.READ_NAMESPACES,
@@ -235,6 +232,45 @@ class OAuthScopesTest {
 				.returns(OAuth2ErrorCodes.INVALID_SCOPE, OAuth2Error::getErrorCode)
 				.returns("Invalid OAuth scope of: unknown", OAuth2Error::getDescription)
 				.returns(null, OAuth2Error::getUri);
+	}
+
+	@Test
+	@DisplayName("transfers all scopes into the target collection")
+	void toCollectionTransfersScopes() {
+		final var target = new ArrayList<OAuthScope>();
+		final var result = OAuthScopes.of(OAuthScope.OPENID, OAuthScope.READ_NAMESPACES).to(target);
+
+		assertThat(result)
+				.isSameAs(target)
+				.containsExactlyInAnyOrder(OAuthScope.OPENID, OAuthScope.READ_NAMESPACES);
+	}
+
+	@Test
+	@DisplayName("recursively transfer included scopes to the target collection without duplicates")
+	void toCollectionTransfersIncludedScopesRecursively() {
+		assertThat(OAuthScopes.of(OAuthScope.NAMESPACES).to(new ArrayList<>()))
+				.containsExactlyInAnyOrder(
+						OAuthScope.NAMESPACES,
+						OAuthScope.READ_NAMESPACES,
+						OAuthScope.WRITE_NAMESPACES,
+						OAuthScope.DELETE_NAMESPACES,
+						OAuthScope.INVITE_MEMBERS,
+						OAuthScope.PUBLISH_RELEASES
+				)
+				.doesNotHaveDuplicates();
+	}
+
+	@Test
+	@DisplayName("transfers converted scopes into the target collection")
+	void toCollectionWithConverterTransfersConvertedScopes() {
+		final var target = new LinkedHashSet<>();
+
+		final var result = OAuthScopes.of(OAuthScope.OPENID, OAuthScope.WRITE_NAMESPACES)
+				.to(target, OAuthScope::getAuthority);
+
+		assertThat(result)
+				.isSameAs(target)
+				.containsExactlyInAnyOrder("openid", "namespaces:read", "namespaces:write");
 	}
 
 	@MethodSource("scopes")

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationServerScopes.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationServerScopes.java
@@ -6,6 +6,15 @@ import org.jspecify.annotations.NonNull;
 
 import java.util.Collection;
 
+/**
+ * Registry of {@link OAuthScope OAuth scopes} that are supported and issued by the Konfigyr
+ * Authorization Server (Identity Provider).
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ * @see OAuthScope
+ * @see OAuthScopes
+ */
 public final class AuthorizationServerScopes {
 
 	private static final OAuthScopes scopes = OAuthScopes.of(
@@ -36,15 +45,7 @@ public final class AuthorizationServerScopes {
 	 * @param scopes collection of scopes to be customized, never {@literal null}
 	 */
 	public static void register(Collection<String> scopes) {
-		AuthorizationServerScopes.get().forEach(scope -> {
-			if (scopes.contains(scope.getAuthority())) {
-				return;
-			}
-
-			scopes.add(scope.getAuthority());
-
-			scope.getIncluded().forEach(included -> scopes.add(included.getAuthority()));
-		});
+		AuthorizationServerScopes.get().to(scopes, OAuthScope::getAuthority);
 	}
 
 }


### PR DESCRIPTION
- Expose OAuth2 Protected Resource Metadata (`/.well-known/oauth-protected-resource`) on the Konfigyr REST API, so clients can discover the resource name, authorization server issuer, and supported scopes
- Add `ResourceServerScopes`, mirroring `AuthorizationServerScopes`, to declare the OAuth scopes supported by the resource server
- Return a `WWW-Authenticate: Bearer resource_metadata=...` header on unauthenticated requests, pointing clients to the metadata endpoint
- Refactor scope-to-collection transfer logic into a reusable `OAuthScopes.to(...)` method, shared by both `ResourceServerScopes` and `AuthorizationServerScopes`
