### PR TITLE
Add MCP server foundation with a secured /mcp endpoint

### DIFF
--- a/gradle/versions.toml
+++ b/gradle/versions.toml
@@ -23,6 +23,7 @@ konfigyr-artifactory = "1.0.0-RC5"
 konfigyr-mail        = "1.1.0"
 bmuschko-docker      = "10.0.0"
 studer-jooq          = "10.2.1"
+mcp                  = "2.0.0"
 
 [libraries]
 spring-boot-bom          = { group = "org.springframework.boot",                        name = "spring-boot-dependencies",           version.ref = "spring-boot" }
@@ -51,6 +52,7 @@ hypersistence-tsid       = { group = "io.hypersistence",                        
 tink                     = { group = "com.google.crypto.tink",                          name = "tink",                               version.ref = "tink" }
 konfigyr-artifactory     = { group = "com.konfigyr",                                    name = "konfigyr-artifactory",               version.ref = "konfigyr-artifactory" }
 konfigyr-mail-test       = { group = "com.konfigyr",                                    name = "konfigyr-mail-test",                 version.ref = "konfigyr-mail" }
+mcp-sdk                  = { group = "io.modelcontextprotocol.sdk",                     name = "mcp",                                version.ref = "mcp" }
 
 [plugins]
 spring-boot     = { id = "org.springframework.boot",        version.ref = "spring-boot" }

--- a/konfigyr-api/build.gradle.kts
+++ b/konfigyr-api/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-security-oauth2-resource-server")
     implementation("org.springframework.boot:spring-boot-starter-restclient")
 
+    implementation(libs.mcp.sdk)
+
     implementation(libs.konfigyr.artifactory)
 
     implementation("org.springframework.boot:spring-boot-starter-cache")

--- a/konfigyr-api/src/main/java/com/konfigyr/mcp/HelloWorldTool.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/mcp/HelloWorldTool.java
@@ -1,0 +1,30 @@
+package com.konfigyr.mcp;
+
+import com.konfigyr.security.OAuthScope;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+
+/**
+ * A trivial MCP tool used to verify that the {@code /mcp} endpoint is reachable and correctly
+ * secured behind the {@link OAuthScope#MCP} scope.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@Component
+class HelloWorldTool {
+
+	static final McpSchema.Tool DEFINITION = McpSchema.Tool.builder("hello_world", Map.of(
+			"type", "object",
+			"properties", Map.of("name", Map.of("type", "string")),
+			"additionalProperties", false
+	)).description("Replies with a friendly greeting; used to verify the MCP server is reachable and secured.").build();
+
+	McpSchema.CallToolResult call(McpSchema.CallToolRequest request) {
+		final String name = (String) request.arguments().getOrDefault("name", "world");
+		return McpSchema.CallToolResult.builder().addTextContent("Hello, " + name + "!").build();
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/mcp/McpAutoConfiguration.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/mcp/McpAutoConfiguration.java
@@ -1,0 +1,50 @@
+package com.konfigyr.mcp;
+
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.json.jackson3.JacksonMcpJsonMapper;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpStatelessSyncServer;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.context.annotation.Bean;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Autoconfiguration that exposes the Konfigyr MCP server over the stateless {@code /mcp} endpoint
+ * registered by {@link com.konfigyr.mcp.McpEndpoint}.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@AutoConfiguration
+class McpAutoConfiguration {
+
+	@Bean
+	McpJsonMapper mcpJsonMapper(JsonMapper mapper) {
+		return new JacksonMcpJsonMapper(
+				mapper.rebuild()
+						.disable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS)
+						.enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT)
+						.build()
+		);
+	}
+
+	@Bean(destroyMethod = "close")
+	McpStatelessSyncServer mcpServer(
+			BuildProperties properties,
+			McpJsonMapper mcpJsonMapper,
+			McpStatelessServerTransport transport,
+			HelloWorldTool helloWorldTool
+	) {
+		return McpServer.sync(transport)
+				.serverInfo("konfigyr-api", properties.getVersion())
+				.jsonMapper(mcpJsonMapper)
+				.capabilities(McpSchema.ServerCapabilities.builder().tools(false).build())
+				.toolCall(HelloWorldTool.DEFINITION, (context, request) -> helloWorldTool.call(request))
+				.build();
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/mcp/McpEndpoint.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/mcp/McpEndpoint.java
@@ -1,0 +1,147 @@
+package com.konfigyr.mcp;
+
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.security.oauth.RequiresScope;
+import io.modelcontextprotocol.common.McpTransportContext;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.server.McpStatelessServerHandler;
+import io.modelcontextprotocol.spec.McpError;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpStatelessServerTransport;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.*;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Mono;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Exposes the Konfigyr MCP server over a stateless {@code /mcp} endpoint as a regular Spring MVC
+ * controller, so it is authenticated and authorized the same way as every other REST endpoint.
+ * <p>
+ * This is a minimal, Spring-native implementation of {@link McpStatelessServerTransport}, since none
+ * of MCP SDK implementation avoids a dependency on {@code org.springframework.ai} or compose with this
+ * codebase's Spring MVC based security and testing infrastructure at the same time.
+ *
+ * @author Vladimir Spasic
+ * @since 1.0.0
+ */
+@Slf4j
+@RestController
+class McpEndpoint implements McpStatelessServerTransport {
+
+	private volatile McpJsonMapper mapper;
+	private volatile McpStatelessServerHandler serverHandler;
+
+	@Autowired
+	void setMapper(McpJsonMapper mapper) {
+		this.mapper = mapper;
+	}
+
+	@Override
+	public void setMcpHandler(McpStatelessServerHandler handler) {
+		this.serverHandler = handler;
+	}
+
+	@Override
+	public Mono<Void> closeGracefully() {
+		return Mono.empty();
+	}
+
+	@RequiresScope(OAuthScope.MCP)
+	@PostMapping(value = "/mcp", consumes = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<String> handle(@RequestHeader(HttpHeaders.ACCEPT) String accept, @RequestBody String body) throws IOException {
+		if (!accept.contains(MediaType.APPLICATION_JSON_VALUE) || !accept.contains(MediaType.TEXT_EVENT_STREAM_VALUE)) {
+			return errorResponse(HttpStatus.BAD_REQUEST, McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+					.message("Both 'application/json' and 'text/event-stream' required in the 'Accept' header")
+					.build());
+		}
+
+		final McpSchema.JSONRPCMessage message;
+
+		try {
+			message = McpSchema.deserializeJsonRpcMessage(mapper, body);
+		} catch (IOException | IllegalArgumentException ex) {
+			log.error("Failed to deserialize incoming MCP JSON-RPC message", ex);
+
+			return errorResponse(HttpStatus.BAD_REQUEST, McpError.builder(McpSchema.ErrorCodes.PARSE_ERROR)
+					.message("Could not parse incoming MCP JSON-RPC message")
+					.build());
+		} catch (Exception ex) {
+			log.error("Unexpected error while deserializing incoming MCP JSON-RPC message", ex);
+
+			return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+					.message("Unexpected error occurred while handling MCP request")
+					.build());
+		}
+
+		return switch (message) {
+			case McpSchema.JSONRPCRequest request -> handle(request);
+			case McpSchema.JSONRPCNotification notification -> handle(notification);
+			default -> errorResponse(HttpStatus.BAD_REQUEST, McpError.builder(McpSchema.ErrorCodes.INVALID_REQUEST)
+					.message("The server accepts either requests or notifications")
+					.build());
+		};
+	}
+
+	ResponseEntity<String> handle(McpSchema.JSONRPCRequest request) throws IOException {
+		McpSchema.JSONRPCResponse response;
+
+		try {
+			response = serverHandler.handleRequest(McpTransportContext.EMPTY, request).block();
+		} catch (Exception ex) {
+			log.error("Failed to handle incoming JSON-RPC request", ex);
+
+			response = McpSchema.JSONRPCResponse.error(request.id(), new McpSchema.JSONRPCResponse.JSONRPCError(
+					McpSchema.ErrorCodes.INTERNAL_ERROR, "Unexpected error occurred while handling JSON RPC request"
+			));
+		}
+
+		return ResponseEntity.ok()
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(mapper.writeValueAsString(response));
+	}
+
+	ResponseEntity<String> handle(McpSchema.JSONRPCNotification notification) throws IOException {
+		try {
+			serverHandler.handleNotification(McpTransportContext.EMPTY, notification).block();
+		} catch (Exception ex) {
+			log.error("Failed to handle incoming JSON-RPC notification", ex);
+
+			return errorResponse(HttpStatus.INTERNAL_SERVER_ERROR, McpError.builder(McpSchema.ErrorCodes.INTERNAL_ERROR)
+					.message("Unexpected error occurred while handling JSON RPC notification")
+					.build());
+		}
+
+		return ResponseEntity.accepted().build();
+	}
+
+	/**
+	 * Builds a JSON RPC error response for failures that occur before a request id is known. A bad
+	 * {@code Accept} header, or a body that isn't valid JSON or doesn't match any known message shape,
+	 * or that can never have one, such as a notification.
+	 * <p>
+	 * Per the JSON-RPC 2.0 spec, {@code id} MUST be {@literal null} when it can't be determined.
+	 * {@link McpSchema.JSONRPCResponse} can't express that itself since its constructor rejects a
+	 * {@literal null} id, so this response is built by hand instead of going through
+	 * {@link McpSchema.JSONRPCResponse#error(Object, McpSchema.JSONRPCResponse.JSONRPCError)}.
+	 *
+	 * @param statusCode the HTTP status code to respond with, can't be {@literal null}
+	 * @param error the JSON RPC error to report, can't be {@literal null}
+	 * @return the JSON RPC error response, never {@literal null}
+	 */
+	ResponseEntity<String> errorResponse(HttpStatusCode statusCode, McpError error) throws IOException {
+		final Map<String, Object> response = new LinkedHashMap<>(3);
+		response.put("jsonrpc", McpSchema.JSONRPC_VERSION);
+		response.put("id", null);
+		response.put("error", error.getJsonRpcError());
+
+		return ResponseEntity.status(statusCode)
+				.contentType(MediaType.APPLICATION_JSON)
+				.body(mapper.writeValueAsString(response));
+	}
+
+}

--- a/konfigyr-api/src/main/java/com/konfigyr/security/ResourceServerScopes.java
+++ b/konfigyr-api/src/main/java/com/konfigyr/security/ResourceServerScopes.java
@@ -18,7 +18,8 @@ public final class ResourceServerScopes {
 
 	private static final OAuthScopes scopes = OAuthScopes.of(
 			OAuthScope.NAMESPACES,
-			OAuthScope.PROFILES
+			OAuthScope.PROFILES,
+			OAuthScope.MCP
 	);
 
 	private ResourceServerScopes() {

--- a/konfigyr-api/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/konfigyr-api/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -7,6 +7,7 @@ com.konfigyr.feature.FeaturesAutoConfiguration
 com.konfigyr.artifactory.ownership.OwnershipAutoConfiguration
 com.konfigyr.kms.KeysetManagerAutoConfiguration
 com.konfigyr.markdown.MarkdownAutoconfiguration
+com.konfigyr.mcp.McpAutoConfiguration
 com.konfigyr.membership.MembershipAutoConfiguration
 com.konfigyr.namespace.NamespaceManagementAutoConfiguration
 com.konfigyr.queue.WorkerQueueAutoConfiguration

--- a/konfigyr-api/src/test/java/com/konfigyr/mcp/McpEndpointTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/mcp/McpEndpointTest.java
@@ -1,0 +1,132 @@
+package com.konfigyr.mcp;
+
+import com.konfigyr.security.OAuthScope;
+import com.konfigyr.test.AbstractControllerTest;
+import com.konfigyr.test.TestPrincipals;
+import io.modelcontextprotocol.spec.McpSchema;
+import org.assertj.core.api.InstanceOfAssertFactories;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.log;
+
+class McpEndpointTest extends AbstractControllerTest {
+
+	private static final String CALL_HELLO_WORLD = """
+			{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"hello_world","arguments":{"name":"Vladimir"}}}""";
+
+	@Test
+	@DisplayName("should reject MCP request without authentication")
+	void shouldRejectRequestWithoutAuthentication() {
+		mvc.post().uri("/mcp")
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(CALL_HELLO_WORLD)
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(unauthorized());
+	}
+
+	@Test
+	@DisplayName("should reject MCP request when MCP scope is missing")
+	void shouldRejectToolCallWithoutMcpScope() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.READ_NAMESPACES))
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(CALL_HELLO_WORLD)
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.satisfies(forbidden(OAuthScope.MCP));
+	}
+
+	@Test
+	@DisplayName("should reject MCP request when 'application/json' content type is missing from Accept header")
+	void shouldRejectToolCallWithoutJsonHeader() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.MCP))
+				.accept(MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(CALL_HELLO_WORLD)
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST)
+				.bodyJson()
+				.hasPathSatisfying("$.id", path -> path.assertThat()
+						.isNull())
+				.hasPathSatisfying("$.jsonrpc", path -> path.assertThat()
+						.isEqualTo(McpSchema.JSONRPC_VERSION))
+				.hasPathSatisfying("$.error.code", path -> path.assertThat()
+						.isEqualTo(McpSchema.ErrorCodes.INVALID_REQUEST))
+				.hasPathSatisfying("$.error.message", path -> path.assertThat()
+						.isEqualTo("Both 'application/json' and 'text/event-stream' required in the 'Accept' header"));
+	}
+
+	@Test
+	@DisplayName("should reject MCP request when 'text/event-stream' content type is missing from Accept header")
+	void shouldRejectToolCallWithoutEventStreamHeader() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.MCP))
+				.accept(MediaType.APPLICATION_JSON)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(CALL_HELLO_WORLD)
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST)
+				.bodyJson()
+				.hasPathSatisfying("$.id", path -> path.assertThat()
+						.isNull())
+				.hasPathSatisfying("$.jsonrpc", path -> path.assertThat()
+						.isEqualTo(McpSchema.JSONRPC_VERSION))
+				.hasPathSatisfying("$.error.code", path -> path.assertThat()
+						.isEqualTo(McpSchema.ErrorCodes.INVALID_REQUEST))
+				.hasPathSatisfying("$.error.message", path -> path.assertThat()
+						.isEqualTo("Both 'application/json' and 'text/event-stream' required in the 'Accept' header"));
+	}
+
+	@Test
+	@DisplayName("should list registered tools when MCP scope is granted")
+	void shouldListToolsWithMcpScope() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.MCP))
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/list\"}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.result")
+				.convertTo(McpSchema.ListToolsResult.class)
+				.extracting(McpSchema.ListToolsResult::tools, InstanceOfAssertFactories.iterable(McpSchema.Tool.class))
+				.containsExactlyInAnyOrder(HelloWorldTool.DEFINITION);
+	}
+
+	@Test
+	@DisplayName("should invoke hello_world tool when MCP scope is granted")
+	void shouldInvokeHelloWorldToolWithMcpScope() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.MCP))
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(CALL_HELLO_WORLD)
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatusOk()
+				.bodyJson()
+				.extractingPath("$.result")
+				.convertTo(McpSchema.CallToolResult.class)
+				.returns(false, McpSchema.CallToolResult::isError)
+				.extracting(McpSchema.CallToolResult::content, InstanceOfAssertFactories.iterable(McpSchema.Content.class))
+				.containsExactly(McpSchema.TextContent.builder("Hello, Vladimir!").build());
+	}
+
+}

--- a/konfigyr-api/src/test/java/com/konfigyr/mcp/McpEndpointTest.java
+++ b/konfigyr-api/src/test/java/com/konfigyr/mcp/McpEndpointTest.java
@@ -91,6 +91,77 @@ class McpEndpointTest extends AbstractControllerTest {
 	}
 
 	@Test
+	@DisplayName("should reject MCP request with a malformed JSON body")
+	void shouldRejectMalformedJsonBody() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.MCP))
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{not valid json")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST)
+				.bodyJson()
+				.hasPathSatisfying("$.id", path -> path.assertThat()
+						.isNull())
+				.hasPathSatisfying("$.error.code", path -> path.assertThat()
+						.isEqualTo(McpSchema.ErrorCodes.PARSE_ERROR));
+	}
+
+	@Test
+	@DisplayName("should reject MCP request whose body matches no known JSON-RPC message shape")
+	void shouldRejectUnrecognizedJsonRpcShape() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.MCP))
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"foo\":\"bar\"}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST)
+				.bodyJson()
+				.hasPathSatisfying("$.id", path -> path.assertThat()
+						.isNull())
+				.hasPathSatisfying("$.error.code", path -> path.assertThat()
+						.isEqualTo(McpSchema.ErrorCodes.PARSE_ERROR));
+	}
+
+	@Test
+	@DisplayName("should reject MCP request whose body is a JSON-RPC response instead of a request or notification")
+	void shouldRejectJsonRpcResponseMessage() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.MCP))
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"jsonrpc\":\"2.0\",\"id\":1,\"result\":{}}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.BAD_REQUEST)
+				.bodyJson()
+				.hasPathSatisfying("$.error.code", path -> path.assertThat()
+						.isEqualTo(McpSchema.ErrorCodes.INVALID_REQUEST))
+				.hasPathSatisfying("$.error.message", path -> path.assertThat()
+						.isEqualTo("The server accepts either requests or notifications"));
+	}
+
+	@Test
+	@DisplayName("should accept MCP notification when MCP scope is granted")
+	void shouldAcceptNotificationWithMcpScope() {
+		mvc.post().uri("/mcp")
+				.with(authentication(TestPrincipals.john(), OAuthScope.MCP))
+				.accept(MediaType.APPLICATION_JSON, MediaType.TEXT_EVENT_STREAM)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}")
+				.exchange()
+				.assertThat()
+				.apply(log())
+				.hasStatus(HttpStatus.ACCEPTED);
+	}
+
+	@Test
 	@DisplayName("should list registered tools when MCP scope is granted")
 	void shouldListToolsWithMcpScope() {
 		mvc.post().uri("/mcp")

--- a/konfigyr-core/src/main/java/com/konfigyr/security/OAuthScope.java
+++ b/konfigyr-core/src/main/java/com/konfigyr/security/OAuthScope.java
@@ -90,7 +90,12 @@ public enum OAuthScope implements GrantedAuthority {
 	/**
 	 * Grants full access to profile operations like read, write, and delete.
 	 */
-	PROFILES("profiles", READ_PROFILES, WRITE_PROFILES, DELETE_PROFILES);
+	PROFILES("profiles", READ_PROFILES, WRITE_PROFILES, DELETE_PROFILES),
+
+	/**
+	 * Grants access to invoke tools exposed by the Konfigyr MCP server.
+	 */
+	MCP("mcp");
 
 	private final String value;
 	private final Set<OAuthScope> included;

--- a/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationServerScopes.java
+++ b/konfigyr-identity/src/main/java/com/konfigyr/identity/authorization/AuthorizationServerScopes.java
@@ -21,7 +21,8 @@ public final class AuthorizationServerScopes {
 			OAuthScope.OPENID,
 			OAuthScope.NAMESPACES,
 			OAuthScope.PUBLISH_ARTIFACTS,
-			OAuthScope.PROFILES
+			OAuthScope.PROFILES,
+			OAuthScope.MCP
 	);
 
 	private AuthorizationServerScopes() {

--- a/konfigyr-identity/src/main/resources/messages/messages.properties
+++ b/konfigyr-identity/src/main/resources/messages/messages.properties
@@ -48,6 +48,8 @@ konfigyr.oauth.scope.READ_PROFILES=Grants read-only access to profile.
 konfigyr.oauth.scope.WRITE_PROFILES=Grants read and write access to profile.
 konfigyr.oauth.scope.DELETE_PROFILES=Grants read, write and delete access to profile.
 
+konfigyr.oauth.scope.MCP=Grants access to Konfigyr MCP server.
+
 ## OAuth Consent page
 konfigyr.consent.title=Konfigyr - Consent
 konfigyr.consent.card.title=Allow {0} to access your account?

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/KonfigyrRegisteredClientRepositoryTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/client/KonfigyrRegisteredClientRepositoryTest.java
@@ -93,7 +93,8 @@ class KonfigyrRegisteredClientRepositoryTest implements ClientRepositoryTestSupp
 						"profiles",
 						"profiles:read",
 						"profiles:write",
-						"profiles:delete"
+						"profiles:delete",
+						"mcp"
 				))
 				.satisfies(assertAuthorizationGrantTypes(
 						AuthorizationGrantType.AUTHORIZATION_CODE,

--- a/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/controller/AuthorizationScopesMetadataControllerTest.java
+++ b/konfigyr-identity/src/test/java/com/konfigyr/identity/authorization/controller/AuthorizationScopesMetadataControllerTest.java
@@ -70,7 +70,8 @@ class AuthorizationScopesMetadataControllerTest extends AbstractControllerIntegr
 						),
 						new ScopeMetadata(OAuthScope.READ_PROFILES.getAuthority(), "Grants read-only access to profile."),
 						new ScopeMetadata(OAuthScope.WRITE_PROFILES.getAuthority(), "Grants read and write access to profile."),
-						new ScopeMetadata(OAuthScope.DELETE_PROFILES.getAuthority(), "Grants read, write and delete access to profile.")
+						new ScopeMetadata(OAuthScope.DELETE_PROFILES.getAuthority(), "Grants read, write and delete access to profile."),
+						new ScopeMetadata(OAuthScope.MCP.getAuthority(), "Grants access to Konfigyr MCP server.")
 				);
 	}
 


### PR DESCRIPTION
## Summary

- Adds the MCP server dependency (`io.modelcontextprotocol.sdk:mcp` only — no `org.springframework.ai` coordinates)
- Exposes a stateless `/mcp` endpoint as a plain `@RestController` (`McpEndpoint`), so it's authenticated and tested the same way as every other REST endpoint in this codebase
- Introduces the `MCP` OAuth2 scope, registered on both the resource server and the identity/authorization server, gating tool invocation via `@RequiresScope`
- Registers a `hello_world` tool (`HelloWorldTool`) to validate the end-to-end wiring — list and call, both covered by tests